### PR TITLE
add prediction column name as confusion matrix dimension

### DIFF
--- a/arthur-common/tests/unit/aggregation_functions/helpers.py
+++ b/arthur-common/tests/unit/aggregation_functions/helpers.py
@@ -1,15 +1,25 @@
+from typing import Any, Optional
+
 from arthur_common.models.metrics import NumericMetric, SketchMetric
 
 
 def assert_dimension_in_metric(
     metric: NumericMetric | SketchMetric,
     dimension: str,
+    expected_dimension_values: Optional[set[Any]] = None,
 ) -> None:
+    """Asserts dimension by the name exists in the metric. If expected_dimension_values is set, also validates that
+    the dimensions exist for each expected value"""
     results = (
         metric.numeric_series
         if isinstance(metric, NumericMetric)
         else metric.sketch_series
     )
+    found_dimensions_vals = set()
     for res in results:
         dims = {r.name: r.value for r in res.dimensions}
         assert dimension in dims
+        found_dimensions_vals.add(dims[dimension])
+
+    if expected_dimension_values:
+        assert found_dimensions_vals == expected_dimension_values

--- a/arthur-common/tests/unit/aggregation_functions/test_confusion_matrix.py
+++ b/arthur-common/tests/unit/aggregation_functions/test_confusion_matrix.py
@@ -58,6 +58,8 @@ def test_int_bool_confusion_matrix(
         segmentation_cols=["packet type"],
     )
     assert_dimension_in_metric(metrics[0], "packet type")
+    # prediction column name should be included as a dimension
+    assert_dimension_in_metric(metrics[0], "prediction_column_name", {prediction_col})
 
 
 @pytest.mark.parametrize(
@@ -131,6 +133,12 @@ def test_str_label_confusion_matrix(
     assert sum([v.value for v in metrics[1].numeric_series[0].values]) == fp
     assert sum([v.value for v in metrics[2].numeric_series[0].values]) == fn
     assert sum([v.value for v in metrics[3].numeric_series[0].values]) == tn
+    # prediction column name should be included as a dimension
+    assert_dimension_in_metric(
+        metrics[0],
+        "prediction_column_name",
+        {f"{prediction_col} str label"},
+    )
 
     # test with segmentation
     metrics = cm_aggregator.aggregate(
@@ -200,6 +208,12 @@ def test_prediction_threshold_confusion_matrix(
     assert sum([v.value for v in metrics[1].numeric_series[0].values]) == fp
     assert sum([v.value for v in metrics[2].numeric_series[0].values]) == fn
     assert sum([v.value for v in metrics[3].numeric_series[0].values]) == tn
+    # prediction column name should be included as a dimension
+    assert_dimension_in_metric(
+        metrics[0],
+        "prediction_column_name",
+        {f"{prediction_col} float value"},
+    )
 
     # test with segmentation
     metrics = cm_aggregator.aggregate(


### PR DESCRIPTION
unblocking CV demo so binary confusion matrix can be configured on different prediction columns in the same dataset