### PR TITLE
[NO-REF]: Pin python images for ML engine to debian 12 for compatibil…

### DIFF
--- a/ml-engine/Dockerfile
+++ b/ml-engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS install
+FROM python:3.13-bookworm AS install
 
 # install poetry and wget
 RUN pip install poetry==2.1.3 && \
@@ -51,7 +51,7 @@ COPY src/genai_client /genai_client
 RUN poetry run pip install /genai_client
 
 # Final Stage(s): Create genai-engine image
-FROM gcr.io/distroless/python3 AS ml-engine-distroless-base
+FROM gcr.io/distroless/python3-debian12 AS ml-engine-distroless-base
 
 COPY --from=install /bin/sh /bin/sh
 COPY --from=install /bin/bash /bin/bash


### PR DESCRIPTION
Previously, with the new release of `python:3.13-slim`, we were seeing the following errors when running the container:

```2025-08-18 18:50:02 /usr/local/bin/python3.13: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /usr/local/bin/../lib/libpython3.13.so.1.0)```

This is an incompatibility issue; the new release of python 3.13-slim had an incompatible version of GLIBC with the distroless image we're using in the build step.

The distroless image we're using uses debian-12 as its base distribution: https://github.com/GoogleContainerTools/distroless?tab=readme-ov-file#base-operating-system

This pins both images to use debian-12 for compatibility.

Passing scope integration tests against this build:
<img width="954" height="584" alt="Screenshot 2025-08-19 at 9 40 28 AM" src="https://github.com/user-attachments/assets/1a41016b-1632-4522-b4c9-2b9d98714f52" />
