### PR TITLE
create strict mode for var replacement in prompts

### DIFF
--- a/genai-engine/src/api_changelog.md
+++ b/genai-engine/src/api_changelog.md
@@ -2,6 +2,10 @@ The intention of this changelog is to document API changes as they happen to eff
 
 ---
 
+# 10/23/2025
+- **CHANGE** for **URL**: /api/v1/completions  added the new optional request property 'completion_request/strict'
+- **CHANGE** for **URL**: /api/v1/tasks/{task_id}/prompts/{prompt_name}/versions/{prompt_version}/completions  added the new optional request property 'strict'
+
 # 10/22/2025
 - **BREAKING CHANGE** for **URL**: /api/v1/task/{task_id}/prompt/{prompt_name}/versions/{prompt_version}/completions  api path removed without deprecation
 - **BREAKING CHANGE** for **URL**: /api/v1/{task_id}/agentic_prompts  api path removed without deprecation

--- a/genai-engine/staging.openapi.json
+++ b/genai-engine/staging.openapi.json
@@ -4832,10 +4832,10 @@
                                     "type": "null"
                                 }
                             ],
-                            "description": "Prompt names to filter on using partial matching. If provided, prompts matching any of these name patterns will be returned. Supports SQL LIKE pattern matching with % wildcards.",
+                            "description": "Prompt names to filter on using partial matching. If provided, prompts matching any of these name patterns will be returned.",
                             "title": "Prompt Names"
                         },
-                        "description": "Prompt names to filter on using partial matching. If provided, prompts matching any of these name patterns will be returned. Supports SQL LIKE pattern matching with % wildcards."
+                        "description": "Prompt names to filter on using partial matching. If provided, prompts matching any of these name patterns will be returned."
                     },
                     {
                         "name": "model_provider",
@@ -4868,10 +4868,10 @@
                                     "type": "null"
                                 }
                             ],
-                            "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet'). Supports SQL LIKE pattern matching with % wildcards.",
+                            "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet').",
                             "title": "Model Name"
                         },
-                        "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet'). Supports SQL LIKE pattern matching with % wildcards."
+                        "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet')."
                     },
                     {
                         "name": "created_after",
@@ -5035,10 +5035,10 @@
                                     "type": "null"
                                 }
                             ],
-                            "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet') Supports SQL LIKE pattern matching with % wildcards.",
+                            "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet').",
                             "title": "Model Name"
                         },
-                        "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet') Supports SQL LIKE pattern matching with % wildcards."
+                        "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet')."
                     },
                     {
                         "name": "created_after",
@@ -5258,7 +5258,8 @@
                                 "$ref": "#/components/schemas/PromptCompletionRequest",
                                 "default": {
                                     "variables": [],
-                                    "stream": false
+                                    "stream": false,
+                                    "strict": false
                                 }
                             }
                         }
@@ -8325,7 +8326,8 @@
                         "description": "Run configuration for the unsaved prompt",
                         "default": {
                             "variables": [],
-                            "stream": false
+                            "stream": false,
+                            "strict": false
                         }
                     }
                 },
@@ -10886,6 +10888,19 @@
                         ],
                         "title": "Stream",
                         "description": "Whether to stream the response",
+                        "default": false
+                    },
+                    "strict": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Strict",
+                        "description": "Whether to enforce strict validation of variables. If True, any variables that are found in the prompt but not in the variables list will raise an error.",
                         "default": false
                     }
                 },


### PR DESCRIPTION
## Description
- Adds a parameter called "strict" to the PromptCompletionRequest schema
- if strict=true we validate if all variables present in the prompt messages being passed in for completion have been set by the user in the request (we do allow them to set variable values to "")
- if strict=false skip this validation and let jinja replace missing variables with ""
- added a unit test to validate this new functionality

## Jira Ticket
- https://arthurai.atlassian.net/browse/UP-3220