### PR TITLE
UP-3128: Limit cases when bump version is triggered

### DIFF
--- a/.github/workflows/version-workflow.yml
+++ b/.github/workflows/version-workflow.yml
@@ -25,8 +25,14 @@ jobs:
   bump-arthur-engine-version:
     environment: shared-protected-branch-secrets
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/dev' && !startsWith(github.event.head_commit.message, 'fix(deps)') && !startsWith(github.event.head_commit.message, 'Increment arthur-engine')) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.intent == 'bump_version' && github.ref != 'refs/heads/main')
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev' &&
+       !startsWith(github.event.head_commit.message, 'fix(deps)') &&
+       !startsWith(github.event.head_commit.message, 'Increment arthur-engine') &&
+       !startsWith(github.event.head_commit.message, 'Update dependency') &&
+       !startsWith(github.event.head_commit.message, 'chore(deps)')) ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.event.inputs.intent == 'bump_version' &&
+       github.ref != 'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
- limit cases when bump version is triggered (skip commits when there are commits that starts with "Update dependency" and "chore(deps)"