### PR TITLE
Remove optional type for ToxicityConfig

### DIFF
--- a/genai-engine/src/api_changelog.md
+++ b/genai-engine/src/api_changelog.md
@@ -1,6 +1,8 @@
 The intention of this changelog is to document API changes as they happen to effectively communicate them to customers.
 
 ---
+# 08/04/2025
+- **CHANGE**: Forces toxicity threshold to float
 
 # 07/23/2025
 - **CHANGE** for **URL**: /v1/spans/{span_id}/metrics/ now returns the span object itself instead of a list of Span objects of len 1

--- a/genai-engine/src/schemas/common_schemas.py
+++ b/genai-engine/src/schemas/common_schemas.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
 from schemas.enums import (
     PaginationSortMethod,
     PIIEntityTypes,
@@ -60,14 +61,14 @@ class ToxicityConfig(BaseModel):
         json_schema_extra={"example": {"threshold": DEFAULT_TOXICITY_RULE_THRESHOLD}},
     )
 
-    @field_validator("threshold")
+    @field_validator("threshold", mode="before")
+    @classmethod
     def validate_toxicity_threshold(cls, v):
-        if v:
-            if (v < 0) | (v > 1):
-                raise ValueError(f'"threshold" must be between 0 and 1')
-            return v
-        else:
-            return v
+        if v is None:
+            return DEFAULT_TOXICITY_RULE_THRESHOLD
+        if (v < 0) | (v > 1):
+            raise ValueError(f'"threshold" must be between 0 and 1')
+        return v
 
 
 class PIIConfig(BaseModel):

--- a/genai-engine/src/schemas/common_schemas.py
+++ b/genai-engine/src/schemas/common_schemas.py
@@ -62,11 +62,12 @@ class ToxicityConfig(BaseModel):
 
     @field_validator("threshold")
     def validate_toxicity_threshold(cls, v):
-        if v is None:
-            return DEFAULT_TOXICITY_RULE_THRESHOLD
-        if (v < 0) | (v > 1):
-            raise ValueError(f'"threshold" must be between 0 and 1')
-        return v
+        if v:
+            if (v < 0) | (v > 1):
+                raise ValueError(f'"threshold" must be between 0 and 1')
+            return v
+        else:
+            return v
 
 
 class PIIConfig(BaseModel):

--- a/genai-engine/src/schemas/common_schemas.py
+++ b/genai-engine/src/schemas/common_schemas.py
@@ -50,7 +50,7 @@ class RegexConfig(BaseModel):
 
 
 class ToxicityConfig(BaseModel):
-    threshold: float | None = Field(
+    threshold: float = Field(
         default=DEFAULT_TOXICITY_RULE_THRESHOLD,
         description=f"Optional. Float (0, 1) indicating the level of tolerable toxicity to consider the rule passed or failed. Min: 0 (no toxic language) Max: 1 (very toxic language). Default: {DEFAULT_TOXICITY_RULE_THRESHOLD}",
     )

--- a/genai-engine/staging.openapi.json
+++ b/genai-engine/staging.openapi.json
@@ -6082,14 +6082,7 @@
             "ToxicityConfig": {
                 "properties": {
                     "threshold": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "type": "number",
                         "title": "Threshold",
                         "description": "Optional. Float (0, 1) indicating the level of tolerable toxicity to consider the rule passed or failed. Min: 0 (no toxic language) Max: 1 (very toxic language). Default: 0.5",
                         "default": 0.5

--- a/ml-engine/src/ml_engine/tools/api_client_type_converters.py
+++ b/ml-engine/src/ml_engine/tools/api_client_type_converters.py
@@ -28,7 +28,6 @@ from genai_client.models import PIIConfig as ShieldPIIConfig
 from genai_client.models import RegexConfig as ShieldRegexConfig
 from genai_client.models import RuleType as ShieldRuleType
 from genai_client.models import ToxicityConfig as ShieldToxicityConfig
-from genai_client.models.threshold import Threshold
 
 ApiConfigTypes = Optional[
     Union[
@@ -88,7 +87,7 @@ class ShieldClientTypeConverter:
             )
         elif isinstance(api, ApiToxicityConfig):
             return ShieldToxicityConfig(
-                threshold=Threshold(api.threshold),
+                threshold=api.threshold,
             )
         elif isinstance(api, ApiPIIConfig):
             return ShieldPIIConfig(


### PR DESCRIPTION
This ensures parity between our enterprise offering and OSS offering, and is more consistent w/ expectations re: user behavior w/ using this API (eg: Toxicity should require a threshold)