### PR TITLE
Fix UI pipeline during arthur-engine release

### DIFF
--- a/genai-engine/dockerfile
+++ b/genai-engine/dockerfile
@@ -40,20 +40,14 @@ FROM node:20-alpine AS ui-build
 
 WORKDIR /app/ui
 
-# Copy UI package files
-COPY ui/package.json ./
-
-# generate package lock file
-RUN npm install
-
-# Install UI dependencies
-RUN npm ci
-
 # Copy UI source code
 COPY ui/ ./
 
+# Install UI dependencies
+RUN corepack enable && yarn install --immutable
+
 # Build the UI as static files
-RUN npm run build
+RUN yarn build
 
 # Copy the built static files
 RUN cp -r dist /app/ui-dist


### PR DESCRIPTION
See failing pipeline in this PR: https://github.com/arthur-ai/arthur-engine/pull/545

This is happening because if the lockfile hasn't been generated, the UI fails in the build stage.