### PR TITLE
add prompts management page and auto-close db sessions

### DIFF
--- a/genai-engine/ui/src/App.tsx
+++ b/genai-engine/ui/src/App.tsx
@@ -9,7 +9,7 @@ import { DatasetsView } from "./components/datasets/DatasetsView";
 import Evaluators from "./components/evaluators/Evaluators";
 import { LoginPage } from "./components/LoginPage";
 import { ModelProviders } from "./components/ModelProviders";
-// import PromptsManagement from "./components/prompts-management/PromptsManagement";
+import PromptsManagement from "./components/prompts-management/PromptsManagement";
 import PromptsPlayground from "./components/prompts-playground/PromptsPlayground";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { TaskDetailContent } from "./components/TaskDetailContent";
@@ -111,6 +111,17 @@ function App() {
                   <ProtectedRoute>
                     <TaskLayout>
                       <Evaluators />
+                    </TaskLayout>
+                  </ProtectedRoute>
+                }
+              />
+
+              <Route
+                path="/tasks/:id/prompts-management"
+                element={
+                  <ProtectedRoute>
+                    <TaskLayout>
+                      <PromptsManagement />
                     </TaskLayout>
                   </ProtectedRoute>
                 }

--- a/genai-engine/ui/src/components/SidebarNavigation.tsx
+++ b/genai-engine/ui/src/components/SidebarNavigation.tsx
@@ -31,42 +31,42 @@ export const SidebarNavigation: React.FC<SidebarNavigationProps> = ({
       label: "Observability",
       items: [
         { id: "traces", label: "Traces" },
-        { id: "retrievals", label: "Retrievals" },
       ],
     },
     {
-      id: "evaluations",
-      label: "Evaluations",
+      id: "prompts",
+      label: "Prompts",
       items: [
-        { id: "evaluators", label: "Evaluators" },
+        { id: "playgrounds/prompts", label: "Prompts Playground" },
+        { id: "prompts-management", label: "Prompts Management" },
+        { id: "prompt-experiments", label: "Prompts Experiments" },
+      ],
+    },
+    {
+      id: "rag",
+      label: "RAG",
+      items: [
+        { id: "playgrounds/retrievals", label: "RAG Playground" },
+        { id: "retrievals", label: "RAG Management" },
+        { id: "rag-experiments", label: "RAG Experiments" },
+      ],
+    },
+    {
+      id: "evals",
+      label: "Evals",
+      items: [
+        { id: "evaluators", label: "Evals Management" },
         { id: "datasets", label: "Datasets" },
       ],
     },
     {
-      id: "experiments",
-      label: "Experiments",
+      id: "agents",
+      label: "Agents",
       items: [
-        { id: "prompt-experiments", label: "Prompt Experiments" },
-        { id: "rag-experiments", label: "Retrieval Experiments" },
-        { id: "agent-experiments", label: "Agent Experiments" },
+
+        { id: "agent-experiments", label: "Experiments" },
       ],
     },
-    {
-      id: "playgrounds",
-      label: "Playgrounds",
-      items: [
-        { id: "playgrounds/prompts", label: "Prompts" },
-        { id: "playgrounds/retrievals", label: "Retrievals" },
-      ],
-    },
-    // { template for future navbar realignment
-    //   id: "prompts",
-    //   label: "Prompts",
-    //   items:[
-    //     { id: "playgrounds/prompts", label: "Prompts" },
-    //     { id: "", label: "Management"}
-    //   ],
-    // },
     {
       id: "settings",
       label: "Settings",
@@ -78,8 +78,8 @@ export const SidebarNavigation: React.FC<SidebarNavigationProps> = ({
   ];
 
   return (
-    <nav className="w-64 bg-white shadow-sm border-r border-gray-200 h-full flex flex-col overflow-hidden">
-      <div className="p-4 flex-1 overflow-y-auto">
+    <nav className="w-64 bg-white shadow-sm border-r border-gray-200 flex flex-col" style={{ height: '100vh' }}>
+      <div className="p-4 overflow-y-scroll" style={{ flex: 1 }}>
         <div className="mb-4">
           <button
             onClick={onBackToDashboard}

--- a/genai-engine/ui/src/components/TaskLayout.tsx
+++ b/genai-engine/ui/src/components/TaskLayout.tsx
@@ -55,6 +55,7 @@ export const TaskLayout: React.FC<TaskLayoutProps> = ({ children }) => {
       "agent-experiments": "Agent Experiments",
       "playgrounds/prompts": "Prompts Playground",
       "playgrounds/retrievals": "Retrievals Playground",
+      "prompts-management": "Prompts Management",
     };
     return titleMap[section] || "Task Details";
   };

--- a/genai-engine/ui/src/components/prompts-management/PromptFormModal.tsx
+++ b/genai-engine/ui/src/components/prompts-management/PromptFormModal.tsx
@@ -1,0 +1,409 @@
+import Alert from "@mui/material/Alert";
+import Autocomplete from "@mui/material/Autocomplete";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogTitle from "@mui/material/DialogTitle";
+import FormControl from "@mui/material/FormControl";
+import FormLabel from "@mui/material/FormLabel";
+import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { PromptFormModalProps } from "./types";
+
+import { useApi } from "@/hooks/useApi";
+import { useTask } from "@/hooks/useTask";
+import type { CreateAgenticPromptRequest, AgenticPrompt, ModelProvider, ModelProviderResponse } from "@/lib/api-client/api-client";
+
+const PromptFormModal = ({ open, onClose, onSubmit, isLoading = false }: PromptFormModalProps) => {
+  const apiClient = useApi();
+  const { task } = useTask();
+  const [promptName, setPromptName] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [modelProvider, setModelProvider] = useState<ModelProvider | "">("");
+  const [modelName, setModelName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [enabledProviders, setEnabledProviders] = useState<ModelProvider[]>([]);
+  const [availableModels, setAvailableModels] = useState<Map<ModelProvider, string[]>>(new Map());
+  const [existingPromptNames, setExistingPromptNames] = useState<string[]>([]);
+  const hasFetchedProviders = useRef(false);
+  const hasFetchedAvailableModels = useRef(false);
+  const hasFetchedPromptNames = useRef(false);
+
+  const fetchProviders = useCallback(async () => {
+    if (hasFetchedProviders.current) {
+      return;
+    }
+
+    if (!apiClient) {
+      console.error("No api client");
+      return;
+    }
+
+    hasFetchedProviders.current = true;
+    try {
+      const response = await apiClient.api.getModelProvidersApiV1ModelProvidersGet();
+      const { data } = response;
+      const providers = data.providers
+        .filter((provider: ModelProviderResponse) => provider.enabled)
+        .map((provider: ModelProviderResponse) => provider.provider);
+      setEnabledProviders(providers);
+    } catch (error) {
+      console.error("Failed to fetch providers:", error);
+      setError("Failed to load providers. Please try again.");
+    }
+  }, [apiClient]);
+
+  const fetchAvailableModels = useCallback(async () => {
+    if (hasFetchedAvailableModels.current || !apiClient || enabledProviders.length === 0) {
+      return;
+    }
+
+    hasFetchedAvailableModels.current = true;
+
+    // Fetch models for all enabled providers in parallel
+    const modelPromises = enabledProviders.map(async (provider) => {
+      try {
+        const response = await apiClient.api.getModelProvidersAvailableModelsApiV1ModelProvidersProviderAvailableModelsGet(provider as ModelProvider);
+        return { provider, models: response.data.available_models };
+      } catch (error) {
+        console.error(`Failed to fetch models for provider ${provider}:`, error);
+        return { provider, models: [] };
+      }
+    });
+
+    const results = await Promise.all(modelPromises);
+
+    const newAvailableModels = new Map<ModelProvider, string[]>();
+    results.forEach(({ provider, models }) => {
+      newAvailableModels.set(provider, models);
+    });
+
+    setAvailableModels(newAvailableModels);
+  }, [apiClient, enabledProviders]);
+
+  const fetchExistingPromptNames = useCallback(async () => {
+    if (hasFetchedPromptNames.current || !apiClient || !task?.id) {
+      return;
+    }
+
+    hasFetchedPromptNames.current = true;
+    try {
+      const response = await apiClient.api.getAllAgenticPromptsApiV1TasksTaskIdPromptsGet({
+        taskId: task.id,
+        page: 0,
+        page_size: 1000, // Fetch all prompt names
+      });
+      const promptNames = response.data.llm_metadata.map((promptMeta) => promptMeta.name);
+      setExistingPromptNames(promptNames);
+    } catch (error) {
+      console.error("Failed to fetch existing prompt names:", error);
+      // Don't show error to user, just fail silently
+    }
+  }, [apiClient, task?.id]);
+
+  // Fetch providers and prompt names when modal opens
+  useEffect(() => {
+    if (open) {
+      // Reset refs when modal opens to allow fresh data fetch
+      hasFetchedProviders.current = false;
+      hasFetchedAvailableModels.current = false;
+      hasFetchedPromptNames.current = false;
+      fetchProviders();
+      fetchExistingPromptNames();
+    }
+  }, [open, fetchProviders, fetchExistingPromptNames]);
+
+  // Fetch available models when providers are loaded
+  useEffect(() => {
+    if (enabledProviders.length > 0) {
+      fetchAvailableModels();
+    }
+  }, [enabledProviders, fetchAvailableModels]);
+
+  // Set the first provider as the default provider
+  useEffect(() => {
+    if (enabledProviders.length > 0 && !modelProvider) {
+      setModelProvider(enabledProviders[0]);
+    }
+  }, [enabledProviders, modelProvider]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!promptName.trim()) {
+      setError("Prompt name is required");
+      return;
+    }
+
+    if (!instructions.trim()) {
+      setError("Instructions are required");
+      return;
+    }
+
+    if (!modelProvider) {
+      setError("Model provider is required");
+      return;
+    }
+
+    if (!modelName.trim()) {
+      setError("Model name is required");
+      return;
+    }
+
+    try {
+      const data: CreateAgenticPromptRequest = {
+        messages: [{ role: "user", content: instructions.trim() }],
+        model_provider: modelProvider as ModelProvider,
+        model_name: modelName.trim(),
+      };
+
+      await onSubmit(promptName.trim(), data);
+
+      // Reset form on success
+      setPromptName("");
+      setInstructions("");
+      setModelProvider(enabledProviders.length > 0 ? enabledProviders[0] : "");
+      setModelName("");
+      setError(null);
+    } catch (err) {
+      console.error("Failed to create prompt:", err);
+      setError(err instanceof Error ? err.message : "Failed to create prompt. Please try again.");
+    }
+  };
+
+  const handleClose = () => {
+    if (!isLoading) {
+      setPromptName("");
+      setInstructions("");
+      setModelProvider(enabledProviders.length > 0 ? enabledProviders[0] : "");
+      setModelName("");
+      setError(null);
+      onClose();
+    }
+  };
+
+  const handleProviderChange = (_event: React.SyntheticEvent<Element, Event>, newValue: ModelProvider | null) => {
+    setModelProvider(newValue || "");
+    setModelName(""); // Clear model selection when provider changes
+  };
+
+  const handleModelChange = (_event: React.SyntheticEvent<Element, Event>, newValue: string | null) => {
+    setModelName(newValue || "");
+  };
+
+  const fetchLatestPromptVersion = useCallback(
+    async (promptName: string) => {
+      if (!apiClient || !task?.id || !promptName) {
+        return;
+      }
+
+      try {
+        // Fetch the latest version using "latest" as the version parameter
+        // API signature: (promptName, promptVersion, taskId)
+        const promptResponse = await apiClient.api.getAgenticPromptApiV1TasksTaskIdPromptsPromptNameVersionsPromptVersionGet(
+          promptName,
+          "latest" as any, // The API accepts "latest" as a special version string
+          task.id
+        );
+
+        const promptData: AgenticPrompt = promptResponse.data;
+
+        // Populate form with the prompt data
+        // Convert messages array to instructions string (for simplicity, just use first message content)
+        const firstMessage = promptData.messages?.[0];
+        if (firstMessage && typeof firstMessage.content === "string") {
+          setInstructions(firstMessage.content);
+        }
+        setModelProvider(promptData.model_provider);
+        setModelName(promptData.model_name);
+      } catch (error) {
+        console.error("Failed to fetch latest prompt version:", error);
+        // Don't show error to user, just fail silently
+      }
+    },
+    [apiClient, task?.id]
+  );
+
+  const prevPromptNameRef = useRef("");
+
+  const handlePromptNameChange = useCallback(
+    (_event: React.SyntheticEvent<Element, Event>, newValue: string | null, reason: string) => {
+      const selectedName = newValue || "";
+
+      // If cleared or empty, reset all fields
+      if (!selectedName || reason === "clear") {
+        setPromptName("");
+        setInstructions("");
+        setModelProvider(enabledProviders.length > 0 ? enabledProviders[0] : "");
+        setModelName("");
+        prevPromptNameRef.current = "";
+        return;
+      }
+
+      // Update promptName
+      setPromptName(selectedName);
+      prevPromptNameRef.current = selectedName;
+
+      // Always fetch when selectOption
+      if (existingPromptNames.includes(selectedName)) {
+        fetchLatestPromptVersion(selectedName);
+      }
+    },
+    [fetchLatestPromptVersion, enabledProviders, existingPromptNames]
+  );
+
+  // Watch for when promptName matches an existing prompt (for when onChange doesn't fire)
+  useEffect(() => {
+    if (promptName && existingPromptNames.includes(promptName) && prevPromptNameRef.current !== promptName) {
+      prevPromptNameRef.current = promptName;
+      fetchLatestPromptVersion(promptName);
+    }
+  }, [promptName, existingPromptNames, fetchLatestPromptVersion]);
+
+  const providerDisabled = enabledProviders.length === 0;
+  const modelDisabled = modelProvider === "";
+  const tooltipTitle = providerDisabled ? "No providers available. Please configure at least one provider." : "";
+  const availableModelsForProvider = useMemo(() => availableModels.get(modelProvider as ModelProvider) || [], [availableModels, modelProvider]);
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
+      <DialogTitle>Create New Prompt</DialogTitle>
+      <form onSubmit={handleSubmit}>
+        <DialogContent>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 3, pt: 1 }}>
+            <FormControl fullWidth>
+              <FormLabel>
+                <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
+                  Prompt Name
+                </Typography>
+              </FormLabel>
+              <Autocomplete
+                freeSolo
+                options={existingPromptNames}
+                value={promptName}
+                onChange={handlePromptNameChange}
+                disabled={isLoading}
+                forcePopupIcon={true}
+                filterOptions={(options, state) => {
+                  if (!state.inputValue) {
+                    return options;
+                  }
+                  const filtered = options.filter((option) =>
+                    option.toLowerCase().includes(state.inputValue.toLowerCase())
+                  );
+                  // Add a placeholder message when no matches
+                  if (filtered.length === 0) {
+                    return ["__NO_OPTIONS__"];
+                  }
+                  return filtered;
+                }}
+                getOptionDisabled={(option) => option === "__NO_OPTIONS__"}
+                renderOption={(props, option) => {
+                  const { key, ...otherProps } = props;
+                  return (
+                    <li key={key} {...otherProps} style={option === "__NO_OPTIONS__" ? { cursor: "default" } : undefined}>
+                      {option === "__NO_OPTIONS__" ? "No existing prompts" : option}
+                    </li>
+                  );
+                }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    placeholder="Enter prompt name or select existing..."
+                    required
+                    size="small"
+                    autoFocus
+                  />
+                )}
+              />
+            </FormControl>
+
+            <FormControl fullWidth>
+              <FormLabel>
+                <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
+                  Instructions
+                </Typography>
+              </FormLabel>
+              <TextField
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                placeholder="Enter prompt instructions..."
+                disabled={isLoading}
+                required
+                multiline
+                minRows={4}
+                maxRows={10}
+                size="small"
+              />
+            </FormControl>
+
+            <Box sx={{ display: "flex", gap: 2 }}>
+              <FormControl fullWidth>
+                <FormLabel>
+                  <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
+                    Model Provider
+                  </Typography>
+                </FormLabel>
+                <Tooltip title={tooltipTitle} placement="top-start" arrow>
+                  <Autocomplete<ModelProvider>
+                    options={enabledProviders}
+                    value={modelProvider || null}
+                    onChange={handleProviderChange}
+                    disabled={providerDisabled || isLoading}
+                    renderInput={(params) => (
+                      <TextField {...params} label="Select Provider" variant="outlined" size="small" sx={{ backgroundColor: "white" }} />
+                    )}
+                  />
+                </Tooltip>
+              </FormControl>
+
+              <FormControl fullWidth>
+                <FormLabel>
+                  <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
+                    Model Name
+                  </Typography>
+                </FormLabel>
+                <Autocomplete
+                  options={availableModelsForProvider}
+                  value={modelName || null}
+                  onChange={handleModelChange}
+                  disabled={modelDisabled || isLoading}
+                  renderInput={(params) => (
+                    <TextField {...params} label="Select Model" variant="outlined" size="small" sx={{ backgroundColor: "white" }} />
+                  )}
+                />
+              </FormControl>
+            </Box>
+
+            {error && (
+              <Alert severity="error" onClose={() => setError(null)}>
+                {error}
+              </Alert>
+            )}
+          </Box>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={handleClose} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={isLoading || !promptName.trim() || !instructions.trim() || !modelProvider || !modelName.trim()}
+            sx={{ minWidth: 120 }}
+          >
+            {isLoading ? "Saving..." : "Save Prompt"}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+};
+
+export default PromptFormModal;

