### PR TITLE
add get requests for llm evals

### DIFF
--- a/genai-engine/src/api_changelog.md
+++ b/genai-engine/src/api_changelog.md
@@ -3,6 +3,17 @@ The intention of this changelog is to document API changes as they happen to eff
 ---
 
 # 11/06/2025
+- **BREAKING CHANGE** for **URL**: /api/v1/tasks/{task_id}/prompts  removed the required property 'prompt_metadata' from the response with the '200' status
+- **CHANGE** for **URL**: /api/v1/tasks/{task_id}/prompts  deleted the 'query' request parameter 'prompt_names'
+- **CHANGE** in components/schemas
+- **CHANGE** in components/schemas
+- **CHANGE** in API GET /api/v1/tasks/{task_id}/llm_evals
+- **CHANGE** in API GET /api/v1/tasks/{task_id}/llm_evals/{eval_name}/versions
+- **CHANGE** in API GET /api/v1/tasks/{task_id}/llm_evals/{eval_name}/versions/{eval_version}
+- **CHANGE** in API GET /api/v1/tasks/{task_id}/prompts
+- **CHANGE** in API GET /api/v1/tasks/{task_id}/prompts
+
+# 11/06/2025
 - **CHANGE** for **URL**: /api/v1/rag_search_settings/{setting_configuration_id}  api tag 'RAG Settings' added
 - **CHANGE** for **URL**: /api/v1/rag_search_settings/{setting_configuration_id}  api tag 'RAG Providers' removed
 - **CHANGE** for **URL**: /api/v1/rag_search_settings/{setting_configuration_id}  api tag 'RAG Settings' added

--- a/genai-engine/src/repositories/llm_evals_repository.py
+++ b/genai-engine/src/repositories/llm_evals_repository.py
@@ -1,13 +1,27 @@
 from datetime import datetime
+from typing import Optional, Tuple
 
 import sqlalchemy as sa
+from arthur_common.models.common_schemas import PaginationParameters
+from arthur_common.models.enums import PaginationSortMethod
+from sqlalchemy import asc, desc
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.query import Query
 
 from db_models.llm_eval_models import DatabaseLLMEval
 from schemas.llm_eval_schemas import LLMEval
-from schemas.request_schemas import CreateEvalRequest
+from schemas.request_schemas import (
+    CreateEvalRequest,
+    LLMGetAllFilterRequest,
+    LLMGetVersionsFilterRequest,
+)
+from schemas.response_schemas import (
+    LLMEvalsVersionListResponse,
+    LLMEvalsVersionResponse,
+    LLMGetAllMetadataListResponse,
+    LLMGetAllMetadataResponse,
+)
 
 
 class LLMEvalsRepository:
@@ -76,6 +90,225 @@ class LLMEvalsRepository:
             raise ValueError(err_message)
 
         return db_eval
