### PR TITLE
refactor markdown parsing into its own class

### DIFF
--- a/genai-engine/src/scorer/checks/hallucination/v2.py
+++ b/genai-engine/src/scorer/checks/hallucination/v2.py
@@ -287,7 +287,7 @@ class HallucinationClaimsV2(RuleScorer):
         Parse the text of the LLM response into text pieces (sentences & list items)
         """
         response = request.llm_response
-        initial_texts = self.claim_parser.parse_markdown(response)
+        initial_texts = self.claim_parser.process_and_extract_claims(response)
 
         """
         Filter out dialog (e.g. 'Any other questions?') & non-claims (e.g. 'I dont have information about X') from the LLM response,

--- a/genai-engine/src/scorer/checks/hallucination/v2.py
+++ b/genai-engine/src/scorer/checks/hallucination/v2.py
@@ -30,7 +30,7 @@ from sentence_transformers import SentenceTransformer
 from utils import constants, utils
 from utils.classifiers import Classifier, LogisticRegressionModel, get_device
 from utils.model_load import get_claim_classifier_embedding_model
-from utils.markdown_parser import MarkdownParser
+from utils.claim_parser import ClaimParser
 
 tracer = trace.get_tracer(__name__)
 logger = logging.getLogger()
@@ -270,7 +270,7 @@ class HallucinationClaimsV2(RuleScorer):
     def __init__(self, sentence_transformer: SentenceTransformer | None):
         self.claim_classifier = get_claim_classifier(sentence_transformer)
         self.model = get_llm_executor().get_gpt_model()
-        self.markdown_parser = MarkdownParser()
+        self.claim_parser = ClaimParser()
 
     def _download_sentence_transformer(self):
         global CLAIM_CLASSIFIER_EMBEDDING_MODEL
@@ -287,7 +287,7 @@ class HallucinationClaimsV2(RuleScorer):
         Parse the text of the LLM response into text pieces (sentences & list items)
         """
         response = request.llm_response
-        initial_texts = self.markdown_parser.parse_markdown(response)
+        initial_texts = self.claim_parser.parse_markdown(response)
 
         """
         Filter out dialog (e.g. 'Any other questions?') & non-claims (e.g. 'I dont have information about X') from the LLM response,

--- a/genai-engine/src/scorer/checks/hallucination/v2.py
+++ b/genai-engine/src/scorer/checks/hallucination/v2.py
@@ -30,7 +30,7 @@ from sentence_transformers import SentenceTransformer
 from utils import constants, utils
 from utils.classifiers import Classifier, LogisticRegressionModel, get_device
 from utils.model_load import get_claim_classifier_embedding_model
-from utils.utils import custom_text_parser
+from utils.markdown_parser import MarkdownParser
 
 tracer = trace.get_tracer(__name__)
 logger = logging.getLogger()
@@ -270,6 +270,7 @@ class HallucinationClaimsV2(RuleScorer):
     def __init__(self, sentence_transformer: SentenceTransformer | None):
         self.claim_classifier = get_claim_classifier(sentence_transformer)
         self.model = get_llm_executor().get_gpt_model()
+        self.markdown_parser = MarkdownParser()
 
     def _download_sentence_transformer(self):
         global CLAIM_CLASSIFIER_EMBEDDING_MODEL
@@ -286,7 +287,7 @@ class HallucinationClaimsV2(RuleScorer):
         Parse the text of the LLM response into text pieces (sentences & list items)
         """
         response = request.llm_response
-        initial_texts = custom_text_parser(response)
+        initial_texts = self.markdown_parser.parse_markdown(response)
 
         """
         Filter out dialog (e.g. 'Any other questions?') & non-claims (e.g. 'I dont have information about X') from the LLM response,

--- a/genai-engine/src/utils/claim_parser.py
+++ b/genai-engine/src/utils/claim_parser.py
@@ -4,11 +4,11 @@ import string
 from utils.abbreviations import ABBREVIATIONS
 from utils.utils import sentence_tokenizer, list_indicator_regex, logger
 
-class MarkdownParser:
+class ClaimParser:
     def __init__(self):
         self.parser = commonmark.Parser()
 
-    def deduplicate(self, seq: list[str]) -> list[str]:
+    def _deduplicate(self, seq: list[str]) -> list[str]:
         """
         Source: https://stackoverflow.com/a/480227/1493011
         """
@@ -16,7 +16,7 @@ class MarkdownParser:
         seen = set()
         return [x for x in seq if not (x in seen or seen.add(x))]
 
-    def strip_markdown(self, text: str) -> str:
+    def _strip_markdown(self, text: str) -> str:
         """
         Strip Markdown from a LLM Response
         """
