### PR TITLE
XP-1497: Prevent expensive regex generation for the profanity detection function in the toxicity rule

### DIFF
--- a/genai-engine/src/scorer/checks/toxicity/toxicity.py
+++ b/genai-engine/src/scorer/checks/toxicity/toxicity.py
@@ -94,8 +94,10 @@ class ToxicityScorer(RuleScorer):
         # "1. do this thing"
         # gets treated as a single section instead of spltting the "1" away from the "do this thing"
         pattern = r"(?:\.|\?)(?=\s+[A-Za-z])"
+        asterisk_pattern = r"\*{2,}"
+        updated_text = re.sub(asterisk_pattern, lambda m: "-" * len(m.group()), text)
 
-        lines = text.split("\n")
+        lines = updated_text.split("\n")
         texts = []
         for line in lines:
             line = line.strip()

--- a/genai-engine/src/scorer/checks/toxicity/toxicity_profanity/profanity.py
+++ b/genai-engine/src/scorer/checks/toxicity/toxicity_profanity/profanity.py
@@ -13,32 +13,34 @@ with open(os.path.join(__location__, FULLY_BAD_WORDS_PATH), "r") as file:
 with open(os.path.join(__location__, END_PUNCTUATIONS_PATH), "r") as file:
     END_PUNCTUATIONS = [json.loads(line)["text"] for line in file]
 
+# Where '*' is occuring, '-' should be included due to the string substitution performed in ToxicityScorer.split_text_into_sections.
+# It prevents detect_profanity from compiling regex that's too expensive to run.
 letter_substitutions = {
-    "a": "[a@4*]",
+    "a": "[a@4*-]",
     "b": "[b8]",
     "c": "[c(]",
     "d": "[d]",
-    "e": "[e3*]",
+    "e": "[e3*-]",
     "f": "[f]",
     "g": "[g9]",
     "h": "[h#]",
-    "i": "[i!1*]",
+    "i": "[i!1*-]",
     "j": "[j]",
     "k": "[k]",
     "l": "[l1]",
     "m": "[m]",
     "n": "[n]",
-    "o": "[o0*]",
+    "o": "[o0*-]",
     "p": "[p]",
     "q": "[q]",
     "r": "[r]",
     "s": "[s$5]",
     "t": "[t+]",
-    "u": "[u*]",
+    "u": "[u*-]",
     "v": "[v]",
     "w": "[w]",
     "x": "[x]",
-    "y": "[y*]",
+    "y": "[y*-]",
     "z": "[z2]",
 }
 

--- a/genai-engine/tests/unit/test_toxicity.py
+++ b/genai-engine/tests/unit/test_toxicity.py
@@ -20,11 +20,17 @@ CLASSIFIER = ToxicityScorer(TOXICITY_MODEL, TOXICITY_TOKENIZER, None, None)
 
 @pytest.mark.unit_tests
 def test_detect_profanity():
-    assert detect_profanity("f*ck")
     assert detect_profanity("shit")
     assert detect_profanity("s h i t")
     assert detect_profanity("s H ! t")
     assert detect_profanity("s       H     , ! t")
+    assert detect_profanity("fuck")
+    assert detect_profanity("f*ck")
+    assert detect_profanity("f-ck")
+    assert detect_profanity("f**ck")
+    assert detect_profanity("f--ck")
+    assert not detect_profanity("fxck")
+    assert not detect_profanity("fxxck")
 
 
 @pytest.mark.unit_tests
@@ -293,3 +299,11 @@ if fast_ema[0] > slow_ema[0]:
         "# Buy",
         "buy_quantity = int(fast_length * data['Volume'] / 2)",
     ]
+
+    chunked_texts = CLASSIFIER.split_text_into_sections(
+        """
+        *This is a test*
+        **This is a test**
+        """,
+    )
+    assert chunked_texts == ["*This is a test*", "--This is a test--"]


### PR DESCRIPTION
Where '*' is occuring, '-' should be substituted for the detect_profanity function in order to prevent very expensive regex processing.