### PR TITLE
Add is_agentic flag to tasks

### DIFF
--- a/genai-engine/alembic/versions/2025_07_21_1506-862b72075d60_add_agentic_flag.py
+++ b/genai-engine/alembic/versions/2025_07_21_1506-862b72075d60_add_agentic_flag.py
@@ -1,0 +1,35 @@
+"""add_agentic_flag
+
+Revision ID: 862b72075d60
+Revises: 7747edf460b3
+Create Date: 2025-07-21 15:06:40.917636
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "862b72075d60"
+down_revision = "7747edf460b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add is_agentic column to tasks table with default value False
+    op.add_column(
+        "tasks",
+        sa.Column(
+            "is_agentic",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Remove is_agentic column from tasks table
+    op.drop_column("tasks", "is_agentic")

--- a/genai-engine/src/db_models/db_models.py
+++ b/genai-engine/src/db_models/db_models.py
@@ -3,7 +3,6 @@ from typing import List
 
 import pgvector.sqlalchemy
 import sqlalchemy.types as types
-from db_models.custom_types import RoleType
 from sqlalchemy import (
     TIMESTAMP,
     Boolean,
@@ -18,6 +17,8 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from db_models.custom_types import RoleType
 from utils import constants
 from utils.utils import get_env_var
 
@@ -53,6 +54,7 @@ class DatabaseTask(Base, IsArchivable):
     name: Mapped[str] = mapped_column(String)
     created_at: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP)
     updated_at: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP)
+    is_agentic: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     rule_links: Mapped[List["DatabaseTaskToRules"]] = relationship(
         back_populates="task",
         lazy="joined",

--- a/genai-engine/src/repositories/tasks_repository.py
+++ b/genai-engine/src/repositories/tasks_repository.py
@@ -1,11 +1,12 @@
-from db_models.db_models import DatabaseRule, DatabaseTask, DatabaseTaskToRules
 from fastapi import HTTPException
 from opentelemetry import trace
+from sqlalchemy import asc, desc
+from sqlalchemy.orm import Session
+
+from db_models.db_models import DatabaseRule, DatabaseTask, DatabaseTaskToRules
 from repositories.rules_repository import RuleRepository
 from schemas.enums import PaginationSortMethod, RuleScope, RuleType
 from schemas.internal_schemas import ApplicationConfiguration, Rule, Task
-from sqlalchemy import asc, desc
-from sqlalchemy.orm import Session
 from utils import constants
 
 tracer = trace.get_tracer(__name__)
@@ -34,6 +35,7 @@ class TaskRepository:
         self,
         ids: list[str] = None,
         task_name: str = None,
+        is_agentic: bool = None,
         include_archived: bool = False,
         sort: PaginationSortMethod = PaginationSortMethod.DESCENDING,
         page_size: int = 10,
@@ -44,6 +46,8 @@ class TaskRepository:
             stmt = stmt.where(DatabaseTask.id.in_(ids))
         if task_name:
             stmt = stmt.where(DatabaseTask.name.ilike(f"%{task_name}%"))
+        if is_agentic is not None:
+            stmt = stmt.where(DatabaseTask.is_agentic == is_agentic)
         if not include_archived:
             stmt = stmt.where(DatabaseTask.archived == False)
         if sort == PaginationSortMethod.DESCENDING:

--- a/genai-engine/src/schemas/internal_schemas.py
+++ b/genai-engine/src/schemas/internal_schemas.py
@@ -6,6 +6,33 @@ from typing import List, Optional
 from fastapi import HTTPException
 from opentelemetry import trace
 from pydantic import BaseModel, Field
+
+from db_models.db_models import (
+    DatabaseApiKey,
+    DatabaseApplicationConfiguration,
+    DatabaseDocument,
+    DatabaseEmbedding,
+    DatabaseEmbeddingReference,
+    DatabaseHallucinationClaim,
+    DatabaseInference,
+    DatabaseInferenceFeedback,
+    DatabaseInferencePrompt,
+    DatabaseInferencePromptContent,
+    DatabaseInferenceResponse,
+    DatabaseInferenceResponseContent,
+    DatabaseKeywordEntity,
+    DatabasePIIEntity,
+    DatabasePromptRuleResult,
+    DatabaseRegexEntity,
+    DatabaseResponseRuleResult,
+    DatabaseRule,
+    DatabaseRuleResultDetail,
+    DatabaseSpan,
+    DatabaseTask,
+    DatabaseTaskToRules,
+    DatabaseToxicityScore,
+    DatabaseUser,
+)
 from schemas.common_schemas import (
     AuthUserRole,
     ExampleConfig,
@@ -65,33 +92,6 @@ from schemas.scorer_schemas import (
     ScorerToxicityScore,
 )
 from utils import constants
-
-from db_models.db_models import (
-    DatabaseApiKey,
-    DatabaseApplicationConfiguration,
-    DatabaseDocument,
-    DatabaseEmbedding,
-    DatabaseEmbeddingReference,
-    DatabaseHallucinationClaim,
-    DatabaseInference,
-    DatabaseInferenceFeedback,
-    DatabaseInferencePrompt,
-    DatabaseInferencePromptContent,
-    DatabaseInferenceResponse,
-    DatabaseInferenceResponseContent,
-    DatabaseKeywordEntity,
-    DatabasePIIEntity,
-    DatabasePromptRuleResult,
-    DatabaseRegexEntity,
-    DatabaseResponseRuleResult,
-    DatabaseRule,
-    DatabaseRuleResultDetail,
-    DatabaseSpan,
-    DatabaseTask,
-    DatabaseTaskToRules,
-    DatabaseToxicityScore,
-    DatabaseUser,
-)
 
 tracer = trace.get_tracer(__name__)
 logger = logging.getLogger()
@@ -283,6 +283,7 @@ class Task(BaseModel):
     name: str
     created_at: datetime
     updated_at: datetime
+    is_agentic: bool = False
     rule_links: Optional[List[TaskToRuleLink]] = None
 
     @staticmethod
@@ -292,6 +293,7 @@ class Task(BaseModel):
             name=x.name,
             created_at=datetime.now(),
             updated_at=datetime.now(),
+            is_agentic=x.is_agentic,
         )
 
     @staticmethod
@@ -301,6 +303,7 @@ class Task(BaseModel):
             name=x.name,
             created_at=x.created_at,
             updated_at=x.updated_at,
+            is_agentic=x.is_agentic,
             rule_links=[
                 TaskToRuleLink._from_database_model(link) for link in x.rule_links
             ],
@@ -312,6 +315,7 @@ class Task(BaseModel):
             name=self.name,
             created_at=self.created_at,
             updated_at=self.updated_at,
+            is_agentic=self.is_agentic,
         )
 
     def _to_response_model(self):
@@ -326,6 +330,7 @@ class Task(BaseModel):
             name=self.name,
             created_at=_serialize_datetime(self.created_at),
             updated_at=_serialize_datetime(self.updated_at),
+            is_agentic=self.is_agentic,
             rules=response_rules,
         )
 
@@ -1359,6 +1364,7 @@ class Span(BaseModel):
             created_at=datetime.now(),
             updated_at=datetime.now(),
         )
+
 
 class OrderedClaim(BaseModel):
     index_number: int

--- a/genai-engine/src/schemas/request_schemas.py
+++ b/genai-engine/src/schemas/request_schemas.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional, Type
 
 from fastapi import HTTPException
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
 from schemas.common_schemas import (
     ExamplesConfig,
     KeywordsConfig,
@@ -246,6 +247,10 @@ class SearchTasksRequest(BaseModel):
         description="Task name substring search string.",
         default=None,
     )
+    is_agentic: Optional[bool] = Field(
+        description="Filter tasks by agentic status. If not provided, returns both agentic and non-agentic tasks.",
+        default=None,
+    )
 
 
 class SearchRulesRequest(BaseModel):
@@ -273,6 +278,10 @@ class SearchRulesRequest(BaseModel):
 
 class NewTaskRequest(BaseModel):
     name: str = Field(description="Name of the task.", min_length=1)
+    is_agentic: bool = Field(
+        description="Whether the task is agentic or not.",
+        default=False,
+    )
 
 
 class NewApiKeyRequest(BaseModel):

--- a/genai-engine/src/schemas/response_schemas.py
+++ b/genai-engine/src/schemas/response_schemas.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
+
 from schemas.common_schemas import (
     AuthUserRole,
     ExamplesConfig,
@@ -416,6 +417,7 @@ class TaskResponse(BaseModel):
     updated_at: int = Field(
         description="Time the task was created in unix milliseconds",
     )
+    is_agentic: bool = Field(description="Whether the task is agentic or not")
     rules: List[RuleResponse] = Field(description="List of all the rule for the task.")
 
 

--- a/genai-engine/tests/integration/test_task_crud.py
+++ b/genai-engine/tests/integration/test_task_crud.py
@@ -1,6 +1,7 @@
 import random
 
 import pytest
+
 from schemas.enums import RuleScope, RuleType
 from tests.clients.base_test_client import GenaiEngineTestClientBase
 
@@ -13,10 +14,12 @@ def test_user_story_create_task_get_task(client: GenaiEngineTestClientBase):
     assert status_code == 200
 
     assert task_response.name == task_name
+    assert task_response.is_agentic == False  # Default should be False
 
     status_code, task = client.get_task(task_response.id)
 
     assert len(task.rules) > 0
+    assert task.is_agentic == False
 
 
 @pytest.mark.integration_tests
@@ -52,3 +55,66 @@ def test_user_story_create_task_rule_update_rule(client: GenaiEngineTestClientBa
     # Assert patched rule is disabled
     patched_rule = [r for r in get_task_rules if r.id == task_scoped_keyword_rule.id][0]
     assert patched_rule.enabled == False
+
+
+@pytest.mark.integration_tests
+def test_create_agentic_task(client: GenaiEngineTestClientBase):
+    """Test creating a task with is_agentic=True"""
+    task_name = str(random.random())
+    status_code, task_response = client.create_task(task_name, is_agentic=True)
+    assert status_code == 200
+
+    assert task_response.name == task_name
+    assert task_response.is_agentic == True
+
+    # Verify by getting the task
+    status_code, task = client.get_task(task_response.id)
+    assert status_code == 200
+    assert task.is_agentic == True
+
+
+@pytest.mark.integration_tests
+def test_search_tasks_by_agentic_status(client: GenaiEngineTestClientBase):
+    """Test filtering tasks by agentic status"""
+    # Create some agentic and non-agentic tasks
+    agentic_task_ids = []
+    non_agentic_task_ids = []
+
+    for i in range(2):  # Fewer tasks for integration tests to be faster
+        # Create agentic tasks
+        status_code, task = client.create_task(
+            f"integration_agentic_{i}",
+            is_agentic=True,
+        )
+        assert status_code == 200
+        agentic_task_ids.append(task.id)
+
+        # Create non-agentic tasks
+        status_code, task = client.create_task(
+            f"integration_non_agentic_{i}",
+            is_agentic=False,
+        )
+        assert status_code == 200
+        non_agentic_task_ids.append(task.id)
+
+    # Search for agentic tasks only
+    status_code, search_response = client.search_tasks(is_agentic=True, page_size=50)
+    assert status_code == 200
+
+    agentic_results = [
+        task for task in search_response.tasks if task.id in agentic_task_ids
+    ]
+    assert len(agentic_results) == 2
+    for task in agentic_results:
+        assert task.is_agentic == True
+
+    # Search for non-agentic tasks only
+    status_code, search_response = client.search_tasks(is_agentic=False, page_size=50)
+    assert status_code == 200
+
+    non_agentic_results = [
+        task for task in search_response.tasks if task.id in non_agentic_task_ids
+    ]
+    assert len(non_agentic_results) == 2
+    for task in non_agentic_results:
+        assert task.is_agentic == False

--- a/genai-engine/tests/unit/routes/tasks/test_task_search_endpoints.py
+++ b/genai-engine/tests/unit/routes/tasks/test_task_search_endpoints.py
@@ -1,6 +1,7 @@
 import random
 
 import pytest
+
 from schemas.enums import PaginationSortMethod
 from tests.clients.base_test_client import GenaiEngineTestClientBase
 
@@ -33,6 +34,12 @@ def test_search_tasks(
     sc, task_resp_base = client.search_tasks(sort=sort, page=page, page_size=page_size)
     assert sc == 200
     assert len(task_resp_base.tasks) == expected_count
+
+    # Verify all tasks have is_agentic field (should default to False)
+    for task in task_resp_base.tasks:
+        assert hasattr(task, "is_agentic")
+        # Since we didn't specify is_agentic in create_task, they should all be False
+        assert task.is_agentic == False
 
     if page:
         sc, task_resp = client.search_tasks(
@@ -101,3 +108,151 @@ def test_search_task_name(
 
     assert len(task_resp.tasks) == expected_count
     assert task_resp.count == expected_count
+
+
+@pytest.mark.unit_tests
+def test_search_tasks_by_is_agentic_filter(client: GenaiEngineTestClientBase):
+    """Test searching tasks specifically by is_agentic filter"""
+    unique_prefix = str(random.random()) + "agentic_test_"
+
+    # Create a mix of agentic and non-agentic tasks
+    agentic_task_ids = []
+    non_agentic_task_ids = []
+
+    for i in range(5):
+        # Create agentic tasks
+        sc, task = client.create_task(
+            name=f"{unique_prefix}agentic_{i}",
+            is_agentic=True,
+        )
+        assert sc == 200
+        agentic_task_ids.append(task.id)
+
+        # Create non-agentic tasks
+        sc, task = client.create_task(
+            name=f"{unique_prefix}non_agentic_{i}",
+            is_agentic=False,
+        )
+        assert sc == 200
+        non_agentic_task_ids.append(task.id)
+
+    # Test 1: Search for only agentic tasks
+    sc, agentic_response = client.search_tasks(is_agentic=True, page_size=50)
+    assert sc == 200
+
+    # Filter to only our test tasks
+    found_agentic = [
+        task for task in agentic_response.tasks if task.id in agentic_task_ids
+    ]
+    assert len(found_agentic) == 5
+
+    for task in found_agentic:
+        assert task.is_agentic == True
+        assert task.id in agentic_task_ids
+
+    # Test 2: Search for only non-agentic tasks
+    sc, non_agentic_response = client.search_tasks(is_agentic=False, page_size=50)
+    assert sc == 200
+
+    # Filter to only our test tasks
+    found_non_agentic = [
+        task for task in non_agentic_response.tasks if task.id in non_agentic_task_ids
+    ]
+    assert len(found_non_agentic) == 5
+
+    for task in found_non_agentic:
+        assert task.is_agentic == False
+        assert task.id in non_agentic_task_ids
+
+    # Test 3: Search without is_agentic filter should return both types
+    sc, all_response = client.search_tasks(page_size=50)
+    assert sc == 200
+
+    all_our_tasks = [
+        task
+        for task in all_response.tasks
+        if task.id in agentic_task_ids + non_agentic_task_ids
+    ]
+    assert len(all_our_tasks) == 10
+
+
+@pytest.mark.unit_tests
+def test_search_tasks_agentic_with_other_filters(client: GenaiEngineTestClientBase):
+    """Test combining is_agentic filter with other search filters"""
+    unique_prefix = str(random.random()) + "combined_test_"
+
+    # Create tasks with specific names
+    agentic_task_ids = []
+    for i in range(3):
+        sc, task = client.create_task(
+            name=f"{unique_prefix}special_agentic_{i}",
+            is_agentic=True,
+        )
+        assert sc == 200
+        agentic_task_ids.append(task.id)
+
+    # Also create some non-agentic tasks with similar names
+    for i in range(2):
+        sc, task = client.create_task(
+            name=f"{unique_prefix}special_non_agentic_{i}",
+            is_agentic=False,
+        )
+        assert sc == 200
+
+    # Test combining name search with is_agentic filter
+    sc, response = client.search_tasks(
+        task_name=f"{unique_prefix}special",
+        is_agentic=True,
+        page_size=50,
+    )
+    assert sc == 200
+
+    # Should only find agentic tasks with "special" in the name
+    found_tasks = [task for task in response.tasks if task.id in agentic_task_ids]
+    assert len(found_tasks) == 3
+
+    for task in found_tasks:
+        assert task.is_agentic == True
+        assert "special" in task.name.lower()
+
+
+@pytest.mark.unit_tests
+def test_search_tasks_agentic_with_pagination(client: GenaiEngineTestClientBase):
+    """Test is_agentic filter with pagination"""
+    unique_prefix = str(random.random()) + "pagination_test_"
+
+    # Create more agentic tasks than page size
+    agentic_task_ids = []
+    for i in range(7):  # More than our page size of 3
+        sc, task = client.create_task(
+            name=f"{unique_prefix}agentic_{i}",
+            is_agentic=True,
+        )
+        assert sc == 200
+        agentic_task_ids.append(task.id)
+
+    # Test first page
+    sc, page1_response = client.search_tasks(is_agentic=True, page=0, page_size=3)
+    assert sc == 200
+
+    page1_our_tasks = [
+        task for task in page1_response.tasks if task.id in agentic_task_ids
+    ]
+    assert len(page1_our_tasks) <= 3
+
+    # Test second page
+    sc, page2_response = client.search_tasks(is_agentic=True, page=1, page_size=3)
+    assert sc == 200
+
+    page2_our_tasks = [
+        task for task in page2_response.tasks if task.id in agentic_task_ids
+    ]
+
+    # Ensure no overlap between pages
+    page1_ids = [task.id for task in page1_our_tasks]
+    page2_ids = [task.id for task in page2_our_tasks]
+    assert len(set(page1_ids).intersection(set(page2_ids))) == 0
+
+    # All found tasks should be agentic
+    for task in page1_our_tasks + page2_our_tasks:
+        assert task.is_agentic == True


### PR DESCRIPTION
Adds a new flag to tasks: `is_agentic: bool`. This allows us to know at execution time whether the task is agentic or not, and allows us to iterate over our data models in the future without blowing up the existing workflow. 