--- a/genai-engine/ui/src/components/prompts-management/PromptsManagement.tsx
+++ b/genai-engine/ui/src/components/prompts-management/PromptsManagement.tsx
@@ -1,9 +1,205 @@
-// Will share same general layout as evals
-const PromptsManagement = () => {
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
+import TablePagination from "@mui/material/TablePagination";
+import React, { useCallback, useMemo, useState } from "react";
+
+import PromptsManagementHeader from "./PromptsManagementHeader";
+import PromptFullScreenView from "./fullscreen/PromptFullScreenView";
+import { usePrompts } from "./hooks/usePrompts";
+import PromptsTable from "./table/PromptsTable";
+
+import { getContentHeight } from "@/constants/layout";
+import { useTask } from "@/hooks/useTask";
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+const PromptsManagement: React.FC = () => {
+  const { task } = useTask();
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+  const [fullScreenPrompt, setFullScreenPrompt] = useState<string | null>(null);
+  const [sortColumn, setSortColumn] = useState<string | null>("latest_version_created_at");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+
+  const filters = useMemo(
+    () => ({
+      page,
+      pageSize,
+      sort: sortDirection,
+    }),
+    [page, pageSize, sortDirection]
+  );
+
+  const { prompts, count, error, isLoading, refetch } = usePrompts(task?.id, filters);
+
+  const handleCreatePrompt = useCallback(() => {
+    // Navigate to prompts playground
+    window.location.href = `/tasks/${task?.id}/playgrounds/prompts`;
+  }, [task?.id]);
+
+  const handleToggleRow = useCallback((promptName: string) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(promptName)) {
+        next.delete(promptName);
+      } else {
+        next.add(promptName);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleExpandToFullScreen = useCallback((promptName: string) => {
+    setFullScreenPrompt(promptName);
+  }, []);
+
+  const handleCloseFullScreen = useCallback(() => {
+    setFullScreenPrompt(null);
+  }, []);
+
+  const handleSort = useCallback(
+    (column: string) => {
+      if (sortColumn === column) {
+        setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+      } else {
+        setSortColumn(column);
+        setSortDirection("desc");
+      }
+    },
+    [sortColumn]
+  );
+
+  const handlePageChange = useCallback((_event: unknown, newPage: number) => {
+    setPage(newPage);
+  }, []);
+
+  const handlePageSizeChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setPageSize(parseInt(event.target.value, 10));
+    setPage(0);
+  }, []);
+
+  if (fullScreenPrompt) {
+    return (
+      <Box sx={{ height: getContentHeight(), overflow: "hidden" }}>
+        <PromptFullScreenView promptName={fullScreenPrompt} onClose={handleCloseFullScreen} />
+      </Box>
+    );
+  }
+
+  if (isLoading && prompts.length === 0) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: getContentHeight(),
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error && prompts.length === 0) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="error" onClose={() => refetch()}>
+          {error.message || "Failed to load prompts"}
+        </Alert>
+      </Box>
+    );
+  }
+
   return (
-    <div>
-      <h1>Prompts Management</h1>
-    </div>
+    <Box
+      sx={{
+        width: "100%",
+        height: getContentHeight(),
+        display: "grid",
+        gridTemplateRows: "auto auto 1fr",
+        overflow: "hidden",
+      }}
+    >
+      <PromptsManagementHeader onCreatePrompt={handleCreatePrompt} />
+
+      {error && prompts.length > 0 && (
+        <Box sx={{ px: 3, pt: 2 }}>
+          <Alert severity="error">{error?.message || "An error occurred"}</Alert>
+        </Box>
+      )}
+
+      <Box
+        sx={{
+          overflow: "auto",
+          minHeight: 0,
+        }}
+      >
+        {!isLoading && prompts.length === 0 ? (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flex: 1,
+              p: 3,
+            }}
+          >
+            <Box sx={{ textAlign: "center" }}>
+              <Box
+                sx={{
+                  fontWeight: 600,
+                  fontSize: "1.25rem",
+                  color: "text.primary",
+                  mb: 1,
+                }}
+              >
+                No prompts found
+              </Box>
+              <Box sx={{ color: "text.secondary", mb: 2 }}>Create your first prompt to get started.</Box>
+              <Button variant="contained" onClick={handleCreatePrompt} sx={{ mt: 1 }}>
+                Create Prompt
+              </Button>
+            </Box>
+          </Box>
+        ) : (
+          <PromptsTable
+            prompts={prompts}
+            sortColumn={sortColumn}
+            sortDirection={sortDirection}
+            onSort={handleSort}
+            expandedRows={expandedRows}
+            onToggleRow={handleToggleRow}
+            onExpandToFullScreen={handleExpandToFullScreen}
+          />
+        )}
+      </Box>
+
+      {prompts.length > 0 && (
+        <Box
+          sx={{
+            borderTop: 1,
+            borderColor: "divider",
+            backgroundColor: "background.paper",
+            display: "flex",
+            justifyContent: "flex-end",
+          }}
+        >
+          <TablePagination
+            component="div"
+            count={count}
+            page={page}
+            onPageChange={handlePageChange}
+            rowsPerPage={pageSize}
+            onRowsPerPageChange={handlePageSizeChange}
+            rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+          />
+        </Box>
+      )}
+    </Box>
   );
 };
 