@@ -79,7 +79,7 @@ class MarkdownParser:
         """
         Returns a list of texts that should contain sentences & list items from an LLM response
         """
-        text = self.strip_markdown(text)
+        text = self._strip_markdown(text)
         abbreviation_pattern = r"([A-Za-z]\.)([A-Za-z]\.)+"
         all_abbreviations = re.finditer(abbreviation_pattern, text)
 
@@ -100,4 +100,4 @@ class MarkdownParser:
             else:
                 texts.extend(sentence_tokenizer.tokenize(line))
 
-        return self.deduplicate(texts)
+        return self._deduplicate(texts)

--- a/genai-engine/src/utils/claim_parser.py
+++ b/genai-engine/src/utils/claim_parser.py
@@ -75,7 +75,7 @@ class ClaimParser:
 
         return parsed
 
-    def parse_markdown(self, text) -> list[str]:
+    def process_and_extract_claims(self, text) -> list[str]:
         """
         Returns a list of texts that should contain sentences & list items from an LLM response
         """

--- a/genai-engine/src/utils/markdown_parser.py
+++ b/genai-engine/src/utils/markdown_parser.py
@@ -1,0 +1,103 @@
+import commonmark
+import re
+import string
+from utils.abbreviations import ABBREVIATIONS
+from utils.utils import sentence_tokenizer, list_indicator_regex, logger
+
+class MarkdownParser:
+    def __init__(self):
+        self.parser = commonmark.Parser()
+
+    def deduplicate(self, seq: list[str]) -> list[str]:
+        """
+        Source: https://stackoverflow.com/a/480227/1493011
+        """
+
+        seen = set()
+        return [x for x in seq if not (x in seen or seen.add(x))]
+
+    def strip_markdown(self, text: str) -> str:
+        """
+        Strip Markdown from a LLM Response
+        """
+        def ast2text(astNode):
+            """
+            Returns the text from markdown, stripped of the markdown syntax itself
+            """
+            walker = astNode.walker()
+            acc = ""
+            iterator = iter(walker)
+            list_level = 0
+            for current, entering in iterator:
+                if current.literal and not (
+                    current.parent
+                    and current.parent.t == "link"
+                    and current.parent.destination == current.literal
+                ):
+                    acc += current.literal
+                if current.t == "linebreak":
+                    acc += "\n"
+                elif current.t == "softbreak":
+                    acc += " "
+                elif current.t == "list" and entering:
+                    if list_level > 0:
+                        # Already in a list
+                        acc = acc.strip() + " "
+                        # Sub the last new line, the rest of the item is supposed to be on the same line
+                    list_level += 1
+                elif current.t == "list" and not entering:
+                    list_level -= 1
+                    if list_level <= 1:
+                        acc = acc.strip()
+                        acc += "\n"
+                elif current.t == "paragraph" and not entering:
+                    if list_level > 1:
+                        if acc[-1] in string.punctuation:
+                            acc = acc[:-1]  # Strip punctuation for list items
+                        acc += " "  # Don't add new line until exiting nested alist
+                    else:
+                        acc = acc.strip()
+                        acc += "\n"
+                elif current.t == "heading" and not entering:
+                    acc += " "
+                elif current.t in ("link", "image") and entering is False:
+                    acc += f" {current.destination}"
+                    if current.title:
+                        acc += f" - {current.title}"
+            return acc.strip()
+
+        try:
+            ast = self.parser.parse(text)
+            parsed = ast2text(ast)
+        except Exception as e:
+            parsed = text
+            logger.warning(f"Failed to parse text with exception {e}")
+
+        return parsed
+
+    def parse_markdown(self, text) -> list[str]:
+        """
+        Returns a list of texts that should contain sentences & list items from an LLM response
+        """
+        text = self.strip_markdown(text)
+        abbreviation_pattern = r"([A-Za-z]\.)([A-Za-z]\.)+"
+        all_abbreviations = re.finditer(abbreviation_pattern, text)
+
+        # Iterate through all found emails and replace .com
+        for abbrev in all_abbreviations:
+            found = abbrev.group(0)
+            text = text.replace(found, found.replace(".", ""))
+
+        for s in ABBREVIATIONS:
+            text = text.replace(s, s.replace(".", ""))
+
+        lines = text.strip().split("\n")
+        texts = []
+        for line in lines:
+            line = line.strip()
+            if list_indicator_regex.match(line.strip()):
+                texts.append(line.strip())
+            else:
+                texts.extend(sentence_tokenizer.tokenize(line))
+
+        return self.deduplicate(texts)

--- a/genai-engine/src/utils/utils.py
+++ b/genai-engine/src/utils/utils.py
@@ -3,13 +3,11 @@ import functools
 import logging
 import os
 import re
