### PR TITLE
[no-ref] update tracing endpoint in mastra exporter

### DIFF
--- a/genai-engine/examples/agents/analytics-agent/src/mastra/observability/arthur/tracing.ts
+++ b/genai-engine/examples/agents/analytics-agent/src/mastra/observability/arthur/tracing.ts
@@ -54,7 +54,7 @@ export class ArthurExporter implements AITracingExporter {
     const baseUrl = config.url.endsWith("/")
       ? config.url.slice(0, -1)
       : config.url;
-    const tracesUrl = `${baseUrl}/v1/traces`;
+    const tracesUrl = `${baseUrl}/api/v1/traces`;
 
     const exporter = new OTLPTraceExporter({
       url: tracesUrl,


### PR DESCRIPTION
updates the mastra exporter to use the non-deprecated traces endpoint