--- a/genai-engine/ui/src/components/prompts-management/PromptsManagementHeader.tsx
+++ b/genai-engine/ui/src/components/prompts-management/PromptsManagementHeader.tsx
@@ -1,0 +1,36 @@
+import AddIcon from "@mui/icons-material/Add";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Divider from "@mui/material/Divider";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+import type { PromptsManagementHeaderProps } from "./types";
+
+const PromptsManagementHeader = ({ onCreatePrompt }: PromptsManagementHeaderProps) => {
+  return (
+    <div>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          p: 2,
+          backgroundColor: "white",
+        }}
+      >
+        <Box>
+          <Typography variant="subtitle1" color="text.primary">
+            Manage and organize your prompts
+          </Typography>
+        </Box>
+        <Button variant="contained" color="primary" startIcon={<AddIcon />} onClick={onCreatePrompt}>
+          New Prompt
+        </Button>
+      </Box>
+      <Divider />
+    </div>
+  );
+};
+
+export default PromptsManagementHeader;

--- a/genai-engine/ui/src/components/prompts-management/fullscreen/PromptDetailView.tsx
+++ b/genai-engine/ui/src/components/prompts-management/fullscreen/PromptDetailView.tsx
@@ -1,0 +1,147 @@
+import CloseIcon from "@mui/icons-material/Close";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import CircularProgress from "@mui/material/CircularProgress";
+import IconButton from "@mui/material/IconButton";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+
+import type { PromptDetailViewProps } from "../types";
+
+import { formatDate } from "@/utils/formatters";
+
+const PromptDetailView = ({ promptData, isLoading, error, promptName, version, onClose }: PromptDetailViewProps) => {
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="error">Error loading prompt: {error.message}</Alert>
+      </Box>
+    );
+  }
+
+  if (!promptData) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="info">No prompt data available</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 3, height: "100%", overflow: "auto" }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3 }}>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>
+          {promptName}
+          {version !== null && <Chip label={`Version ${version}`} size="small" sx={{ ml: 2, height: 24 }} />}
+        </Typography>
+        {onClose && (
+          <IconButton onClick={onClose} aria-label="Close">
+            <CloseIcon />
+          </IconButton>
+        )}
+      </Box>
+
+      <Paper sx={{ p: 3, mb: 3 }}>
+        <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
+          Metadata
+        </Typography>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Model Provider
+            </Typography>
+            <Typography variant="body1" sx={{ fontWeight: 500 }}>
+              {promptData.model_provider}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Model Name
+            </Typography>
+            <Typography variant="body1" sx={{ fontWeight: 500 }}>
+              {promptData.model_name}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Created At
+            </Typography>
+            <Typography variant="body1" sx={{ fontWeight: 500 }}>
+              {promptData.created_at ? formatDate(promptData.created_at) : "N/A"}
+            </Typography>
+          </Box>
+          {promptData.deleted_at && (
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                Deleted At
+              </Typography>
+              <Typography variant="body1" sx={{ fontWeight: 500, color: "error.main" }}>
+                {formatDate(promptData.deleted_at)}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      </Paper>
+
+      <Paper sx={{ p: 3, mb: 3 }}>
+        <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
+          Messages
+        </Typography>
+        <Box
+          component="pre"
+          sx={{
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            fontFamily: "monospace",
+            backgroundColor: "grey.50",
+            p: 2,
+            borderRadius: 1,
+            overflow: "auto",
+            fontSize: "0.875rem",
+          }}
+        >
+          {JSON.stringify(promptData.messages, null, 2)}
+        </Box>
+      </Paper>
+
+      {promptData.config && (
+        <Paper sx={{ p: 3 }}>
+          <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
+            Configuration
+          </Typography>
+          <Box
+            component="pre"
+            sx={{
+              backgroundColor: "grey.50",
+              p: 2,
+              borderRadius: 1,
+              overflow: "auto",
+              fontSize: "0.875rem",
+              fontFamily: "monospace",
+            }}
+          >
+            {JSON.stringify(promptData.config, null, 2)}
+          </Box>
+        </Paper>
+      )}
+    </Box>
+  );
+};
+
+export default PromptDetailView;

