### PR TITLE
NO-REF: Pin ML engine platform because of MSSQL Driver 17 dependency …

### DIFF
--- a/ml-engine/Dockerfile
+++ b/ml-engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bookworm AS install
+FROM --platform=linux/amd64 python:3.13-slim-bookworm AS install
 
 # install poetry and wget
 RUN pip install poetry==2.1.3 && \
@@ -75,7 +75,7 @@ COPY src/genai_client /genai_client
 RUN poetry run pip install /genai_client
 
 # Final Stage(s): Create ml-engine image
-FROM gcr.io/distroless/python3-debian12:nonroot AS ml-engine-distroless-base
+FROM --platform=linux/amd64 gcr.io/distroless/python3-debian12:nonroot AS ml-engine-distroless-base
 
 COPY --from=install /bin/sh /bin/sh
 COPY --from=install /bin/bash /bin/bash


### PR DESCRIPTION
Related slack thread: https://arthur-ai.slack.com/archives/C06F737P85R/p1759164712671159

I fixed this in the Docker image build instead of in the docker-compose even though it warns you against the static platform choice because the Dockerfile is useless with other platforms—it won't build if the platform is set to ARM. I figured this was better than maintaining this in multiple places, but let me know if anyone disagrees!