### PR TITLE
Up 3311 refactor variables drawer

### DIFF
--- a/genai-engine/ui/src/components/prompts-playground/PromptsPlayground.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/PromptsPlayground.tsx
@@ -224,27 +224,11 @@ const PromptsPlayground = () => {
             </Box>
           </Collapse>
         </Box>
-        <Box
-          component="main"
-          className="flex-1 flex flex-col"
-          sx={
-            {
-              // marginLeft: `${drawerWidth}px`,
-              // width: `calc(100% - ${drawerWidth}px)`,
-            }
-          }
-        >
+        <Box component="main" className="flex-1 flex flex-col">
           <Box ref={scrollContainerRef} className="flex-1 overflow-x-auto overflow-y-auto p-1">
-            <Stack direction="row" spacing={1} sx={{ minWidth: "max-content", height: "100%" }}>
+            <Stack direction="row" spacing={1} sx={{ height: "100%" }}>
               {state.prompts.map((prompt) => (
-                <Box
-                  key={prompt.id}
-                  className="flex-1 h-full"
-                  sx={{
-                    minWidth: 750,
-                    flexShrink: 0,
-                  }}
-                >
+                <Box key={prompt.id} className="flex-1 h-full" sx={{ minWidth: 600 }}>
                   <PromptComponent prompt={prompt} />
                 </Box>
               ))}
@@ -257,39 +241,3 @@ const PromptsPlayground = () => {
 };
 
 export default PromptsPlayground;
-
-{
-  /* <Stack justifyContent="flex-end" alignItems="center" spacing={2} sx={{ pt: 2 }}>
-<IconButton onClick={() => setDrawerOpen(!drawerOpen)} sx={{ height: 32 }}>
-  <ChevronRightIcon />
-</IconButton>
-<Divider />
-<IconButton onClick={handleAddPrompt} color="primary" sx={{ height: 32 }}>
-  <AddIcon />
-</IconButton>
-<IconButton onClick={handleRunAllPrompts} color="primary" sx={{ height: 32 }}>
-  <PlayArrowIcon />
-</IconButton>
-<IconButton onClick={() => {}} color="primary" sx={{ height: 32 }}>
-  <CodeIcon />
-</IconButton>
-</Stack>
-
-<Stack justifyContent="flex-end" spacing={2} sx={{ pt: 2 }}>
-<Box sx={{ display: "flex", justifyContent: "flex-end", width: "100%" }}>
-  <IconButton onClick={() => setDrawerOpen(!drawerOpen)} sx={{ height: 32 }}>
-    <ChevronLeftIcon />
-  </IconButton>
-</Box>
-<Divider sx={{ margin: 0 }} />
-<Button variant="contained" sx={{ height: 32, width: "100%" }} onClick={handleAddPrompt} startIcon={<AddIcon />}>
-  Add Prompt
-</Button>
-<Button variant="contained" sx={{ height: 32, width: "100%" }} onClick={handleRunAllPrompts} startIcon={<PlayArrowIcon />}>
-  Run All Prompts
-</Button>
-<Button variant="contained" sx={{ height: 32, width: "100%" }} onClick={() => {}}>
-  &#123;&#123;&nbsp;&#125;&#125;&nbsp;Variables
-</Button>
-</Stack> */
-}

--- a/genai-engine/ui/src/components/prompts-playground/prompts/OutputField.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/prompts/OutputField.tsx
@@ -144,7 +144,7 @@ const OutputField = ({ promptId, running, runResponse, responseFormat, dialogOpe
           {showSkeletons ? <>{skeletons()}</> : <div className="flex flex-col h-full">{renderContent}</div>}
         </div>
         <Divider />
-        <div className="flex gap-3 flex-shrink-0">
+        <div className="flex gap-3 shrink-0">
           {/* eslint-disable-next-line no-constant-condition */}
           {false ? (
             <div className="flex items-center">

--- a/genai-engine/ui/src/components/prompts-playground/prompts/PromptComponent.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/prompts/PromptComponent.tsx
@@ -74,7 +74,7 @@ const Prompt = ({ prompt }: PromptComponentProps) => {
   return (
     <div className="h-full shadow-md rounded-lg p-1 bg-gray-200 flex flex-col">
       <Container component="div" ref={containerRef} className="p-1 mt-1 flex flex-col h-full" maxWidth="lg" disableGutters>
-        <div className="flex justify-between items-center gap-1 mb-2 flex-shrink-0">
+        <div className="flex justify-between items-center gap-1 mb-2 shrink-0">
           <div className="flex justify-start items-center gap-1">
             {prompt.tools.length > 0 ? (
               <Badge badgeContent={prompt.tools.length} color="primary">
@@ -94,16 +94,16 @@ const Prompt = ({ prompt }: PromptComponentProps) => {
               Format Response
             </Button>
           </div>
-          <div className="flex justify-end items-center gap-1 flex-shrink-0">
+          <div className="flex justify-end items-center gap-1 shrink-0">
             <ManagementButtons prompt={prompt} setSavePromptOpen={setSavePromptOpen} />
           </div>
         </div>
-        <div className="min-w-[300px] flex-shrink-0">
+        <div className="min-w-[300px] shrink-0">
           <PromptSelectors prompt={prompt} currentPromptName={currentPromptName} onPromptNameChange={setCurrentPromptName} />
         </div>
         <div className="mt-1 flex-1 min-h-0 flex flex-col">
           <div
-            className="flex-shrink-0"
+            className="shrink-0"
             style={{
               flexBasis: `${messagesHeightRatio * 100}%`,
               minHeight: "30%",
@@ -116,7 +116,7 @@ const Prompt = ({ prompt }: PromptComponentProps) => {
           </div>
           <ResizableSplitter onResize={handleResize} minTopRatio={0.3} minBottomRatio={0.3} />
           <div
-            className="flex-shrink-0"
+            className="shrink-0"
             style={{
               flexBasis: `${(1 - messagesHeightRatio) * 100}%`,
               minHeight: "30%",


### PR DESCRIPTION
- Collapse the left drawer to a Collapse component
- Fix the horizontal spacing when adding prompts. Min-width is 600px. Similar functionality to Langfuse.



<img width="562" height="771" alt="Screenshot 2025-11-14 at 18 32 06" src="https://github.com/user-attachments/assets/bb0eff56-5093-4414-bb9c-98b0e8717151" />
<img width="562" height="771" alt="Screenshot 2025-11-14 at 18 32 11" src="https://github.com/user-attachments/assets/ed62301f-f84f-4ad1-939e-c3645f5e37d1" />