--- a/genai-engine/ui/src/components/prompts-management/fullscreen/PromptFullScreenView.tsx
+++ b/genai-engine/ui/src/components/prompts-management/fullscreen/PromptFullScreenView.tsx
@@ -1,0 +1,59 @@
+import Box from "@mui/material/Box";
+import React, { useState, useEffect } from "react";
+
+import { usePrompt } from "../hooks/usePrompt";
+import { usePromptVersions } from "../hooks/usePromptVersions";
+import type { PromptFullScreenViewProps } from "../types";
+
+import PromptDetailView from "./PromptDetailView";
+import PromptVersionDrawer from "./PromptVersionDrawer";
+
+import { useTask } from "@/hooks/useTask";
+
+const PromptFullScreenView = ({ promptName, initialVersion, onClose }: PromptFullScreenViewProps) => {
+  const { task } = useTask();
+  const [selectedVersion, setSelectedVersion] = useState<number | null>(initialVersion ?? null);
+
+  // Fetch versions to get the latest if no version is selected
+  const { versions } = usePromptVersions(task?.id, promptName, {
+    sort: "desc",
+    pageSize: 1,
+  });
+
+  useEffect(() => {
+    if (selectedVersion === null && versions.length > 0) {
+      setSelectedVersion(versions[0].version);
+    }
+  }, [versions, selectedVersion]);
+
+  const { prompt: promptData, isLoading, error } = usePrompt(task?.id, promptName, selectedVersion !== null ? selectedVersion.toString() : undefined);
+
+  const handleSelectVersion = (version: number) => {
+    setSelectedVersion(version);
+  };
+
+  return (
+    <Box sx={{ display: "flex", height: "100%", position: "relative" }}>
+      <PromptVersionDrawer
+        open={true}
+        onClose={onClose}
+        taskId={task?.id ?? ""}
+        promptName={promptName}
+        selectedVersion={selectedVersion}
+        onSelectVersion={handleSelectVersion}
+      />
+      <Box
+        sx={{
+          flex: 1,
+          height: "100%",
+          overflow: "hidden",
+          minWidth: 0,
+        }}
+      >
+        <PromptDetailView promptData={promptData} isLoading={isLoading} error={error} promptName={promptName} version={selectedVersion} onClose={onClose} />
+      </Box>
+    </Box>
+  );
+};
+
+export default PromptFullScreenView;

