### PR TITLE
Dark-mode compatible Arthur logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="docs/images/arthur-logo-symbol.svg" alt="Arthur AI Logo" width="150"/>
+<img src="https://cdn.prod.website-files.com/5a749d2c4f343700013366d4/67eab9e594ec4accb58badeb_arthur-logo-symbol.svg" alt="Arthur AI Logo" width="150"/>
 
 <i>Make AI work for Everyone.</i>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="https://cdn.prod.website-files.com/6230fe4706acf355d38b2d54/65b98b3564bb58c88c0a1b66_arthur-logo-light-nav.svg" alt="Arthur AI Logo" width="300" style="background-color: white;"/>
+<img src="docs/images/arthur-logo-symbol.svg" alt="Arthur AI Logo" width="150"/>
 
 <i>Make AI work for Everyone.</i>
 

--- a/docs/images/arthur-logo-symbol.svg
+++ b/docs/images/arthur-logo-symbol.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Artwork" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="50 50 220 210" style="enable-background:new 0 0 220 210;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#AC37F6;}
+</style>
+<g>
+	<path class="st0" d="M176,68.7h-33.2L68.9,189c0,0,27.9,51.8,90.3,51.9c62.3,0.1,90.3-51.9,90.3-51.9L176,68.7z M113.4,188.4
+		l45.7-75.2l46.1,75.2H113.4z"/>
+</g>
+</svg>


### PR DESCRIPTION
Make sure the Arthur logo is dark mode compatible on the Github README page.

The previous SVG image was not rendering correctly on the GitHub README page dark-mode. 

GitHub strips custom CSS from README:
https://github.com/orgs/community/discussions/41899
