### PR TITLE
Remove the client secret parameter from the launch button template

### DIFF
--- a/deployment/cloudformation/start-cpu-stack.html
+++ b/deployment/cloudformation/start-cpu-stack.html
@@ -1,3 +1,3 @@
-<a href="https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/2.1.48/root-arthur-engine-cpu.yml&stackName=arthur-engine&param_MLEngineClientId=yourClientIdHere&param_MLEngineClientSecret=yourClientSecretHere">
+<a href="https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/2.1.48/root-arthur-engine-cpu.yml&stackName=arthur-engine&param_MLEngineClientId=yourClientIdHere">
     <img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" alt="Launch">
 </a>

--- a/deployment/cloudformation/start-gpu-stack.html
+++ b/deployment/cloudformation/start-gpu-stack.html
@@ -1,3 +1,3 @@
-<a href="https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/2.1.48/root-arthur-engine-gpu.yml&stackName=arthur-engine&param_MLEngineClientId=yourClientIdHere&param_MLEngineClientSecret=yourClientSecretHere">
+<a href="https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/2.1.48/root-arthur-engine-gpu.yml&stackName=arthur-engine&param_MLEngineClientId=yourClientIdHere">
     <img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" alt="Launch">
 </a>


### PR DESCRIPTION
Forgot to add the commit to remove the client secret in [the previous PR](https://github.com/arthur-ai/arthur-engine/pull/271). It's necessary for security reasons.