### PR TITLE
Fix connection test request

### DIFF
--- a/genai-engine/src/api_changelog.md
+++ b/genai-engine/src/api_changelog.md
@@ -2,6 +2,10 @@ The intention of this changelog is to document API changes as they happen to eff
 
 ---
 
+# 11/03/2025
+- **CHANGE** for **URL**: /api/v1/tasks/{task_id}/rag_providers/test_connection  removed the request property 'description'
+- **CHANGE** for **URL**: /api/v1/tasks/{task_id}/rag_providers/test_connection  removed the request property 'name'
+
 # 10/31/2025
 - **CHANGE** for **URL**: /api/v1/rag_providers/{provider_id}/hybrid_search  endpoint added
 

--- a/genai-engine/src/clients/rag_providers/rag_client_constructor.py
+++ b/genai-engine/src/clients/rag_providers/rag_client_constructor.py
@@ -1,9 +1,14 @@
+from typing import Union
+
 from fastapi import HTTPException
 
 from clients.rag_providers.rag_provider_client import RagProviderClient
 from clients.rag_providers.weaviate_client import WeaviateClient
 from schemas.enums import ConnectionCheckOutcome, RagAPIKeyAuthenticationProviderEnum
-from schemas.internal_schemas import RagProviderConfiguration
+from schemas.internal_schemas import (
+    RagProviderConfiguration,
+    RagProviderTestConfiguration,
+)
 from schemas.request_schemas import (
     RagHybridSearchSettingRequest,
     RagKeywordSearchSettingRequest,
@@ -19,7 +24,10 @@ from schemas.response_schemas import (
 class RagClientConstructor:
     """Responsible for picking a RAG client."""
 
-    def __init__(self, provider_config: RagProviderConfiguration) -> None:
+    def __init__(
+        self,
+        provider_config: Union[RagProviderTestConfiguration, RagProviderConfiguration],
+    ) -> None:
         self.provider_config = provider_config
 
     def pick_rag_provider_client(self) -> RagProviderClient:

--- a/genai-engine/src/routers/v1/rag_routes.py
+++ b/genai-engine/src/routers/v1/rag_routes.py
@@ -23,6 +23,7 @@ from schemas.enums import (
 from schemas.internal_schemas import (
     ApplicationConfiguration,
     RagProviderConfiguration,
+    RagProviderTestConfiguration,
     User,
 )
 from schemas.request_schemas import (
@@ -30,6 +31,7 @@ from schemas.request_schemas import (
     RagKeywordSearchSettingRequest,
     RagProviderConfigurationRequest,
     RagProviderConfigurationUpdateRequest,
+    RagProviderTestConfigurationRequest,
     RagVectorSimilarityTextSearchSettingRequest,
 )
 from schemas.response_schemas import (
@@ -242,16 +244,25 @@ def list_rag_provider_collections(
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
 def test_rag_provider_connection(
-    request: RagProviderConfigurationRequest,
+    request: RagProviderTestConfigurationRequest,
     task_id: str = Path(
         description="ID of the task to test the new provider connection for. Should be formatted as a UUID.",
     ),
     db_session: Session = Depends(get_db_session),
+    application_config: ApplicationConfiguration = Depends(get_application_config),
     current_user: User | None = Depends(multi_validator.validate_api_multi_auth),
 ) -> ConnectionCheckResult:
+    # validate task exists - get function will raise a 404 if it doesn't exist
+    task_repo = TaskRepository(
+        db_session,
+        RuleRepository(db_session),
+        MetricRepository(db_session),
+        application_config,
+    )
+    task_repo.get_task_by_id(task_id)
+
     try:
-        rag_provider_config = RagProviderConfiguration._from_request_model(
-            task_id,
+        rag_provider_config = RagProviderTestConfiguration._from_request_model(
             request,
         )
         rag_client_constructor = RagClientConstructor(rag_provider_config)

--- a/genai-engine/src/schemas/internal_schemas.py
+++ b/genai-engine/src/schemas/internal_schemas.py
@@ -116,6 +116,7 @@ from schemas.request_schemas import (
     NewDatasetVersionRequest,
     NewDatasetVersionRowColumnItemRequest,
     RagProviderConfigurationRequest,
+    RagProviderTestConfigurationRequest,
 )
 from schemas.response_schemas import (
     ApiKeyRagAuthenticationConfigResponse,
@@ -2388,6 +2389,31 @@ class ApiKeyRagAuthenticationConfig(BaseModel):
 
 
 RagAuthenticationConfigTypes = Union[ApiKeyRagAuthenticationConfig]
+
+
+class RagProviderTestConfiguration(BaseModel):
+    authentication_config: RagAuthenticationConfigTypes
+
+    @staticmethod
+    def _from_request_model(
+        request: RagProviderTestConfigurationRequest,
+    ) -> "RagProviderTestConfiguration":
+        if isinstance(
+            request.authentication_config,
+            ApiKeyRagAuthenticationConfigRequest,
+        ):
+            config = ApiKeyRagAuthenticationConfig._from_request_model(
+                request.authentication_config,
+            )
+        else:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Authentication method {type(request.authentication_config)} is not supported.",
+            )
+
+        return RagProviderTestConfiguration(
+            authentication_config=config,
+        )
 
 
 class RagProviderConfiguration(BaseModel):

--- a/genai-engine/src/schemas/request_schemas.py
+++ b/genai-engine/src/schemas/request_schemas.py
@@ -140,10 +140,13 @@ class ApiKeyRagAuthenticationConfigRequest(BaseModel):
 RagAuthenticationConfigRequestTypes = Union[ApiKeyRagAuthenticationConfigRequest]
 
 
-class RagProviderConfigurationRequest(BaseModel):
+class RagProviderTestConfigurationRequest(BaseModel):
     authentication_config: RagAuthenticationConfigRequestTypes = Field(
         description="Configuration of the authentication strategy.",
     )
+
+
+class RagProviderConfigurationRequest(RagProviderTestConfigurationRequest):
     name: str = Field(description="Name of RAG provider configuration.")
     description: Optional[str] = Field(
         default=None,

--- a/genai-engine/staging.openapi.json
+++ b/genai-engine/staging.openapi.json
@@ -6602,7 +6602,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/RagProviderConfigurationRequest"
+                                "$ref": "#/components/schemas/RagProviderTestConfigurationRequest"
                             }
                         }
                     }
@@ -12353,6 +12353,19 @@
                     "response"
                 ],
                 "title": "RagProviderQueryResponse"
+            },
+            "RagProviderTestConfigurationRequest": {
+                "properties": {
+                    "authentication_config": {
+                        "$ref": "#/components/schemas/ApiKeyRagAuthenticationConfigRequest",
+                        "description": "Configuration of the authentication strategy."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "authentication_config"
+                ],
+                "title": "RagProviderTestConfigurationRequest"
             },
             "RagVectorSimilarityTextSearchSettingRequest": {
                 "properties": {

--- a/genai-engine/tests/clients/base_test_client.py
+++ b/genai-engine/tests/clients/base_test_client.py
@@ -73,6 +73,7 @@ from schemas.request_schemas import (
     RagKeywordSearchSettingRequest,
     RagProviderConfigurationRequest,
     RagProviderConfigurationUpdateRequest,
+    RagProviderTestConfigurationRequest,
     RagVectorSimilarityTextSearchSettingRequest,
     WeaviateHybridSearchSettingsRequest,
     WeaviateKeywordSearchSettingsRequest,
@@ -2598,8 +2599,6 @@ class GenaiEngineTestClientBase(httpx.Client):
     def test_rag_provider_connection(
         self,
         task_id: str,
-        name: str,
-        description: str = None,
         authentication_method: RagProviderAuthenticationMethodEnum = RagProviderAuthenticationMethodEnum.API_KEY_AUTHENTICATION,
         api_key: str = "test-api-key",
         host_url: str = "https://test-weaviate.example.com",
@@ -2610,12 +2609,10 @@ class GenaiEngineTestClientBase(httpx.Client):
             api_key=api_key,
             host_url=host_url,
             rag_provider=rag_provider,
+            authentication_method=authentication_method,
         )
 
-        request = RagProviderConfigurationRequest(
-            name=name,
-            description=description,
-            authentication_method=authentication_method,
+        request = RagProviderTestConfigurationRequest(
             authentication_config=auth_config,
         )
 

--- a/genai-engine/tests/unit/routes/rag/test_rag_provider_search.py
+++ b/genai-engine/tests/unit/routes/rag/test_rag_provider_search.py
@@ -30,8 +30,6 @@ def test_rag_provider_connection_success(
     # Test the connection
     status_code, result = client.test_rag_provider_connection(
         task_id=task_id,
-        name="Test RAG Provider",
-        description="Test RAG provider for connection testing",
         api_key="test-api-key",
         host_url="https://test-weaviate.example.com",
     )
@@ -73,8 +71,6 @@ def test_rag_provider_connection_failure(
     # Test the connection
     status_code, result = client.test_rag_provider_connection(
         task_id=task_id,
-        name="Test RAG Provider",
-        description="Test RAG provider for connection failure testing",
         api_key="invalid-api-key",
         host_url="https://invalid-weaviate.example.com",
     )
@@ -124,8 +120,6 @@ def test_rag_provider_connection_constructor_exception(
     # Test the connection
     status_code, result = client.test_rag_provider_connection(
         task_id=task_id,
-        name="Test RAG Provider",
-        description="Test RAG provider for connection not connected testing",
         api_key="invalid-api-key",
         host_url="https://invalid-weaviate.example.com",
     )


### PR DESCRIPTION
Realized in standup the BE API accepts a name & description during a connection test request for no reason—removing here.