--- a/genai-engine/ui/src/components/prompts-management/fullscreen/PromptVersionDrawer.tsx
+++ b/genai-engine/ui/src/components/prompts-management/fullscreen/PromptVersionDrawer.tsx
@@ -1,0 +1,199 @@
+import Autocomplete from "@mui/material/Autocomplete";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Divider from "@mui/material/Divider";
+import Drawer from "@mui/material/Drawer";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import { useMemo, useState, useCallback } from "react";
+
+import { usePromptVersions } from "../hooks/usePromptVersions";
+import type { PromptVersionDrawerProps } from "../types";
+
+import { formatDate } from "@/utils/formatters";
+
+const PromptVersionDrawer = ({ open, onClose, taskId, promptName, selectedVersion, onSelectVersion }: PromptVersionDrawerProps) => {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+
+  const { versions, isLoading, error } = usePromptVersions(taskId, promptName, {
+    sort: sortOrder,
+    exclude_deleted: false,
+  });
+
+  const sortedAndFilteredVersions = useMemo(() => {
+    let filtered = versions;
+
+    // Filter by search query
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      filtered = filtered.filter(
+        (v) =>
+          v.version.toString().includes(query) ||
+          v.model_name.toLowerCase().includes(query) ||
+          v.model_provider.toLowerCase().includes(query) ||
+          formatDate(v.created_at).toLowerCase().includes(query)
+      );
+    }
+
+    // Sort by creation date
+    return [...filtered].sort((a, b) => {
+      const aTime = new Date(a.created_at).getTime();
+      const bTime = new Date(b.created_at).getTime();
+      return sortOrder === "asc" ? aTime - bTime : bTime - aTime;
+    });
+  }, [versions, searchQuery, sortOrder]);
+
+  const autocompleteOptions = useMemo(() => {
+    return versions.map((v) => ({
+      label: `Version ${v.version} - ${v.model_provider}/${v.model_name} (${formatDate(v.created_at)})`,
+      version: v.version,
+    }));
+  }, [versions]);
+
+  const handleVersionClick = useCallback(
+    (version: number) => {
+      onSelectVersion(version);
+    },
+    [onSelectVersion]
+  );
+
+  const handleAutocompleteChange = useCallback(
+    (_event: unknown, value: { label: string; version: number } | string | null) => {
+      if (value && typeof value === "object") {
+        onSelectVersion(value.version);
+        setSearchQuery("");
+      } else if (typeof value === "string") {
+        setSearchQuery(value);
+      } else {
+        setSearchQuery("");
+      }
+    },
+    [onSelectVersion]
+  );
+
+  return (
+    <Drawer
+      variant="permanent"
+      anchor="left"
+      open={open}
+      onClose={onClose}
+      sx={{
+        width: 400,
+        flexShrink: 0,
+        position: "relative",
+        "& .MuiDrawer-paper": {
+          width: 400,
+          boxSizing: "border-box",
+          position: "relative",
+          height: "100%",
+          borderRight: "1px solid",
+          borderColor: "divider",
+          overflow: "visible",
+        },
+      }}
+    >
+      <Box sx={{ p: 2, display: "flex", flexDirection: "column", height: "100%" }}>
+        <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
+          Versions: {promptName}
+        </Typography>
+
+        <Autocomplete
+          freeSolo
+          options={autocompleteOptions}
+          getOptionLabel={(option) => (typeof option === "string" ? option : option.label)}
+          onChange={handleAutocompleteChange}
+          onInputChange={(_event, value) => setSearchQuery(value)}
+          inputValue={searchQuery}
+          renderInput={(params) => <TextField {...params} label="Search versions" variant="outlined" size="small" sx={{ mb: 2 }} />}
+        />
+
+        <Box sx={{ display: "flex", gap: 1, mb: 2 }}>
+          <Chip
+            label={`Sort: ${sortOrder === "asc" ? "Oldest First" : "Newest First"}`}
+            onClick={() => setSortOrder(sortOrder === "asc" ? "desc" : "asc")}
+            clickable
+            size="small"
+          />
+        </Box>
+
+        <Divider sx={{ mb: 2 }} />
+
+        {isLoading && (
+          <Box sx={{ p: 2, textAlign: "center" }}>
+            <Typography variant="body2" color="text.secondary">
+              Loading versions...
+            </Typography>
+          </Box>
+        )}
+
+        {error && (
+          <Box sx={{ p: 2 }}>
+            <Typography variant="body2" color="error">
+              Error loading versions: {error.message}
+            </Typography>
+          </Box>
+        )}
+
+        {!isLoading && !error && sortedAndFilteredVersions.length === 0 && (
+          <Box sx={{ p: 2, textAlign: "center" }}>
+            <Typography variant="body2" color="text.secondary">
+              No versions found
+            </Typography>
+          </Box>
+        )}
+
+        {!isLoading && !error && sortedAndFilteredVersions.length > 0 && (
+          <List sx={{ flex: 1, overflow: "auto" }}>
+            {sortedAndFilteredVersions.map((version) => {
+              const isSelected = selectedVersion === version.version;
+              const isDeleted = !!version.deleted_at;
+
+              return (
+                <ListItem key={version.version} disablePadding>
+                  <ListItemButton
+                    selected={isSelected}
+                    onClick={() => handleVersionClick(version.version)}
+                    sx={{
+                      backgroundColor: isSelected ? "action.selected" : "transparent",
+                      "&:hover": {
+                        backgroundColor: "action.hover",
+                      },
+                    }}
+                  >
+                    <ListItemText
+                      primary={
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                          <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                            Version {version.version}
+                          </Typography>
+                          {isDeleted && <Chip label="Deleted" size="small" color="error" sx={{ height: 18, fontSize: "0.7rem" }} />}
+                        </Box>
+                      }
+                      secondary={
+                        <Box component="span" sx={{ mt: 0.5, display: "block" }}>
+                          <Typography variant="caption" color="text.secondary" component="span">
+                            {version.model_provider} / {version.model_name}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary" component="span" sx={{ display: "block", mt: 0.5 }}>
+                            {formatDate(version.created_at)}
+                          </Typography>
+                        </Box>
+                      }
+                    />
+                  </ListItemButton>
+                </ListItem>
+              );
+            })}
+          </List>
+        )}
+      </Box>
+    </Drawer>
+  );
+};
+
+export default PromptVersionDrawer;

