### PR TITLE
[no-ref] fix genAI client gen to always use the same generator version

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -244,7 +244,8 @@ jobs:
           openapi-generator-cli generate -g python \
             -i ./genai-engine/staging.openapi.json \
             -o ./ml-engine/src/genai_client \
-            --skip-validate-spec --package-name genai_client
+            --skip-validate-spec --package-name genai_client \
+            --openapitools ./ml-engine/scripts/openapitools.json
           sed -i 's/license = "NoLicense"/license = "Unlicense"/g' ./ml-engine/src/genai_client/pyproject.toml
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.5.0


### PR DESCRIPTION
Previously, the GenAI client code generation in CICD was not using a pinned version of the generator, so it would always use the latest. This can cause incompatible code changes when new versions of the generator are released, so we should pin it to the same version to ensure consistency. Currently using 7.11 as that was what the old repo used.