### PR TITLE
Don't specify the Postgres minor version on CFT

### DIFF
--- a/deployment/cloudformation/core/arthur-core-rds.yml
+++ b/deployment/cloudformation/core/arthur-core-rds.yml
@@ -87,7 +87,7 @@ Resources:
       DBClusterIdentifier: !Sub "${ArthurResourceNamespace}-db-cluster${ArthurResourceNameSuffix}"
       DatabaseName: !Ref ArthurRDSDatabaseName
       Engine: 'aurora-postgresql'
-      EngineVersion: '15.3'
+      EngineVersion: '15'
       ServerlessV2ScalingConfiguration:
         MinCapacity: !Ref ArthurRDSScalingConfigurationMinCapacity
         MaxCapacity: !Ref ArthurRDSScalingConfigurationMaxCapacity


### PR DESCRIPTION
RDS auto-upgrades the minor Postgres version. Therefore, we don't want to specify the minor version in CFT because the CFT will try to downgrade Postgres after the auto-upgrades.