--- a/genai-engine/ui/src/components/prompts-management/hooks/useCreatePromptMutation.ts
+++ b/genai-engine/ui/src/components/prompts-management/hooks/useCreatePromptMutation.ts
@@ -1,0 +1,22 @@
+import { useApi } from "@/hooks/useApi";
+import { useApiMutation } from "@/hooks/useApiMutation";
+import type { CreateAgenticPromptRequest, AgenticPrompt } from "@/lib/api-client/api-client";
+
+export const useCreatePromptMutation = (taskId: string | undefined, onSuccess?: (promptData: AgenticPrompt) => void) => {
+  const api = useApi();
+
+  return useApiMutation<AgenticPrompt, { promptName: string; data: CreateAgenticPromptRequest }>({
+    mutationFn: async ({ promptName, data }) => {
+      if (!api || !taskId) throw new Error("API or task not available");
+
+      const response = await api.api.saveAgenticPromptApiV1TasksTaskIdPromptsPromptNamePost(promptName, taskId, data);
+
+      return response.data;
+    },
+    invalidateQueries: [{ queryKey: ["getAllAgenticPromptsApiV1TasksTaskIdPromptsGet"] }],
+    onSuccess,
+    onError: (err) => {
+      console.error("Failed to create prompt:", err);
+    },
+  });
+};

--- a/genai-engine/ui/src/components/prompts-management/hooks/usePrompt.ts
+++ b/genai-engine/ui/src/components/prompts-management/hooks/usePrompt.ts
@@ -1,0 +1,23 @@
+import { useApiQuery } from "@/hooks/useApiQuery";
+import type { AgenticPrompt } from "@/lib/api-client/api-client";
+
+// Get a prompt by name and version
+export function usePrompt(taskId: string | undefined, promptName: string | undefined, promptVersion: string | undefined) {
+  const { data, error, isLoading, refetch } = useApiQuery<"getAgenticPromptApiV1TasksTaskIdPromptsPromptNameVersionsPromptVersionGet">({
+    method: "getAgenticPromptApiV1TasksTaskIdPromptsPromptNameVersionsPromptVersionGet",
+    args: [promptName!, promptVersion!, taskId!],
+    enabled: !!taskId && !!promptName && !!promptVersion,
+    queryOptions: {
+      staleTime: 2000,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+    },
+  });
+
+  return {
+    prompt: data as AgenticPrompt | undefined,
+    error,
+    isLoading,
+    refetch,
+  };
+}

