### PR TITLE
[no-ref] fix batch ingestion when root spans are present

### DIFF
--- a/genai-engine/src/db_models/db_models.py
+++ b/genai-engine/src/db_models/db_models.py
@@ -448,11 +448,13 @@ class DatabaseSpan(Base):
     id: Mapped[str] = mapped_column(String, primary_key=True)
     trace_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
     span_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
-    parent_span_id: Mapped[str] = mapped_column(String, nullable=True, index=True)
-    span_kind: Mapped[str] = mapped_column(String, nullable=True)
-    start_time: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP, nullable=False)
-    end_time: Mapped[TIMESTAMP] = mapped_column(TIMESTAMP, nullable=False)
-    task_id: Mapped[str] = mapped_column(
+    parent_span_id: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
+    span_kind: Mapped[str | None] = mapped_column(String, nullable=True)
+    start_time: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False)
+    end_time: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False)
+    task_id: Mapped[str | None] = mapped_column(
         String,
         ForeignKey("tasks.id"),
         nullable=True,

--- a/genai-engine/tests/routes/span/test_span_routes.py
+++ b/genai-engine/tests/routes/span/test_span_routes.py
@@ -51,6 +51,7 @@ def test_receive_traces_with_resource_attributes(
     client: GenaiEngineTestClientBase,
     sample_openinference_trace,
     sample_span_missing_task_id,
+    sample_openinference_trace_multiple_spans,
 ):
     """Test receive_traces with resource attributes for task ID extraction."""
 
@@ -73,6 +74,17 @@ def test_receive_traces_with_resource_attributes(
         "Missing or invalid task ID in resource attributes"
         in response_json["rejection_reasons"][0]
     )
+
+    # test inserting trace with spans with and without parent_span_id
+    status_code, response = client.receive_traces(
+        sample_openinference_trace_multiple_spans
+    )
+    assert status_code == 200
+    response_json = json.loads(response)
+    assert response_json["total_spans"] == 2
+    assert response_json["accepted_spans"] == 2
+    assert response_json["rejected_spans"] == 0
+    assert response_json["status"] == "success"
 
 
 @pytest.mark.unit_tests


### PR DESCRIPTION
## Overview

This bug occurred when using the `BatchSpanProcessor` to bulk send multiple spans per request async, instead of the `SimpleSpanProcessor` which makes a single request per span synchronously. 

Previously, when inserting a simple trace like:
```
trace:
 --> root span
   --> child span
```

The traces endpoint would 500 with the following error:
```
INSERT value for column spans.parent_span_id is explicitly rendered as a boundparameter in the VALUES clause; a Python-side value or SQL expression is required
```

This occurred because we were inserting raw dictionary values into SQLAlchemy. When the child span was first in the list of values to insert, `parent_span_id` would be set for that row, so SQLAlchemy would craft a query to insert values into the `parent_span_id` column. The problem the occurred when SQLAlchemy got to the root span, because it had no `parent_span_id` key set.

## The fix

Updated the insertion logic to use typed `DatabaseSpan` objects so it is clearer the columns and values being inserted.