### PR TITLE
Move model download to worker process

### DIFF
--- a/genai-engine/src/gunicorn.conf.py
+++ b/genai-engine/src/gunicorn.conf.py
@@ -1,9 +1,5 @@
 from os import environ
 
-from gunicorn.arbiter import Arbiter
-
-from utils.model_load import download_models
-
 bind = "0.0.0.0:" + environ.get("PORT", "3030")
 workers = environ.get("WORKERS", 1)
 loglevel = environ.get("LOG_LEVEL", "info")
@@ -11,13 +7,3 @@ accesslog = "-"  # stdout
 errorlog = "-"  # stdout
 timeout = environ.get("TIMEOUT", 120)
 worker_class = "uvicorn.workers.UvicornWorker"
-
-
-def on_starting(server: Arbiter) -> None:
-    server.log.info("Downloading models...")
-    try:
-        download_models(int(workers))
-    except Exception as e:
-        server.log.error(f"Error downloading models: {e}")
-        raise e
-    server.log.info("Models downloaded.")

--- a/genai-engine/src/server.py
+++ b/genai-engine/src/server.py
@@ -52,6 +52,7 @@ from routers.v2.routers import (
 from utils import constants as constants
 from utils.classifiers import get_device
 from utils.model_load import (
+    download_models,
     get_bert_scorer,
     get_claim_classifier_embedding_model,
     get_prompt_injection_model,
@@ -151,6 +152,15 @@ async def lifespan(app: FastAPI):
     if not is_api_only_mode_enabled():
         get_oauth_client()
         time.sleep(random.randint(0, 3))
+
+    # Download models in worker process
+    logger.info("Downloading models...")
+    try:
+        download_models(1)  # Use single process in worker
+    except Exception as e:
+        logger.error(f"Error downloading models: {e}")
+        raise e
+    logger.info("Models downloaded.")
 
     get_claim_classifier_embedding_model()
     get_prompt_injection_model()


### PR DESCRIPTION
Gunicorn runs a master process that spawns worker processes using `fork()`. The `on_starting` hook is executed **before workers are forked** and is intended for setup tasks that should happen once at startup.

In our case, the `on_starting` method called `model_download` → `model_load` → `get_device` imported, which caused CUDA to initialize in the **master process**. After that, Gunicorn forked worker processes. When the workers later attempted to load the models on GPU, CUDA initialization failed with the error:

```
Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method
```

This happens because CUDA contexts can’t be safely inherited across `fork()`. See https://docs.pytorch.org/docs/stable/notes/multiprocessing.html#poison-fork-in-multiprocessing

The fix is to move the model loading into the **worker processes**. This avoids CUDA being initialized in the master process. Using `hf_hub_download` is safe here because:

* It checks for existing files and won’t redownload.
* It uses file locking to ensure thread/process safety.

With this change, models are downloaded (if not already cached) and loaded inside the worker processes. That way, CUDA is only initialized once per worker, which avoids the fork-related error while still being efficient.