### PR TITLE
[no-ref] fix docker compose deploy so it starts in daemon mode

### DIFF
--- a/deployment/docker-compose/genai-engine/setup-and-start.sh
+++ b/deployment/docker-compose/genai-engine/setup-and-start.sh
@@ -69,4 +69,4 @@ fi
 
 sleep 1
 
-curl -s https://raw.githubusercontent.com/arthur-ai/arthur-engine/refs/heads/main/deployment/docker-compose/genai-engine/docker-compose.yml | docker compose -f - up --pull always
+curl -s https://raw.githubusercontent.com/arthur-ai/arthur-engine/refs/heads/main/deployment/docker-compose/genai-engine/docker-compose.yml | docker compose -f - up -d --pull always


### PR DESCRIPTION
currently using the https://engine.arthur.ai installation script, the docker images start in the foreground. Adding a the `-d` flag so it runs in the background.