### PR TITLE
remove model dump for getting completion parameters

### DIFF
--- a/genai-engine/src/services/prompt/chat_completion_service.py
+++ b/genai-engine/src/services/prompt/chat_completion_service.py
@@ -10,7 +10,7 @@ from litellm import (
 
 from clients.llm.llm_client import LLMClient, LLMModelResponse
 from schemas.agentic_prompt_schemas import AgenticPrompt
-from schemas.enums import OpenAIMessageType
+from schemas.enums import OpenAIMessageType, ToolChoiceEnum
 from schemas.llm_schemas import LLMResponseFormat, OpenAIMessage
 from schemas.request_schemas import CompletionRequest, PromptCompletionRequest
 from schemas.response_schemas import AgenticPromptRunResponse


### PR DESCRIPTION
## Description
Explicitly set each parameter passed in to liteLLM instead of doing model_dump with exclusions over an agentic prompt to avoid errors when adding/removing parameters from the AgenticPrompt schema