### PR TITLE
[no-ref] fix docker compose

### DIFF
--- a/deployment/docker-compose/arthur-engine/docker-compose.yml
+++ b/deployment/docker-compose/arthur-engine/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - POSTGRES_USER=postgres
       # Must match POSTGRES_PASSWORD in the db service
       - POSTGRES_PASSWORD=changeme_pg_password
-      - POSTGRES_URL=arthur-engine-db
+      - POSTGRES_URL=db
       - POSTGRES_PORT=5432
       - POSTGRES_DB=arthur_genai_engine
       - POSTGRES_USE_SSL=false

--- a/deployment/docker-compose/genai-engine/docker-compose.yml
+++ b/deployment/docker-compose/genai-engine/docker-compose.yml
@@ -1,7 +1,6 @@
 name: arthur-genai-engine
 services:
   db:
-    container_name: arthur-genai-engine-db
     image: postgres
     shm_size: 128mb
     environment:
@@ -13,7 +12,6 @@ services:
     env_file:
       - .env
   genai-engine:
-    container_name: arthur-genai-engine
     # If you have GPUs, use `genai-engine-gpu` image instead
     image: arthurplatform/genai-engine-cpu:${GENAI_ENGINE_VERSION-latest}
     platform: linux/amd64
@@ -25,7 +23,7 @@ services:
       - POSTGRES_USER=postgres
       # Must match POSTGRES_PASSWORD in the db service
       - POSTGRES_PASSWORD=changeme_pg_password
-      - POSTGRES_URL=arthur-genai-engine-db
+      - POSTGRES_URL=db
       - POSTGRES_PORT=5432
       - POSTGRES_DB=arthur_genai_engine
       - POSTGRES_USE_SSL=false

--- a/deployment/docker-compose/ml-engine/docker-compose.yaml
+++ b/deployment/docker-compose/ml-engine/docker-compose.yaml
@@ -2,7 +2,6 @@
 name: arthur-ml-engine
 services:
   ml-engine:
-    container_name: arthur-ml-engine
     image: arthurplatform/ml-engine:${ML_ENGINE_VERSION-latest}
     platform: linux/amd64
     restart: unless-stopped


### PR DESCRIPTION
1. remove container_name
2. update DB hostnames to match service name since container names are removed

Running the latest docker compose I get this error:
```
genai-engine-1  | sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) could not translate host name "arthur-engine-db" to address: Name or service not known
genai-engine-1  |
genai-engine-1  | (Background on this error at: https://sqlalche.me/e/20/e3q8)
```