### PR TITLE
[no ref] fix openapi generator cli in CICD

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -240,12 +240,11 @@ jobs:
       - uses: ./.github/workflows/composite-actions/set-version
       - name: Generate GenAI Client
         run: |
-          pip install openapi-generator-cli[jdk4py]
+          pip install 'openapi-generator-cli[jdk4py]==7.12'
           openapi-generator-cli generate -g python \
             -i ./genai-engine/staging.openapi.json \
             -o ./ml-engine/src/genai_client \
-            --skip-validate-spec --package-name genai_client \
-            --openapitools ./ml-engine/scripts/openapitools.json
+            --skip-validate-spec --package-name genai_client
           sed -i 's/license = "NoLicense"/license = "Unlicense"/g' ./ml-engine/src/genai_client/pyproject.toml
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.5.0

--- a/ml-engine/scripts/openapitools.json
+++ b/ml-engine/scripts/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.11.0"
+    "version": "7.12.0"
   }
 }


### PR DESCRIPTION
Previously the openapi generator step in CICD [failed](https://github.com/arthur-ai/arthur-engine/actions/runs/17275930586/job/49032558505?pr=403) with this error:
```
Error:  Found unexpected parameters: [--openapitools, ./ml-engine/scripts/openapitools.json]
```

Turns out when I was testing the change in https://github.com/arthur-ai/arthur-engine/pull/389, my local version was using the brew installed version and not the PyPI installed version. Since the PyPI version does not seem to respect the same config file, I'm manually pinning it to match 7.12.