### PR TITLE
Apply TTL on the ingress DNS record

### DIFF
--- a/genai-engine/cloudformation/arthur-genai-engine-lb.yml
+++ b/genai-engine/cloudformation/arthur-genai-engine-lb.yml
@@ -108,6 +108,7 @@ Resources:
       HostedZoneId: !Ref GenaiEngineRoute53HostedZoneId
       Name: !Ref GenaiEngineRoute53RecordName
       Type: 'A'
+      TTL: 300
       AliasTarget:
         DNSName: !GetAtt GenaiEngineLoadBalancer.DNSName
         HostedZoneId: !GetAtt GenaiEngineLoadBalancer.CanonicalHostedZoneID


### PR DESCRIPTION
Set TTL on the ingress DNS record on CFT. It's important to leverage DNS caching.