--- a/genai-engine/ui/src/components/prompts-management/hooks/usePromptVersions.ts
+++ b/genai-engine/ui/src/components/prompts-management/hooks/usePromptVersions.ts
@@ -1,0 +1,40 @@
+import type { PromptVersionsFilters } from "../types";
+
+import { useApiQuery } from "@/hooks/useApiQuery";
+import type { AgenticPromptVersionListResponse } from "@/lib/api-client/api-client";
+
+export function usePromptVersions(taskId: string | undefined, promptName: string | undefined, filters: PromptVersionsFilters = {}) {
+  const { data, error, isLoading, refetch } = useApiQuery<"getAllAgenticPromptVersionsApiV1TasksTaskIdPromptsPromptNameVersionsGet">({
+    method: "getAllAgenticPromptVersionsApiV1TasksTaskIdPromptsPromptNameVersionsGet",
+    args: [
+      {
+        taskId: taskId!,
+        promptName: promptName!,
+        page: filters.page ?? 0,
+        page_size: filters.pageSize ?? 10,
+        sort: filters.sort ?? "desc",
+        created_after: filters.created_after ?? null,
+        created_before: filters.created_before ?? null,
+        model_provider: filters.model_provider ?? null,
+        model_name: filters.model_name ?? null,
+        exclude_deleted: filters.exclude_deleted ?? false,
+        min_version: filters.min_version ?? null,
+        max_version: filters.max_version ?? null,
+      },
+    ],
+    enabled: !!taskId && !!promptName,
+    queryOptions: {
+      staleTime: 2000,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+    },
+  });
+
+  return {
+    versions: (data as AgenticPromptVersionListResponse | undefined)?.versions ?? [],
+    count: (data as AgenticPromptVersionListResponse | undefined)?.count ?? 0,
+    error,
+    isLoading,
+    refetch,
+  };
+}

--- a/genai-engine/ui/src/components/prompts-management/hooks/usePrompts.ts
+++ b/genai-engine/ui/src/components/prompts-management/hooks/usePrompts.ts
@@ -1,0 +1,37 @@
+import type { PromptsFilters } from "../types";
+
+import { useApiQuery } from "@/hooks/useApiQuery";
+import type { LLMGetAllMetadataListResponse } from "@/lib/api-client/api-client";
+
+export function usePrompts(taskId: string | undefined, filters: PromptsFilters) {
+  const { data, error, isLoading, refetch } = useApiQuery<"getAllAgenticPromptsApiV1TasksTaskIdPromptsGet">({
+    method: "getAllAgenticPromptsApiV1TasksTaskIdPromptsGet",
+    args: [
+      {
+        taskId: taskId!,
+        page: filters.page ?? 0,
+        page_size: filters.pageSize ?? 10,
+        sort: filters.sort ?? "desc",
+        created_after: filters.created_after ?? null,
+        created_before: filters.created_before ?? null,
+        model_provider: filters.model_provider ?? null,
+        model_name: filters.model_name ?? null,
+        llm_asset_names: filters.llm_asset_names ?? null,
+      },
+    ],
+    enabled: !!taskId,
+    queryOptions: {
+      staleTime: 2000,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+    },
+  });
+
+  return {
+    prompts: (data as LLMGetAllMetadataListResponse | undefined)?.llm_metadata ?? [],
+    count: (data as LLMGetAllMetadataListResponse | undefined)?.count ?? 0,
+    error,
+    isLoading,
+    refetch,
+  };
+}

