### PR TITLE
UP-2513: Install lsof in genai-engine image

### DIFF
--- a/genai-engine/dockerfile
+++ b/genai-engine/dockerfile
@@ -23,6 +23,9 @@ WORKDIR /app
 ENV PYTHONPATH="$PYTHONPATH:/app/src"
 RUN poetry install --without dev,performance --no-ansi
 
+# install lsof for healthchecks
+RUN apt-get update && apt-get install -y lsof && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 
 # GPU Install: Install PyTorch for GPU
 FROM preinstall AS gpu-install
@@ -73,6 +76,8 @@ COPY --from=install /usr/bin/sh /usr/bin/sh
 COPY --from=install /usr/bin/bash /usr/bin/bash
 COPY --from=install /usr/bin/env /usr/bin/env
 COPY --from=install /usr/bin/printenv /usr/bin/printenv
+COPY --from=install /usr/bin/lsof /usr/bin/lsof
+COPY --from=install /usr/lib /usr/lib
 COPY --from=install /usr/local/lib/ /usr/local/lib/
 COPY --from=install /usr/local/bin/ /usr/local/bin/
 COPY --from=install /etc/ld.so.cache /etc/ld.so.cache


### PR DESCRIPTION
This is related to the PR here: https://github.com/arthur-ai/arthur-engine/pull/154/files

I'm separating the dockerfile changes from the docker-compose changes so that `lsof` will be in the `latest` image once this is merged to main so the changes to the docker-compose don't break anything