-import string
 import traceback
 import urllib
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, List, Union
 
-import commonmark
 import utils.constants as constants
 from dotenv import load_dotenv
 from fastapi import HTTPException, Query
@@ -20,7 +18,6 @@ from opentelemetry.sdk.trace import Tracer
 from schemas.common_schemas import LLMTokenConsumption, PaginationParameters
 from schemas.enums import PaginationSortMethod
 from sqlalchemy.orm import Session
-from utils.abbreviations import ABBREVIATIONS
 
 _root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _genai_engine_version = None
@@ -224,105 +221,6 @@ async def common_pagination_parameters(
     if page_size > constants.MAX_PAGE_SIZE or page_size <= 0:
         raise HTTPException(status_code=400, detail=constants.ERROR_PAGE_SIZE_TOO_LARGE)
     return PaginationParameters(sort=sort, page_size=page_size, page=page)
-
-
-def deduplicate(seq: list[str]) -> list[str]:
-    """
-    Source: https://stackoverflow.com/a/480227/1493011
-    """
-
-    seen = set()
-    return [x for x in seq if not (x in seen or seen.add(x))]
-
-
-def strip_markdown(text: str) -> str:
-    """
-    Strip Markdown from a LLM Response
-    """
-    parser = commonmark.Parser()
-
-    def ast2text(astNode):
-        """
-        Returns the text from markdown, stripped of the markdown syntax itself
-        """
-        walker = astNode.walker()
-        acc = ""
-        iterator = iter(walker)
-        list_level = 0
-        for current, entering in iterator:
-            if current.literal and not (
-                current.parent
-                and current.parent.t == "link"
-                and current.parent.destination == current.literal
-            ):
-                acc += current.literal
-            if current.t == "linebreak":
-                acc += "\n"
-            elif current.t == "softbreak":
-                acc += " "
-            elif current.t == "list" and entering:
-                if list_level > 0:
-                    # Already in a list
-                    acc = acc.strip() + " "
-                    # Sub the last new line, the rest of the item is supposed to be on the same line
-                list_level += 1
-            elif current.t == "list" and not entering:
-                list_level -= 1
-                if list_level <= 1:
-                    acc = acc.strip()
-                    acc += "\n"
-            elif current.t == "paragraph" and not entering:
-                if list_level > 1:
-                    if acc[-1] in string.punctuation:
-                        acc = acc[:-1]  # Strip punctuation for list items
-                    acc += " "  # Don't add new line until exiting nested alist
-                else:
-                    acc = acc.strip()
-                    acc += "\n"
-            elif current.t == "heading" and not entering:
-                acc += " "
-            elif current.t in ("link", "image") and entering is False:
-                acc += f" {current.destination}"
-                if current.title:
-                    acc += f" - {current.title}"
-        return acc.strip()
-
-    try:
-        ast = parser.parse(text)
-        parsed = ast2text(ast)
-    except Exception as e:
-        parsed = text
-        logger.warning(f"Failed to parse text with exception {e}")
-
-    return parsed
-
-
-def custom_text_parser(text, delims="all") -> list[str]:
-    """
-    Returns a list of texts that should contain sentences & list items from an LLM response
-    """
-    text = strip_markdown(text)
-    abbreviation_pattern = r"([A-Za-z]\.)([A-Za-z]\.)+"
-    all_abbreviations = re.finditer(abbreviation_pattern, text)
-
-    # Iterate through all found emails and replace .com
-    for abbrev in all_abbreviations:
-        found = abbrev.group(0)
-        text = text.replace(found, found.replace(".", ""))
-
-    for s in ABBREVIATIONS:
-        text = text.replace(s, s.replace(".", ""))
-
-    lines = text.strip().split("\n")
-    texts = []
-    for line in lines:
-        line = line.strip()
-        if list_indicator_regex.match(line.strip()):
-            texts.append(line.strip())
-        else:
-            texts.extend(sentence_tokenizer.tokenize(line))
-    return deduplicate(texts)
-
 
 def pad_text(
     text: Union[str, List[str]],

--- a/genai-engine/tests/unit/test_hallucination.py
+++ b/genai-engine/tests/unit/test_hallucination.py
@@ -80,7 +80,11 @@ def test_claim_and_nonclaims_v2(
     request = ScoreRequest(
         rule_type=RuleType.MODEL_HALLUCINATION_V2,
         context="Some context",
-        llm_response="Isaac Newton built on the principles put forth by Galileo when formulating the laws of gravity.\n -hello. -hi, how are you? -I'm fine thanks and you?",
+        llm_response="""Isaac Newton built on the principles put forth by Galileo when formulating the laws of gravity.
+
+    - hello. 
+    - hi, how are you? 
+    - I'm fine thanks and you?""",
     )
 
     scorer = HallucinationClaimsV2(claim_classifier_embedding_model)

--- a/genai-engine/tests/unit/utils/test_utils.py
+++ b/genai-engine/tests/unit/utils/test_utils.py
@@ -14,10 +14,10 @@ from utils.utils import (
     get_postgres_connection_string,
     is_api_only_mode_enabled,
 )
-from utils.markdown_parser import MarkdownParser
+from utils.claim_parser import ClaimParser
 
 CURRDIR = os.path.dirname(os.path.abspath(__file__))
-markdown_parser = MarkdownParser()
+claim_parser = ClaimParser()
 
 @pytest.mark.parametrize(
     "exceeds",
@@ -93,7 +93,7 @@ def test_is_api_only_mode_enabled(mock_get_env_var):
 )
 @pytest.mark.unit_tests
 def test_custom_test_parser(source_str: str, target_strs: list[str]):
-    chunked = markdown_parser.parse_markdown(source_str)
+    chunked = claim_parser.parse_markdown(source_str)
     assert len(chunked) == len(target_strs)
     for chunk in chunked:
         assert chunk in target_strs
@@ -162,7 +162,7 @@ Item3""",
 )
 @pytest.mark.unit_tests
 def test_strip_markdown(source_str: str, target_str: str):
-    stripped = markdown_parser.strip_markdown(source_str)
+    stripped = claim_parser._strip_markdown(source_str)
     assert stripped == target_str.strip()
 
 

--- a/genai-engine/tests/unit/utils/test_utils.py
+++ b/genai-engine/tests/unit/utils/test_utils.py
@@ -93,7 +93,7 @@ def test_is_api_only_mode_enabled(mock_get_env_var):
 )
 @pytest.mark.unit_tests
 def test_custom_test_parser(source_str: str, target_strs: list[str]):
-    chunked = claim_parser.parse_markdown(source_str)
+    chunked = claim_parser.process_and_extract_claims(source_str)
     assert len(chunked) == len(target_strs)
     for chunk in chunked:
         assert chunk in target_strs

--- a/genai-engine/tests/unit/utils/test_utils.py
+++ b/genai-engine/tests/unit/utils/test_utils.py
@@ -8,17 +8,16 @@ from schemas.common_schemas import LLMTokenConsumption
 from schemas.custom_exceptions import LLMTokensPerPeriodRateLimitException
 from scorer import llm_client
 from utils.utils import (
-    custom_text_parser,
     get_auth_logout_uri,
     get_auth_metadata_uri,
     get_jwks_uri,
     get_postgres_connection_string,
     is_api_only_mode_enabled,
-    strip_markdown,
 )
+from utils.markdown_parser import MarkdownParser
 
 CURRDIR = os.path.dirname(os.path.abspath(__file__))
-
+markdown_parser = MarkdownParser()
 
 @pytest.mark.parametrize(
     "exceeds",
@@ -94,7 +93,7 @@ def test_is_api_only_mode_enabled(mock_get_env_var):
 )
 @pytest.mark.unit_tests
 def test_custom_test_parser(source_str: str, target_strs: list[str]):
-    chunked = custom_text_parser(source_str)
+    chunked = markdown_parser.parse_markdown(source_str)
     assert len(chunked) == len(target_strs)
     for chunk in chunked:
         assert chunk in target_strs
@@ -163,7 +162,7 @@ Item3""",
 )
 @pytest.mark.unit_tests
 def test_strip_markdown(source_str: str, target_str: str):
-    stripped = strip_markdown(source_str)
+    stripped = markdown_parser.strip_markdown(source_str)
     assert stripped == target_str.strip()
 
 


### PR DESCRIPTION
## Refactors the markdown parsing functionality into its own module and class and fixes test cases related to markdown

### v2.py
- changes the custom_text_parser import to import the new MarkdownParser class
- creates a MarkdownParser as a member variable for the HallucinationClaimsV2 class
- calls the new class instead of custom_text_parser

### utils/markdown_parser.py
- Creates the new MarkdownParser class
- adds the deduplicate, strip_markdown and custom_text_parser functions to the new class
- renames custom_text_parser() to parse_markdown()

### utils/utils.py
- Removes the deduplicate, strip_markdown and custom_text_parser functions
- Remove unnecessary imports after deleting the above functions

### test_hallucination.py
- Replaces the markdown string for test_claim_and_nonclaims_v2 to contain a proper markdown bulleted list

### test_utils.py
- Replaces all calls that were direct to markdown functions in utils.py to call them through the new MarkdownParser class