--- a/genai-engine/ui/src/components/prompts-management/table/PromptRowExpansion.tsx
+++ b/genai-engine/ui/src/components/prompts-management/table/PromptRowExpansion.tsx
@@ -1,0 +1,78 @@
+import OpenInFullIcon from "@mui/icons-material/OpenInFull";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import Typography from "@mui/material/Typography";
+import React from "react";
+
+import type { PromptRowExpansionProps } from "../types";
+
+const PromptRowExpansion: React.FC<PromptRowExpansionProps> = ({ prompt: promptMetadata, onExpandToFullScreen }) => {
+  const formatDate = (dateString: string): string => {
+    try {
+      const date = new Date(dateString);
+      return date.toLocaleString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      });
+    } catch {
+      return dateString;
+    }
+  };
+
+  return (
+    <Box sx={{ p: 2, backgroundColor: "grey.50" }}>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+        <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Versions
+            </Typography>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {promptMetadata.versions}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Created At
+            </Typography>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {formatDate(promptMetadata.created_at)}
+            </Typography>
+          </Box>
+          <Box>
+            <Typography variant="caption" color="text.secondary">
+              Latest Version Created At
+            </Typography>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {formatDate(promptMetadata.latest_version_created_at)}
+            </Typography>
+          </Box>
+          {promptMetadata.deleted_versions.length > 0 && (
+            <Box>
+              <Typography variant="caption" color="text.secondary">
+                Deleted Versions
+              </Typography>
+              <Box sx={{ display: "flex", gap: 0.5, mt: 0.5 }}>
+                {promptMetadata.deleted_versions.map((version) => (
+                  <Chip key={version} label={`v${version}`} size="small" color="error" sx={{ height: 20, fontSize: "0.75rem" }} />
+                ))}
+              </Box>
+            </Box>
+          )}
+        </Box>
+        <Box>
+          <Button variant="outlined" size="small" startIcon={<OpenInFullIcon />} onClick={onExpandToFullScreen}>
+            Expand to Full Screen
+          </Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default PromptRowExpansion;

--- a/genai-engine/ui/src/components/prompts-management/table/PromptsTable.tsx
+++ b/genai-engine/ui/src/components/prompts-management/table/PromptsTable.tsx
@@ -1,0 +1,164 @@
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Collapse from "@mui/material/Collapse";
+import Paper from "@mui/material/Paper";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import TableSortLabel from "@mui/material/TableSortLabel";
+import React, { useCallback, useMemo } from "react";
+
+import type { PromptsTableProps } from "../types";
+
+import PromptRowExpansion from "./PromptRowExpansion";
+
+import { formatDate } from "@/utils/formatters";
+
+type SortableColumn = "name" | "created_at" | "latest_version_created_at";
+
+const PromptsTable = ({ prompts, sortColumn, sortDirection, onSort, expandedRows, onToggleRow, onExpandToFullScreen }: PromptsTableProps) => {
+  const handleSort = useCallback(
+    (column: SortableColumn) => {
+      onSort(column);
+    },
+    [onSort]
+  );
+
+  const handleRowClick = useCallback(
+    (promptName: string) => {
+      onToggleRow(promptName);
+    },
+    [onToggleRow]
+  );
+
+  const sortedPrompts = useMemo(() => {
+    if (!sortColumn) return prompts;
+
+    return [...prompts].sort((a, b) => {
+      let aValue: string | number;
+      let bValue: string | number;
+
+      switch (sortColumn) {
+        case "name":
+          aValue = a.name.toLowerCase();
+          bValue = b.name.toLowerCase();
+          break;
+        case "created_at":
+          aValue = new Date(a.created_at).getTime();
+          bValue = new Date(b.created_at).getTime();
+          break;
+        case "latest_version_created_at":
+          aValue = new Date(a.latest_version_created_at).getTime();
+          bValue = new Date(b.latest_version_created_at).getTime();
+          break;
+        default:
+          return 0;
+      }
+
+      if (aValue < bValue) return sortDirection === "asc" ? -1 : 1;
+      if (aValue > bValue) return sortDirection === "asc" ? 1 : -1;
+      return 0;
+    });
+  }, [prompts, sortColumn, sortDirection]);
+
+  return (
+    <TableContainer
+      component={Paper}
+      elevation={1}
+      sx={{
+        overflow: "auto",
+        height: "100%",
+      }}
+    >
+      <Table sx={{ minWidth: 650 }} aria-label="prompts table" stickyHeader>
+        <TableHead>
+          <TableRow>
+            <TableCell>
+              <Box component="span" sx={{ fontWeight: 600 }}>
+                Name
+              </Box>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortColumn === "created_at"}
+                direction={sortColumn === "created_at" ? sortDirection : "asc"}
+                onClick={() => handleSort("created_at")}
+              >
+                <Box component="span" sx={{ fontWeight: 600 }}>
+                  Created At
+                </Box>
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <TableSortLabel
+                active={sortColumn === "latest_version_created_at"}
+                direction={sortColumn === "latest_version_created_at" ? sortDirection : "asc"}
+                onClick={() => handleSort("latest_version_created_at")}
+              >
+                <Box component="span" sx={{ fontWeight: 600 }}>
+                  Latest Version Created At
+                </Box>
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>
+              <Box component="span" sx={{ fontWeight: 600 }}>
+                Versions
+              </Box>
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sortedPrompts.map((promptMetadata) => {
+            const isExpanded = expandedRows.has(promptMetadata.name);
+            return (
+              <React.Fragment key={promptMetadata.name}>
+                <TableRow
+                  hover
+                  onClick={() => handleRowClick(promptMetadata.name)}
+                  sx={{
+                    cursor: "pointer",
+                    "&:hover": {
+                      backgroundColor: "action.hover",
+                    },
+                  }}
+                >
+                  <TableCell component="th" scope="row">
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                      <Box sx={{ fontWeight: 500 }}>{promptMetadata.name}</Box>
+                      {promptMetadata.versions > 0 && (
+                        <Chip
+                          label={`v${promptMetadata.versions}`}
+                          size="small"
+                          sx={{
+                            height: 20,
+                            fontSize: "0.75rem",
+                            fontWeight: 500,
+                          }}
+                        />
+                      )}
+                    </Box>
+                  </TableCell>
+                  <TableCell>{formatDate(promptMetadata.created_at)}</TableCell>
+                  <TableCell>{formatDate(promptMetadata.latest_version_created_at)}</TableCell>
+                  <TableCell>{promptMetadata.versions}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={4}>
+                    <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+                      <PromptRowExpansion prompt={promptMetadata} onExpandToFullScreen={() => onExpandToFullScreen(promptMetadata.name)} />
+                    </Collapse>
+                  </TableCell>
+                </TableRow>
+              </React.Fragment>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default PromptsTable;

--- a/genai-engine/ui/src/components/prompts-management/types.ts
+++ b/genai-engine/ui/src/components/prompts-management/types.ts
@@ -1,0 +1,82 @@
+import { LLMGetAllMetadataResponse, AgenticPrompt, CreateAgenticPromptRequest } from "@/lib/api-client/api-client";
+
+interface PromptRowExpansionProps {
+  prompt: LLMGetAllMetadataResponse;
+  onExpandToFullScreen: () => void;
+}
+
+interface PromptsTableProps {
+  prompts: LLMGetAllMetadataResponse[];
+  sortColumn: string | null;
+  sortDirection: "asc" | "desc";
+  onSort: (column: string) => void;
+  expandedRows: Set<string>;
+  onToggleRow: (promptName: string) => void;
+  onExpandToFullScreen: (promptName: string) => void;
+}
+
+interface PromptVersionDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  taskId: string;
+  promptName: string;
+  selectedVersion: number | null;
+  onSelectVersion: (version: number) => void;
+}
+interface PromptFullScreenViewProps {
+  promptName: string;
+  initialVersion?: number | null;
+  onClose: () => void;
+}
+
+interface PromptDetailViewProps {
+  promptData: AgenticPrompt | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  promptName: string;
+  version: number | null;
+  onClose?: () => void;
+}
+
+interface FiltersBase {
+  page?: number;
+  pageSize?: number;
+  sort?: "asc" | "desc";
+  created_after?: string | null;
+  created_before?: string | null;
+  model_provider?: string | null;
+  model_name?: string | null;
+}
+
+interface PromptsFilters extends FiltersBase {
+  llm_asset_names?: string[] | null;
+}
+
+interface PromptVersionsFilters extends FiltersBase {
+  exclude_deleted?: boolean;
+  min_version?: number | null;
+  max_version?: number | null;
+}
+
+interface PromptsManagementHeaderProps {
+  onCreatePrompt: () => void;
+}
+
+interface PromptFormModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (promptName: string, data: CreateAgenticPromptRequest) => Promise<void>;
+  isLoading?: boolean;
+}
+
+export type {
+  PromptRowExpansionProps,
+  PromptsTableProps,
+  PromptVersionDrawerProps,
+  PromptFullScreenViewProps,
+  PromptDetailViewProps,
+  PromptsFilters,
+  PromptVersionsFilters,
+  PromptsManagementHeaderProps,
+  PromptFormModalProps,
+};


### PR DESCRIPTION
## Description
- yield db_session instead of returning it and add a finally to close it so it auto-closes for all routes
- Add prompts management page

## TODO:
- add delete for prompts and evals management
- remove the expansion for management pages just click straight into the versions
- QA change to db_session