### PR TITLE
UP-2513: Docker compose health checks

### DIFF
--- a/deployment/docker-compose/genai-engine/docker-compose.yml
+++ b/deployment/docker-compose/genai-engine/docker-compose.yml
@@ -35,4 +35,10 @@ services:
       - GENAI_ENGINE_ADMIN_KEY=changeme_genai_engine_admin_key
     env_file:
       - .env
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:3030/docs" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 10s
     entrypoint: [ "bash", "-c", "/app/src/docker-entrypoint.sh" ]

--- a/deployment/docker-compose/ml-engine/docker-compose.yaml
+++ b/deployment/docker-compose/ml-engine/docker-compose.yaml
@@ -9,9 +9,7 @@ services:
     stop_grace_period: "60s"
     env_file:
       - .env
-    entrypoint:
-      - python3
-      - app/job_agent.py
+    entrypoint: [ "bash", "-c", "until wget --spider --quiet http://host.docker.internal:3030/docs; do sleep 1; done; python3 app/job_agent.py" ]
     healthcheck:
       test: wget -qO - http://127.0.0.1:7492/health
       interval: 30s

--- a/genai-engine/alembic/versions/2025_04_29_1301-7747edf460b3_create_span_table.py
+++ b/genai-engine/alembic/versions/2025_04_29_1301-7747edf460b3_create_span_table.py
@@ -1,7 +1,7 @@
 """create_span_table
 
 Revision ID: 7747edf460b3
-Revises: 68f8943ed6a4
+Revises: 5c2dd37eed9e
 Create Date: 2025-04-29 13:01:29.420778
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "7747edf460b3"
-down_revision = "68f8943ed6a4"
+down_revision = "5c2dd37eed9e"
 branch_labels = None
 depends_on = None
 

--- a/genai-engine/dockerfile
+++ b/genai-engine/dockerfile
@@ -23,6 +23,9 @@ WORKDIR /app
 ENV PYTHONPATH="$PYTHONPATH:/app/src"
 RUN poetry install --without dev,performance --no-ansi
 
+# install curl for healthchecks
+RUN apt-get update && apt-get install -y curl && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 
 # GPU Install: Install PyTorch for GPU
 FROM preinstall AS gpu-install
@@ -73,6 +76,8 @@ COPY --from=install /usr/bin/sh /usr/bin/sh
 COPY --from=install /usr/bin/bash /usr/bin/bash
 COPY --from=install /usr/bin/env /usr/bin/env
 COPY --from=install /usr/bin/printenv /usr/bin/printenv
+COPY --from=install /usr/bin/curl /usr/bin/curl
+COPY --from=install /usr/lib/ /usr/lib/
 COPY --from=install /usr/local/lib/ /usr/local/lib/
 COPY --from=install /usr/local/bin/ /usr/local/bin/
 COPY --from=install /etc/ld.so.cache /etc/ld.so.cache


### PR DESCRIPTION
Pretty much just did what was in the ticket except I used an equivalent wget command for the ml-engine healthcheck since it's already installed the ml-engine image & curl isn't. I also kept the start command as `python3 app/job_agent.py` instead of `.src/docker-entrypoint.sh` as in the ticket since that was the entrypoint to begin with.

I validated that the ml-engine health status stays in either the `starting` state or the `unhealthy` state (after 5 health check failures) until the genai-engine finishes downloading the models & the API doc page is available.