### PR TITLE
Add MSSQL connector table name field to constants

### DIFF
--- a/arthur-common/src/arthur_common/models/connectors.py
+++ b/arthur-common/src/arthur_common/models/connectors.py
@@ -35,6 +35,8 @@ MSSQL_CONNECTOR_DATABASE_FIELD = "database"
 MSSQL_CONNECTOR_USERNAME_FIELD = "username"
 MSSQL_CONNECTOR_PASSWORD_FIELD = "password"
 MSSQL_CONNECTOR_DRIVER_FIELD = "driver"
+MSSQL_CONNECTOR_TABLE_NAME_FIELD = "table_name"
+
 
 # dataset (connector type dependent) constants
 SHIELD_DATASET_TASK_ID_FIELD = "task_id"


### PR DESCRIPTION
Based on the diff showing the addition of `MSSQL_CONNECTOR_TABLE_NAME_FIELD = "table_name"` to the existing MSSQL connector constants, here's an updated pull request description:

## Pull Request Description

### 🚀 Add MSSQL Connector Table Name Field

**Summary:**
This PR extends the MSSQL connector field constants by adding the `table_name` field, completing the set of configuration parameters needed for MSSQL database connectivity in the Arthur Engine platform.

### 📋 Changes Made

**File Modified:**
- `arthur-common/src/arthur_common/models/connectors.py`

**Added Constant:**
- `MSSQL_CONNECTOR_TABLE_NAME_FIELD = "table_name"` - Target table name for data operations

### 🎯 Purpose

This change completes the MSSQL connector field definitions by adding the missing `table_name` parameter. This field is essential for specifying which table within the MSSQL database should be used for data operations, following the same pattern as other database connectors like BigQuery which also require table specification.

### �� Context

The MSSQL connector now has all the necessary field constants for a complete database connection:
- **Connection fields**: `host`, `port`, `database`, `username`, `password`, `driver`
- **Data source field**: `table_name`

This aligns with the existing BigQuery connector pattern which uses `BIG_QUERY_DATASET_TABLE_NAME_FIELD = "table_name"` for similar functionality.