+
+    def _apply_sorting_pagination_and_count(
+        self,
+        query: Query,
+        pagination_parameters: PaginationParameters,
+        sort_column,
+    ) -> Tuple[Query, int]:
+        """
+        Apply sorting and pagination to a query and return the total count.
+
+        Parameters:
+            query: Query - the SQLAlchemy query to sort and paginate
+            pagination_parameters: PaginationParameters - pagination and sorting params
+            sort_column - the column or label to sort by
+
+        Returns:
+            Tuple[Query, int] - the sorted and paginated query, and total count
+        """
+        # Apply sorting
+        if pagination_parameters.sort == PaginationSortMethod.DESCENDING:
+            query = query.order_by(desc(sort_column))
+        else:  # ASCENDING or default
+            query = query.order_by(asc(sort_column))
+
+        # Get total count BEFORE applying pagination
+        total_count = query.count()
+
+        # Apply pagination
+        query = query.offset(
+            pagination_parameters.page * pagination_parameters.page_size,
+        )
+        query = query.limit(pagination_parameters.page_size)
+
+        return query, total_count
+
+    def get_eval(
+        self,
+        task_id: str,
+        eval_name: str,
+        eval_version: str = "latest",
+    ) -> LLMEval:
+        """
+        Get an llm eval by task_id, name, and version
+
+        Parameters:
+            task_id: str - the id of the task
+            eval_name: str - the name of the llm eval
+            eval_version: str = "latest" - the version of the llm eval, defaults to 'latest'
+
+        * Note - Supports getting an llm eval by:
+            - eval_version = 'latest' -> gets the latest version
+            - eval_version = <string number> (e.g. '1', '2', etc.) -> gets that version
+            - eval_version = <datetime> (i.e. YYYY-MM-DDTHH:MM:SS, checks to the second) -> gets the version created at that time
+
+        Returns:
+            LLMEval - the llm eval object
+        """
+        base_query = self.db_session.query(DatabaseLLMEval).filter(
+            DatabaseLLMEval.task_id == task_id,
+            DatabaseLLMEval.name == eval_name,
+        )
+
+        # Version resolution
+        err_msg = f"LLM eval '{eval_name}' (version '{eval_version}') not found for task '{task_id}'"
+        db_eval = self._get_db_eval_by_version(
+            base_query,
+            eval_version,
+            err_message=err_msg,
+        )
+
+        return LLMEval.from_db_model(db_eval)
+
+    def get_eval_versions(
+        self,
+        task_id: str,
+        eval_name: str,
+        pagination_parameters: PaginationParameters,
+        filter_request: Optional[LLMGetVersionsFilterRequest] = None,
+    ) -> LLMEvalsVersionListResponse:
+        """
+        Get all versions of an llm eval by task_id and name, including metadata:
+            - version number
+            - created_at and deleted_at timestamps
+            - model provider and name
+
+        Parameters:
+            task_id: str - the id of the task
+            eval_name: str - the name of the llm eval
+            pagination_parameters: PaginationParameters - pagination and sorting params
+
+        Returns:
+            LLMEvalsVersionListResponse - the list of version metadata objects with total count
+        """
+        # Build base query
+        base_query = self.db_session.query(DatabaseLLMEval).filter(
+            DatabaseLLMEval.task_id == task_id,
+            DatabaseLLMEval.name == eval_name,
+        )
+
+        # Apply filters
+        if filter_request is not None:
+            base_query = filter_request.apply_filters_to_query(
+                base_query,
+                DatabaseLLMEval,
+            )
+
+        # Apply sorting, pagination, and get count
+        base_query, total_count = self._apply_sorting_pagination_and_count(
+            base_query,
+            pagination_parameters,
+            DatabaseLLMEval.version,
+        )
+
+        db_evals = base_query.all()
+
+        # If we're past the last page, return empty list
+        if not db_evals:
+            return LLMEvalsVersionListResponse(versions=[], count=total_count)
+
+        versions = []
+        for db_eval in db_evals:
+            versions.append(
+                LLMEvalsVersionResponse(
+                    version=db_eval.version,
+                    created_at=db_eval.created_at,
+                    deleted_at=db_eval.deleted_at,
+                    model_provider=db_eval.model_provider,
+                    model_name=db_eval.model_name,
+                ),
+            )
+
+        return LLMEvalsVersionListResponse(versions=versions, count=total_count)
+
+    def get_all_llm_eval_metadata(
+        self,
+        task_id: str,
+        pagination_parameters: PaginationParameters,
+        filter_request: Optional[LLMGetAllFilterRequest] = None,
+    ) -> LLMGetAllMetadataListResponse:
+        """
+        Get metadata for all llm evals by task_id, including:
+            - name
+            - number of versions
+            - creation timestamps for first and latest versions
+            - list of deleted version numbers
+
+        Parameters:
+            task_id: str - the id of the task
+            pagination_parameters: PaginationParameters - pagination and sorting params
+            filter_request: LLMGetAllFilterRequest - filter request parameters
+
+        Returns:
+            LLMGetAllMetadataListResponse - list of llm eval metadata objects with total count
+        """
+        # Start with aggregated query
+        base_query = self.db_session.query(
+            DatabaseLLMEval.name.label("name"),
+            sa.func.count(DatabaseLLMEval.version).label("versions"),
+            sa.func.min(DatabaseLLMEval.created_at).label("created_at"),
+            sa.func.max(DatabaseLLMEval.created_at).label(
+                "latest_version_created_at",
+            ),
+        ).filter(DatabaseLLMEval.task_id == task_id)
+
+        # Apply filters BEFORE grouping
+        if filter_request is not None:
+            base_query = filter_request.apply_filters_to_query(
+                base_query,
+                DatabaseLLMEval,
+            )
+
+        # Apply grouping
+        base_query = base_query.group_by(DatabaseLLMEval.name)
+
+        # Apply sorting, pagination, and get count
+        base_query, total_count = self._apply_sorting_pagination_and_count(
+            base_query,
+            pagination_parameters,
+            DatabaseLLMEval.name,
+        )
+
+        results = base_query.all()
+
+        if not results:
+            return LLMGetAllMetadataListResponse(
+                llm_metadata=[],
+                count=total_count,
+            )
+
+        llm_metadata = []
+        for row in results:
+            # get the deleted versions
+            deleted_versions = (
+                self.db_session.query(DatabaseLLMEval.version)
+                .filter(
+                    DatabaseLLMEval.task_id == task_id,
+                    DatabaseLLMEval.name == row.name,
+                    DatabaseLLMEval.deleted_at.isnot(None),
+                )
+                .order_by(DatabaseLLMEval.version.asc())
+                .all()
+            )
+            deleted_versions = [v for (v,) in deleted_versions]
+
+            # set the metadata
+            llm_metadata.append(
+                LLMGetAllMetadataResponse(
+                    name=row.name,
+                    versions=row.versions,
+                    created_at=row.created_at,
+                    latest_version_created_at=row.latest_version_created_at,
+                    deleted_versions=deleted_versions,
+                ),
+            )
+
+        return LLMGetAllMetadataListResponse(
+            llm_metadata=llm_metadata,
+            count=total_count,
+        )
 
     def save_eval(
         self,

--- a/genai-engine/src/routers/v1/llm_eval_routes.py
+++ b/genai-engine/src/routers/v1/llm_eval_routes.py
@@ -1,20 +1,155 @@
+from typing import Annotated
+
+from arthur_common.models.common_schemas import PaginationParameters
 from fastapi import APIRouter, Depends, HTTPException, Path, Response, status
 from sqlalchemy.orm import Session
 
-from dependencies import get_db_session, get_validated_agentic_task
+from dependencies import (
+    get_db_session,
+    get_validated_agentic_task,
+    llm_get_all_filter_parameters,
+    llm_get_versions_filter_parameters,
+)
 from repositories.llm_evals_repository import LLMEvalsRepository
 from routers.route_handler import GenaiEngineRoute
 from routers.v2 import multi_validator
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import Task, User
 from schemas.llm_eval_schemas import LLMEval
-from schemas.request_schemas import CreateEvalRequest
+from schemas.request_schemas import (
+    CreateEvalRequest,
+    LLMGetAllFilterRequest,
+    LLMGetVersionsFilterRequest,
+)
+from schemas.response_schemas import (
+    LLMEvalsVersionListResponse,
+    LLMGetAllMetadataListResponse,
+)
 from utils.users import permission_checker
+from utils.utils import common_pagination_parameters
 
 llm_eval_routes = APIRouter(
     prefix="/api/v1",
     route_class=GenaiEngineRoute,
 )
+
+
+@llm_eval_routes.get(
+    "/tasks/{task_id}/llm_evals/{eval_name}/versions/{eval_version}",
+    summary="Get an llm eval",
+    description="Get an llm eval by name and version",
+    response_model=LLMEval,
+    response_model_exclude_none=True,
+    tags=["LLMEvals"],
+)
+@permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+def get_llm_eval(
+    eval_name: str = Path(
+        ...,
+        description="The name of the llm eval to retrieve.",
+        title="LLM Eval Name",
+    ),
+    eval_version: str = Path(
+        ...,
+        description="The version of the llm eval to retrieve. Can be 'latest', a version number (e.g. '1', '2', etc.), or an ISO datetime string (e.g. '2025-01-01T00:00:00').",
+        title="LLM Eval Version",
+    ),
+    db_session: Session = Depends(get_db_session),
+    current_user: User | None = Depends(multi_validator.validate_api_multi_auth),
+    task: Task = Depends(get_validated_agentic_task),
+):
+    try:
+        llm_eval_service = LLMEvalsRepository(db_session)
+        llm_eval = llm_eval_service.get_eval(
+            task.id,
+            eval_name,
+            eval_version,
+        )
+        return llm_eval
+    except ValueError as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(status_code=404, detail=str(e))
+        else:
+            raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@llm_eval_routes.get(
+    "/tasks/{task_id}/llm_evals/{eval_name}/versions",
+    summary="List all versions of an llm eval",
+    description="List all versions of an llm eval with optional filtering.",
+    response_model=LLMEvalsVersionListResponse,
+    response_model_exclude_none=True,
+    tags=["LLMEvals"],
+)
+@permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+def get_all_llm_eval_versions(
+    pagination_parameters: Annotated[
+        PaginationParameters,
+        Depends(common_pagination_parameters),
+    ],
+    filter_request: Annotated[
+        LLMGetVersionsFilterRequest,
+        Depends(llm_get_versions_filter_parameters),
+    ],
+    eval_name: str = Path(
+        ...,
+        description="The name of the llm eval to retrieve.",
+        title="LLM Eval Name",
+    ),
+    db_session: Session = Depends(get_db_session),
+    current_user: User | None = Depends(multi_validator.validate_api_multi_auth),
+    task: Task = Depends(get_validated_agentic_task),
+):
+    try:
+
+        llm_eval_service = LLMEvalsRepository(db_session)
+        return llm_eval_service.get_eval_versions(
+            task.id,
+            eval_name,
+            pagination_parameters,
+            filter_request,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@llm_eval_routes.get(
+    "/tasks/{task_id}/llm_evals",
+    summary="Get all llm evals",
+    description="Get all llm evals for a given task with optional filtering.",
+    response_model=LLMGetAllMetadataListResponse,
+    response_model_exclude_none=True,
+    tags=["LLMEvals"],
+)
+@permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+def get_all_llm_evals(
+    pagination_parameters: Annotated[
+        PaginationParameters,
+        Depends(common_pagination_parameters),
+    ],
+    filter_request: Annotated[
+        LLMGetAllFilterRequest,
+        Depends(llm_get_all_filter_parameters),
+    ],
+    db_session: Session = Depends(get_db_session),
+    current_user: User | None = Depends(multi_validator.validate_api_multi_auth),
+    task: Task = Depends(get_validated_agentic_task),
+):
+    try:
+        llm_eval_service = LLMEvalsRepository(db_session)
+        return llm_eval_service.get_all_llm_eval_metadata(
+            task.id,
+            pagination_parameters,
+            filter_request,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @llm_eval_routes.post(

--- a/genai-engine/src/schemas/request_schemas.py
+++ b/genai-engine/src/schemas/request_schemas.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Type, Union
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -16,7 +16,7 @@ from weaviate.collections.classes.grpc import (
 )
 from weaviate.types import INCLUDE_VECTOR
 
-from db_models.agentic_prompt_models import DatabaseAgenticPrompt
+from db_models.base import Base
 from schemas.agentic_prompt_schemas import LLMConfigSettings
 from schemas.enums import (
     DocumentStorageEnvironment,
@@ -495,16 +495,16 @@ class RagSearchSettingConfigurationNewVersionRequest(BaseModel):
     )
 
 
-class BasePromptFilterRequest(BaseModel, ABC):
+class BaseFilterRequest(BaseModel, ABC):
     """Abstract Pydantic base class enforcing apply_filters_to_query implementation."""
 
     @abstractmethod
-    def apply_filters_to_query(self, query: Query) -> Query:
+    def apply_filters_to_query(self, query: Query, db_model: Type[Base]) -> Query:
         """Apply filters to a SQLAlchemy query."""
 
 
-class PromptsGetVersionsFilterRequest(BasePromptFilterRequest):
-    """Request schema for filtering agentic prompts with comprehensive filtering options."""
+class LLMGetVersionsFilterRequest(BaseFilterRequest):
+    """Request schema for filtering agentic prompts and llm evals with comprehensive filtering options."""
 
     # Optional filters
     model_provider: Optional[ModelProvider] = Field(
@@ -541,6 +541,7 @@ class PromptsGetVersionsFilterRequest(BasePromptFilterRequest):
     def apply_filters_to_query(
         self,
         query: Query,
+        db_model: Type[Base],
     ) -> Query:
         """
         Apply filters to a query based on the filter request.
@@ -554,53 +555,53 @@ class PromptsGetVersionsFilterRequest(BasePromptFilterRequest):
         # Filter by model provider
         if self.model_provider:
             query = query.filter(
-                DatabaseAgenticPrompt.model_provider == self.model_provider,
+                db_model.model_provider == self.model_provider,
             )
 
         # Filter by model name using LIKE for partial matching
         if self.model_name:
             query = query.filter(
-                DatabaseAgenticPrompt.model_name.like(f"%{self.model_name}%"),
+                db_model.model_name.like(f"%{self.model_name}%"),
             )
 
         # Filter by start time (inclusive)
         if self.created_after:
             query = query.filter(
-                DatabaseAgenticPrompt.created_at >= self.created_after,
+                db_model.created_at >= self.created_after,
             )
 
         # Filter by end time (exclusive)
         if self.created_before:
             query = query.filter(
-                DatabaseAgenticPrompt.created_at < self.created_before,
+                db_model.created_at < self.created_before,
             )
 
         # Filter by deleted status
         if self.exclude_deleted == True:
-            query = query.filter(DatabaseAgenticPrompt.deleted_at.is_(None))
+            query = query.filter(db_model.deleted_at.is_(None))
 
         # Filter by min version
         if self.min_version is not None:
             query = query.filter(
-                DatabaseAgenticPrompt.version >= self.min_version,
+                db_model.version >= self.min_version,
             )
 
         # Filter by max version
         if self.max_version is not None:
             query = query.filter(
-                DatabaseAgenticPrompt.version <= self.max_version,
+                db_model.version <= self.max_version,
             )
 
         return query
 
 
-class PromptsGetAllFilterRequest(BasePromptFilterRequest):
-    """Request schema for filtering agentic prompts with comprehensive filtering options."""
+class LLMGetAllFilterRequest(BaseFilterRequest):
+    """Request schema for filtering agentic prompts and llm evals with comprehensive filtering options."""
 
     # Optional filters
-    prompt_names: Optional[list[str]] = Field(
+    llm_asset_names: Optional[list[str]] = Field(
         None,
-        description="Prompt names to filter on using partial matching. If provided, prompts matching any of these name patterns will be returned. Supports SQL LIKE pattern matching with % wildcards.",
+        description="LLM asset names to filter on using partial matching. If provided, llm assets matching any of these name patterns will be returned",
     )
     model_provider: Optional[ModelProvider] = Field(
         None,
@@ -608,7 +609,7 @@ class PromptsGetAllFilterRequest(BasePromptFilterRequest):
     )
     model_name: Optional[str] = Field(
         None,
-        description="Filter by model name using partial matching (e.g., 'gpt-4', 'claude'). Supports SQL LIKE pattern matching with % wildcards.",
+        description="Filter by model name using partial matching (e.g., 'gpt-4o', 'claude-3-5-sonnet').",
     )
     created_after: Optional[datetime] = Field(
         None,
@@ -622,6 +623,7 @@ class PromptsGetAllFilterRequest(BasePromptFilterRequest):
     def apply_filters_to_query(
         self,
         query: Query,
+        db_model: Type[Base],
     ) -> Query:
         """
         Apply filters to a query based on the filter request.
@@ -633,35 +635,34 @@ class PromptsGetAllFilterRequest(BasePromptFilterRequest):
             Query - the query with filters applied
         """
         # Filter by prompt names using LIKE for partial matching
-        if self.prompt_names:
+        if self.llm_asset_names:
             name_conditions = [
-                DatabaseAgenticPrompt.name.like(f"%{name}%")
-                for name in self.prompt_names
+                db_model.name.like(f"%{name}%") for name in self.llm_asset_names
             ]
             query = query.filter(or_(*name_conditions))
 
         # Filter by model provider
         if self.model_provider:
             query = query.filter(
-                DatabaseAgenticPrompt.model_provider == self.model_provider,
+                db_model.model_provider == self.model_provider,
             )
 
         # Filter by model name using LIKE for partial matching
         if self.model_name:
             query = query.filter(
-                DatabaseAgenticPrompt.model_name.like(f"%{self.model_name}%"),
+                db_model.model_name.like(f"%{self.model_name}%"),
             )
 
         # Filter by start time (inclusive)
         if self.created_after:
             query = query.filter(
-                DatabaseAgenticPrompt.created_at >= self.created_after,
+                db_model.created_at >= self.created_after,
             )
 
         # Filter by end time (exclusive)
         if self.created_before:
             query = query.filter(
-                DatabaseAgenticPrompt.created_at < self.created_before,
+                db_model.created_at < self.created_before,
             )
 
         return query

--- a/genai-engine/src/schemas/response_schemas.py
+++ b/genai-engine/src/schemas/response_schemas.py
@@ -602,23 +602,23 @@ class ListRagSearchSettingConfigurationsResponse(BaseModel):
     )
 
 
-class AgenticPromptMetadataResponse(BaseModel):
-    name: str = Field(description="Name of the prompt")
-    versions: int = Field(description="Number of versions of the prompt")
-    created_at: datetime = Field(description="Timestamp when the prompt was created")
+class LLMGetAllMetadataResponse(BaseModel):
+    name: str = Field(description="Name of the llm asset")
+    versions: int = Field(description="Number of versions of the llm asset")
+    created_at: datetime = Field(description="Timestamp when the llm asset was created")
     latest_version_created_at: datetime = Field(
-        description="Timestamp when the last version of the prompt was created",
+        description="Timestamp when the last version of the llm asset was created",
     )
     deleted_versions: List[int] = Field(
-        description="List of deleted versions of the prompt",
+        description="List of deleted versions of the llm asset",
     )
 
 
-class AgenticPromptMetadataListResponse(BaseModel):
-    prompt_metadata: list[AgenticPromptMetadataResponse] = Field(
-        description="List of prompt metadata",
+class LLMGetAllMetadataListResponse(BaseModel):
+    llm_metadata: list[LLMGetAllMetadataResponse] = Field(
+        description="List of llm asset metadata",
     )
-    count: int = Field(description="Total number of prompts matching filters")
+    count: int = Field(description="Total number of llm assets matching filters")
 
 
 class AgenticPromptVersionResponse(BaseModel):
@@ -640,3 +640,26 @@ class AgenticPromptVersionListResponse(BaseModel):
         description="List of prompt version metadata",
     )
     count: int = Field(description="Total number of prompts matching filters")
+
+
+class LLMEvalsVersionResponse(BaseModel):
+    version: int = Field(description="Version number of the llm eval")
+    created_at: datetime = Field(
+        description="Timestamp when the llm eval version was created",
+    )
+    deleted_at: Optional[datetime] = Field(
+        description="Timestamp when the llm eval version was deleted (None if not deleted)",
+    )
+    model_provider: ModelProvider = Field(
+        description="Model provider chosen for this version of the llm eval",
+    )
+    model_name: str = Field(
+        description="Model name chosen for this version of the llm eval",
+    )
+
+
+class LLMEvalsVersionListResponse(BaseModel):
+    versions: list[LLMEvalsVersionResponse] = Field(
+        description="List of llm eval version metadata",
+    )
+    count: int = Field(description="Total number of llm evals matching filters")

--- a/genai-engine/staging.openapi.json
+++ b/genai-engine/staging.openapi.json
@@ -4817,7 +4817,7 @@
                         "description": "Page number"
                     },
                     {
-                        "name": "prompt_names",
+                        "name": "llm_asset_names",
                         "in": "query",
                         "required": false,
                         "schema": {
@@ -4832,10 +4832,10 @@
                                     "type": "null"
                                 }
                             ],
-                            "description": "Prompt names to filter on using partial matching. If provided, prompts matching any of these name patterns will be returned.",
-                            "title": "Prompt Names"
+                            "description": "LLM asset names to filter on using partial matching. If provided, llm assets matching any of these name patterns will be returned",
+                            "title": "Llm Asset Names"
                         },
-                        "description": "Prompt names to filter on using partial matching. If provided, prompts matching any of these name patterns will be returned."
+                        "description": "LLM asset names to filter on using partial matching. If provided, llm assets matching any of these name patterns will be returned"
                     },
                     {
                         "name": "model_provider",
@@ -4916,7 +4916,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/AgenticPromptMetadataListResponse"
+                                    "$ref": "#/components/schemas/LLMGetAllMetadataListResponse"
                                 }
                             }
                         }
@@ -7326,6 +7326,533 @@
                 }
             }
         },
+        "/api/v1/tasks/{task_id}/llm_evals/{eval_name}/versions/{eval_version}": {
+            "get": {
+                "tags": [
+                    "LLMEvals"
+                ],
+                "summary": "Get an llm eval",
+                "description": "Get an llm eval by name and version",
+                "operationId": "get_llm_eval_api_v1_tasks__task_id__llm_evals__eval_name__versions__eval_version__get",
+                "security": [
+                    {
+                        "API Key": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "eval_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "LLM Eval Name",
+                            "description": "The name of the llm eval to retrieve."
+                        },
+                        "description": "The name of the llm eval to retrieve."
+                    },
+                    {
+                        "name": "eval_version",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "LLM Eval Version",
+                            "description": "The version of the llm eval to retrieve. Can be 'latest', a version number (e.g. '1', '2', etc.), or an ISO datetime string (e.g. '2025-01-01T00:00:00')."
+                        },
+                        "description": "The version of the llm eval to retrieve. Can be 'latest', a version number (e.g. '1', '2', etc.), or an ISO datetime string (e.g. '2025-01-01T00:00:00')."
+                    },
+                    {
+                        "name": "task_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Task Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LLMEval"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "LLMEvals"
+                ],
+                "summary": "Delete an llm eval version",
+                "description": "Deletes a specific version of an llm eval",
+                "operationId": "soft_delete_llm_eval_version_api_v1_tasks__task_id__llm_evals__eval_name__versions__eval_version__delete",
+                "security": [
+                    {
+                        "API Key": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "eval_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "LLM Eval Name",
+                            "description": "The name of the llm eval to delete."
+                        },
+                        "description": "The name of the llm eval to delete."
+                    },
+                    {
+                        "name": "eval_version",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "LLM Eval Version",
+                            "description": "The version of the llm eval to delete. Can be 'latest', a version number (e.g. '1', '2', etc.), or an ISO datetime string (e.g. '2025-01-01T00:00:00')."
+                        },
+                        "description": "The version of the llm eval to delete. Can be 'latest', a version number (e.g. '1', '2', etc.), or an ISO datetime string (e.g. '2025-01-01T00:00:00')."
+                    },
+                    {
+                        "name": "task_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Task Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "LLM eval version deleted."
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/tasks/{task_id}/llm_evals/{eval_name}/versions": {
+            "get": {
+                "tags": [
+                    "LLMEvals"
+                ],
+                "summary": "List all versions of an llm eval",
+                "description": "List all versions of an llm eval with optional filtering.",
+                "operationId": "get_all_llm_eval_versions_api_v1_tasks__task_id__llm_evals__eval_name__versions_get",
+                "security": [
+                    {
+                        "API Key": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "eval_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "LLM Eval Name",
+                            "description": "The name of the llm eval to retrieve."
+                        },
+                        "description": "The name of the llm eval to retrieve."
+                    },
+                    {
+                        "name": "task_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Task Id"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/PaginationSortMethod",
+                            "description": "Sort the results (asc/desc)",
+                            "default": "desc"
+                        },
+                        "description": "Sort the results (asc/desc)"
+                    },
+                    {
+                        "name": "page_size",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "description": "Page size. Default is 10. Must be greater than 0 and less than 5000.",
+                            "default": 10,
+                            "title": "Page Size"
+                        },
+                        "description": "Page size. Default is 10. Must be greater than 0 and less than 5000."
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "description": "Page number",
+                            "default": 0,
+                            "title": "Page"
+                        },
+                        "description": "Page number"
+                    },
+                    {
+                        "name": "model_provider",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter by model provider (e.g., 'openai', 'anthropic', 'azure').",
+                            "title": "Model Provider"
+                        },
+                        "description": "Filter by model provider (e.g., 'openai', 'anthropic', 'azure')."
+                    },
+                    {
+                        "name": "model_name",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet').",
+                            "title": "Model Name"
+                        },
+                        "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet')."
+                    },
+                    {
+                        "name": "created_after",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Inclusive start date for prompt creation in ISO8601 string format. Use local time (not UTC).",
+                            "title": "Created After"
+                        },
+                        "description": "Inclusive start date for prompt creation in ISO8601 string format. Use local time (not UTC)."
+                    },
+                    {
+                        "name": "created_before",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Exclusive end date for prompt creation in ISO8601 string format. Use local time (not UTC).",
+                            "title": "Created Before"
+                        },
+                        "description": "Exclusive end date for prompt creation in ISO8601 string format. Use local time (not UTC)."
+                    },
+                    {
+                        "name": "exclude_deleted",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "description": "Whether to exclude deleted prompt versions from the results. Default is False.",
+                            "default": false,
+                            "title": "Exclude Deleted"
+                        },
+                        "description": "Whether to exclude deleted prompt versions from the results. Default is False."
+                    },
+                    {
+                        "name": "min_version",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 1
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Minimum version number to filter on (inclusive).",
+                            "title": "Min Version"
+                        },
+                        "description": "Minimum version number to filter on (inclusive)."
+                    },
+                    {
+                        "name": "max_version",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 1
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Maximum version number to filter on (inclusive).",
+                            "title": "Max Version"
+                        },
+                        "description": "Maximum version number to filter on (inclusive)."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LLMEvalsVersionListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/tasks/{task_id}/llm_evals": {
+            "get": {
+                "tags": [
+                    "LLMEvals"
+                ],
+                "summary": "Get all llm evals",
+                "description": "Get all llm evals for a given task with optional filtering.",
+                "operationId": "get_all_llm_evals_api_v1_tasks__task_id__llm_evals_get",
+                "security": [
+                    {
+                        "API Key": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "task_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Task Id"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/components/schemas/PaginationSortMethod",
+                            "description": "Sort the results (asc/desc)",
+                            "default": "desc"
+                        },
+                        "description": "Sort the results (asc/desc)"
+                    },
+                    {
+                        "name": "page_size",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "description": "Page size. Default is 10. Must be greater than 0 and less than 5000.",
+                            "default": 10,
+                            "title": "Page Size"
+                        },
+                        "description": "Page size. Default is 10. Must be greater than 0 and less than 5000."
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "description": "Page number",
+                            "default": 0,
+                            "title": "Page"
+                        },
+                        "description": "Page number"
+                    },
+                    {
+                        "name": "llm_asset_names",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "LLM asset names to filter on using partial matching. If provided, llm assets matching any of these name patterns will be returned",
+                            "title": "Llm Asset Names"
+                        },
+                        "description": "LLM asset names to filter on using partial matching. If provided, llm assets matching any of these name patterns will be returned"
+                    },
+                    {
+                        "name": "model_provider",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter by model provider (e.g., 'openai', 'anthropic', 'azure').",
+                            "title": "Model Provider"
+                        },
+                        "description": "Filter by model provider (e.g., 'openai', 'anthropic', 'azure')."
+                    },
+                    {
+                        "name": "model_name",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet').",
+                            "title": "Model Name"
+                        },
+                        "description": "Filter by model name (e.g., 'gpt-4', 'claude-3-5-sonnet')."
+                    },
+                    {
+                        "name": "created_after",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Inclusive start date for prompt creation in ISO8601 string format. Use local time (not UTC).",
+                            "title": "Created After"
+                        },
+                        "description": "Inclusive start date for prompt creation in ISO8601 string format. Use local time (not UTC)."
+                    },
+                    {
+                        "name": "created_before",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Exclusive end date for prompt creation in ISO8601 string format. Use local time (not UTC).",
+                            "title": "Created Before"
+                        },
+                        "description": "Exclusive end date for prompt creation in ISO8601 string format. Use local time (not UTC)."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LLMGetAllMetadataListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/tasks/{task_id}/llm_evals/{eval_name}": {
             "post": {
                 "tags": [
@@ -7433,70 +7960,6 @@
                 "responses": {
                     "204": {
                         "description": "LLM eval deleted."
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/tasks/{task_id}/llm_evals/{eval_name}/versions/{eval_version}": {
-            "delete": {
-                "tags": [
-                    "LLMEvals"
-                ],
-                "summary": "Delete an llm eval version",
-                "description": "Deletes a specific version of an llm eval",
-                "operationId": "soft_delete_llm_eval_version_api_v1_tasks__task_id__llm_evals__eval_name__versions__eval_version__delete",
-                "security": [
-                    {
-                        "API Key": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "eval_name",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "title": "LLM Eval Name",
-                            "description": "The name of the llm eval to delete."
-                        },
-                        "description": "The name of the llm eval to delete."
-                    },
-                    {
-                        "name": "eval_version",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "title": "LLM Eval Version",
-                            "description": "The version of the llm eval to delete. Can be 'latest', a version number (e.g. '1', '2', etc.), or an ISO datetime string (e.g. '2025-01-01T00:00:00')."
-                        },
-                        "description": "The version of the llm eval to delete. Can be 'latest', a version number (e.g. '1', '2', etc.), or an ISO datetime string (e.g. '2025-01-01T00:00:00')."
-                    },
-                    {
-                        "name": "task_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Task Id"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "LLM eval version deleted."
                     },
                     "422": {
                         "description": "Validation Error",
@@ -8913,72 +9376,6 @@
                 ],
                 "title": "AgenticPromptMessage",
                 "description": "The message schema class for the prompts playground.\nThis class adheres to OpenAI's message schema."
-            },
-            "AgenticPromptMetadataListResponse": {
-                "properties": {
-                    "prompt_metadata": {
-                        "items": {
-                            "$ref": "#/components/schemas/AgenticPromptMetadataResponse"
-                        },
-                        "type": "array",
-                        "title": "Prompt Metadata",
-                        "description": "List of prompt metadata"
-                    },
-                    "count": {
-                        "type": "integer",
-                        "title": "Count",
-                        "description": "Total number of prompts matching filters"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "prompt_metadata",
-                    "count"
-                ],
-                "title": "AgenticPromptMetadataListResponse"
-            },
-            "AgenticPromptMetadataResponse": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "title": "Name",
-                        "description": "Name of the prompt"
-                    },
-                    "versions": {
-                        "type": "integer",
-                        "title": "Versions",
-                        "description": "Number of versions of the prompt"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Created At",
-                        "description": "Timestamp when the prompt was created"
-                    },
-                    "latest_version_created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Latest Version Created At",
-                        "description": "Timestamp when the last version of the prompt was created"
-                    },
-                    "deleted_versions": {
-                        "items": {
-                            "type": "integer"
-                        },
-                        "type": "array",
-                        "title": "Deleted Versions",
-                        "description": "List of deleted versions of the prompt"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "name",
-                    "versions",
-                    "created_at",
-                    "latest_version_created_at",
-                    "deleted_versions"
-                ],
-                "title": "AgenticPromptMetadataResponse"
             },
             "AgenticPromptRunResponse": {
                 "properties": {
@@ -11375,6 +11772,141 @@
                     "instructions"
                 ],
                 "title": "LLMEval"
+            },
+            "LLMEvalsVersionListResponse": {
+                "properties": {
+                    "versions": {
+                        "items": {
+                            "$ref": "#/components/schemas/LLMEvalsVersionResponse"
+                        },
+                        "type": "array",
+                        "title": "Versions",
+                        "description": "List of llm eval version metadata"
+                    },
+                    "count": {
+                        "type": "integer",
+                        "title": "Count",
+                        "description": "Total number of llm evals matching filters"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "versions",
+                    "count"
+                ],
+                "title": "LLMEvalsVersionListResponse"
+            },
+            "LLMEvalsVersionResponse": {
+                "properties": {
+                    "version": {
+                        "type": "integer",
+                        "title": "Version",
+                        "description": "Version number of the llm eval"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At",
+                        "description": "Timestamp when the llm eval version was created"
+                    },
+                    "deleted_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Deleted At",
+                        "description": "Timestamp when the llm eval version was deleted (None if not deleted)"
+                    },
+                    "model_provider": {
+                        "$ref": "#/components/schemas/ModelProvider",
+                        "description": "Model provider chosen for this version of the llm eval"
+                    },
+                    "model_name": {
+                        "type": "string",
+                        "title": "Model Name",
+                        "description": "Model name chosen for this version of the llm eval"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "version",
+                    "created_at",
+                    "deleted_at",
+                    "model_provider",
+                    "model_name"
+                ],
+                "title": "LLMEvalsVersionResponse"
+            },
+            "LLMGetAllMetadataListResponse": {
+                "properties": {
+                    "llm_metadata": {
+                        "items": {
+                            "$ref": "#/components/schemas/LLMGetAllMetadataResponse"
+                        },
+                        "type": "array",
+                        "title": "Llm Metadata",
+                        "description": "List of llm asset metadata"
+                    },
+                    "count": {
+                        "type": "integer",
+                        "title": "Count",
+                        "description": "Total number of llm assets matching filters"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "llm_metadata",
+                    "count"
+                ],
+                "title": "LLMGetAllMetadataListResponse"
+            },
+            "LLMGetAllMetadataResponse": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "Name of the llm asset"
+                    },
+                    "versions": {
+                        "type": "integer",
+                        "title": "Versions",
+                        "description": "Number of versions of the llm asset"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At",
+                        "description": "Timestamp when the llm asset was created"
+                    },
+                    "latest_version_created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Latest Version Created At",
+                        "description": "Timestamp when the last version of the llm asset was created"
+                    },
+                    "deleted_versions": {
+                        "items": {
+                            "type": "integer"
+                        },
+                        "type": "array",
+                        "title": "Deleted Versions",
+                        "description": "List of deleted versions of the llm asset"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "name",
+                    "versions",
+                    "created_at",
+                    "latest_version_created_at",
+                    "deleted_versions"
+                ],
+                "title": "LLMGetAllMetadataResponse"
             },
             "LLMResponseFormat-Input": {
                 "properties": {

--- a/genai-engine/tests/unit/repositories/test_agentic_prompts_repository.py
+++ b/genai-engine/tests/unit/repositories/test_agentic_prompts_repository.py
@@ -27,14 +27,14 @@ from schemas.agentic_prompt_schemas import (
 from schemas.common_schemas import JsonSchema
 from schemas.enums import MessageRole, ModelProvider
 from schemas.request_schemas import (
-    PromptsGetAllFilterRequest,
-    PromptsGetVersionsFilterRequest,
+    LLMGetAllFilterRequest,
+    LLMGetVersionsFilterRequest,
 )
 from schemas.response_schemas import (
-    AgenticPromptMetadataListResponse,
-    AgenticPromptMetadataResponse,
     AgenticPromptRunResponse,
     AgenticPromptVersionListResponse,
+    LLMGetAllMetadataListResponse,
+    LLMGetAllMetadataResponse,
 )
 from tests.clients.base_test_client import override_get_db_session
 
@@ -310,14 +310,13 @@ def test_get_all_prompts(agentic_prompt_repo, mock_db_session, sample_db_prompt)
     )
     result = agentic_prompt_repo.get_all_prompt_metadata(task_id, pagination_parameters)
 
-    assert isinstance(result, AgenticPromptMetadataListResponse)
-    assert len(result.prompt_metadata) == 2
+    assert isinstance(result, LLMGetAllMetadataListResponse)
+    assert len(result.llm_metadata) == 2
     assert all(
-        isinstance(prompt, AgenticPromptMetadataResponse)
-        for prompt in result.prompt_metadata
+        isinstance(prompt, LLMGetAllMetadataResponse) for prompt in result.llm_metadata
     )
-    assert result.prompt_metadata[0].name == sample_db_prompt.name
-    assert result.prompt_metadata[1].name == prompt2.name
+    assert result.llm_metadata[0].name == sample_db_prompt.name
+    assert result.llm_metadata[1].name == prompt2.name
 
 
 @pytest.mark.unit_tests
@@ -345,8 +344,8 @@ def test_get_all_prompts_empty(agentic_prompt_repo, mock_db_session):
     )
     result = agentic_prompt_repo.get_all_prompt_metadata(task_id, pagination_parameters)
 
-    assert isinstance(result, AgenticPromptMetadataListResponse)
-    assert len(result.prompt_metadata) == 0
+    assert isinstance(result, LLMGetAllMetadataListResponse)
+    assert len(result.llm_metadata) == 0
 
 
 @pytest.mark.unit_tests
@@ -1153,7 +1152,7 @@ def test_get_prompt_by_version_success(prompt_version):
     [
         ("model_provider", ModelProvider.OPENAI, 1, "prompt_openai"),
         ("model_name", "gpt-4", 1, "prompt_openai"),
-        ("prompt_names", ["prompt_openai"], 1, "prompt_openai"),
+        ("llm_asset_names", ["prompt_openai"], 1, "prompt_openai"),
         ("created_after", datetime(2025, 1, 1), 2, None),
         ("created_before", datetime(2025, 1, 2), 1, "prompt_openai"),
     ],
@@ -1200,7 +1199,7 @@ def test_get_all_prompt_metadata_with_filters(
 
     try:
         # Create filter request
-        filter_request = PromptsGetAllFilterRequest(**{filter_param: filter_value})
+        filter_request = LLMGetAllFilterRequest(**{filter_param: filter_value})
 
         # Create pagination parameters
         pagination_params = PaginationParameters(
@@ -1217,13 +1216,13 @@ def test_get_all_prompt_metadata_with_filters(
         )
 
         # Verify filtering worked
-        assert isinstance(result, AgenticPromptMetadataListResponse)
+        assert isinstance(result, LLMGetAllMetadataListResponse)
         assert result.count == expected_count
-        assert len(result.prompt_metadata) == expected_count
+        assert len(result.llm_metadata) == expected_count
 
         # Verify the correct prompt was returned based on the filter
         if expected_name:
-            assert result.prompt_metadata[0].name == expected_name
+            assert result.llm_metadata[0].name == expected_name
 
     finally:
         # Cleanup
@@ -1244,6 +1243,7 @@ def test_get_all_prompt_metadata_with_filters(
         ("exclude_deleted", True, 2),
         ("min_version", 2, 2),
         ("max_version", 2, 2),
+        ("min_version", 10, 0),  # verify no returned versions doesn't spawn an error
     ],
 )
 def test_get_prompt_versions_with_filters(filter_param, filter_value, expected_count):
@@ -1296,7 +1296,7 @@ def test_get_prompt_versions_with_filters(filter_param, filter_value, expected_c
 
     try:
         # Create filter request
-        filter_request = PromptsGetVersionsFilterRequest(**{filter_param: filter_value})
+        filter_request = LLMGetVersionsFilterRequest(**{filter_param: filter_value})
 
         # Create pagination parameters
         pagination_params = PaginationParameters(
@@ -1376,13 +1376,13 @@ def test_get_all_prompt_metadata_with_pagination(page, page_size, sort, expected
         )
 
         # Verify pagination worked
-        assert isinstance(result, AgenticPromptMetadataListResponse)
+        assert isinstance(result, LLMGetAllMetadataListResponse)
         assert result.count == 3  # Total count should always be 3
-        assert len(result.prompt_metadata) == len(expected_names)
+        assert len(result.llm_metadata) == len(expected_names)
 
         # Verify the order of prompts
         for i, expected_name in enumerate(expected_names):
-            assert result.prompt_metadata[i].name == expected_name
+            assert result.llm_metadata[i].name == expected_name
 
     finally:
         # Cleanup

--- a/genai-engine/tests/unit/routes/tasks/test_agentic_prompt_routes.py
+++ b/genai-engine/tests/unit/routes/tasks/test_agentic_prompt_routes.py
@@ -131,20 +131,20 @@ def test_get_all_agentic_prompts_success(client: GenaiEngineTestClientBase):
     assert response.status_code == 200
 
     prompts_response = response.json()
-    assert "prompt_metadata" in prompts_response
-    assert len(prompts_response["prompt_metadata"]) == 2
+    assert "llm_metadata" in prompts_response
+    assert len(prompts_response["llm_metadata"]) == 2
 
-    metadata = prompts_response["prompt_metadata"]
+    metadata = prompts_response["llm_metadata"]
 
-    for i, prompt_metadata in enumerate(metadata):
-        assert prompt_metadata["name"] == prompt_names[i]
-        assert prompt_metadata["versions"] == i + 1
-        assert prompt_metadata["created_at"] is not None
-        assert prompt_metadata["latest_version_created_at"] is not None
-        assert prompt_metadata["deleted_versions"] == []
+    for i, llm_metadata in enumerate(metadata):
+        assert llm_metadata["name"] == prompt_names[i]
+        assert llm_metadata["versions"] == i + 1
+        assert llm_metadata["created_at"] is not None
+        assert llm_metadata["latest_version_created_at"] is not None
+        assert llm_metadata["deleted_versions"] == []
 
-        created = datetime.fromisoformat(prompt_metadata["created_at"])
-        latest = datetime.fromisoformat(prompt_metadata["latest_version_created_at"])
+        created = datetime.fromisoformat(llm_metadata["created_at"])
+        latest = datetime.fromisoformat(llm_metadata["latest_version_created_at"])
 
         if i == 0:
             assert abs((created - latest).total_seconds()) < 1
@@ -168,8 +168,8 @@ def test_get_all_agentic_prompts_empty(client: GenaiEngineTestClientBase):
     assert response.status_code == 200
 
     prompts_response = response.json()
-    assert "prompt_metadata" in prompts_response
-    assert len(prompts_response["prompt_metadata"]) == 0
+    assert "llm_metadata" in prompts_response
+    assert len(prompts_response["llm_metadata"]) == 0
 
 
 @pytest.mark.unit_tests
@@ -755,7 +755,7 @@ def test_get_all_prompts_includes_deleted_prompts(client: GenaiEngineTestClientB
         headers=client.authorized_user_api_key_headers,
     )
 
-    metadata = response.json()["prompt_metadata"]
+    metadata = response.json()["llm_metadata"]
     created = datetime.fromisoformat(metadata[0]["created_at"])
     latest = datetime.fromisoformat(metadata[0]["latest_version_created_at"])
 
@@ -780,9 +780,9 @@ def test_get_all_prompts_includes_deleted_prompts(client: GenaiEngineTestClientB
         headers=client.authorized_user_api_key_headers,
     )
     assert response.status_code == 200
-    assert len(response.json()["prompt_metadata"]) == 1
+    assert len(response.json()["llm_metadata"]) == 1
 
-    metadata = response.json()["prompt_metadata"]
+    metadata = response.json()["llm_metadata"]
     created = datetime.fromisoformat(metadata[0]["created_at"])
     latest = datetime.fromisoformat(metadata[0]["latest_version_created_at"])
 
@@ -927,11 +927,11 @@ def test_get_unique_prompt_names(client: GenaiEngineTestClientBase):
     assert response.status_code == 204
 
     response = client.base_client.get(
-        f"/api/v1/tasks/{task.id}/prompts/{prompt_name}/versions",
+        f"/api/v1/tasks/{task.id}/prompts",
         headers=client.authorized_user_api_key_headers,
     )
     assert response.status_code == 200
-    assert len(response.json()["versions"]) == 2
+    assert response.json()["count"] == 1
 
     response = client.base_client.get(
         f"/api/v1/tasks/{task.id}/prompts/{prompt_name}/versions",
@@ -1029,7 +1029,7 @@ def test_run_deleted_prompt_spawns_error(
 
 @pytest.mark.unit_tests
 def test_get_all_prompts_pagination_and_filtering(client: GenaiEngineTestClientBase):
-    """Test pagination, sorting, and filtering for both get_all_prompts and get_prompt_versions"""
+    """Test pagination, sorting, and filtering for get_all_agentic_prompts"""
     # Create an agentic task
     task_name = f"agentic_task_{random.random()}"
     status_code, task = client.create_task(task_name, is_agentic=True)
@@ -1059,9 +1059,9 @@ def test_get_all_prompts_pagination_and_filtering(client: GenaiEngineTestClientB
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["prompt_metadata"]) == 2
+    assert len(result["llm_metadata"]) == 2
     assert result["count"] == 3
-    assert result["prompt_metadata"][0]["name"] == "alpha"
+    assert result["llm_metadata"][0]["name"] == "alpha"
 
     # Test sorting descending
     response = client.base_client.get(
@@ -1071,8 +1071,8 @@ def test_get_all_prompts_pagination_and_filtering(client: GenaiEngineTestClientB
     )
     assert response.status_code == 200
     result = response.json()
-    assert result["prompt_metadata"][0]["name"] == "gamma"
-    assert result["prompt_metadata"][2]["name"] == "alpha"
+    assert result["llm_metadata"][0]["name"] == "gamma"
+    assert result["llm_metadata"][2]["name"] == "alpha"
 
     # Test filtering by provider
     response = client.base_client.get(
@@ -1082,7 +1082,7 @@ def test_get_all_prompts_pagination_and_filtering(client: GenaiEngineTestClientB
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["prompt_metadata"]) == 2
+    assert len(result["llm_metadata"]) == 2
     assert result["count"] == 2
 
 
@@ -1090,7 +1090,7 @@ def test_get_all_prompts_pagination_and_filtering(client: GenaiEngineTestClientB
 def test_get_prompt_versions_pagination_and_filtering(
     client: GenaiEngineTestClientBase,
 ):
-    """Test pagination, sorting, and filtering for both get_all_prompts and get_prompt_versions"""
+    """Test pagination, sorting, and filtering for get_prompt_versions"""
     # Create an agentic task
     task_name = f"agentic_task_{random.random()}"
     status_code, task = client.create_task(task_name, is_agentic=True)


### PR DESCRIPTION
## Description
- Adds the ability to get an llm eval version, list all versions of an llm eval, or list all llm evals for a specific task id
- Fixes a bug in agentic prompts that raised an error in list versions when no versions were found (it now just returns an empty object)
- Fixes some comments in the agentic prompts that weren't correct
- Adds unit tests for all get requests for both the router and repository for llm evals
- Modifies GetAllMetadata response object from being specific to AgenticPrompts to be more generic since both prompts and llm evals have the exact same metadata parameters so it can be reused.
- Modifies filter requests for agentic prompts to also be more generic since llm evals has the exact same filters 
- Extracts dependencies that were in the agentic prompt router file to the dependencies file so it can be reused by llm evals

## Jira Tickets
- https://arthurai.atlassian.net/browse/UP-3274

## TODO
- Implement the ability to run an llm eval
- Extract template evals for FE to use