### PR TITLE
make prompts and llm evals created_at property mandatory

### DIFF
--- a/genai-engine/src/api_changelog.md
+++ b/genai-engine/src/api_changelog.md
@@ -2,6 +2,16 @@ The intention of this changelog is to document API changes as they happen to eff
 
 ---
 
+# 11/16/2025
+- **BREAKING CHANGE** for **URL**: /api/v1/tasks/{task_id}/llm_evals/{eval_name}  the 'created_at' response's property type/format changed from ''/'' to 'string'/'date-time' for status '200'
+- **BREAKING CHANGE** for **URL**: /api/v1/tasks/{task_id}/llm_evals/{eval_name}/versions/{eval_version}  the 'created_at' response's property type/format changed from ''/'' to 'string'/'date-time' for status '200'
+- **BREAKING CHANGE** for **URL**: /api/v1/tasks/{task_id}/prompts/{prompt_name}  the 'created_at' response's property type/format changed from ''/'' to 'string'/'date-time' for status '200'
+- **BREAKING CHANGE** for **URL**: /api/v1/tasks/{task_id}/prompts/{prompt_name}/versions/{prompt_version}  the 'created_at' response's property type/format changed from ''/'' to 'string'/'date-time' for status '200'
+- **CHANGE** for **URL**: /api/v1/tasks/{task_id}/llm_evals/{eval_name}  the response property 'created_at' became required for the status '200'
+- **CHANGE** for **URL**: /api/v1/tasks/{task_id}/llm_evals/{eval_name}/versions/{eval_version}  the response property 'created_at' became required for the status '200'
+- **CHANGE** for **URL**: /api/v1/tasks/{task_id}/prompts/{prompt_name}  the response property 'created_at' became required for the status '200'
+- **CHANGE** for **URL**: /api/v1/tasks/{task_id}/prompts/{prompt_name}/versions/{prompt_version}  the response property 'created_at' became required for the status '200'
+
 # 11/15/2025
 - **CHANGE** for **URL**: /api/v1/tasks/{task_id}/llm_evals/{eval_name}  removed the request property 'max_score'
 - **CHANGE** for **URL**: /api/v1/tasks/{task_id}/llm_evals/{eval_name}  removed the request property 'min_score'

--- a/genai-engine/src/routers/v1/agentic_prompt_routes.py
+++ b/genai-engine/src/routers/v1/agentic_prompt_routes.py
@@ -375,8 +375,7 @@ def save_agentic_prompt(
 ) -> AgenticPrompt:
     try:
         agentic_prompt_service = AgenticPromptRepository(db_session)
-        full_prompt = AgenticPrompt(name=prompt_name, **prompt_config.model_dump())
-        return agentic_prompt_service.save_llm_item(task.id, full_prompt)
+        return agentic_prompt_service.save_llm_item(task.id, prompt_name, prompt_config)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/genai-engine/src/routers/v1/llm_eval_routes.py
+++ b/genai-engine/src/routers/v1/llm_eval_routes.py
@@ -215,8 +215,7 @@ def save_llm_eval(
 ):
     try:
         llm_eval_service = LLMEvalsRepository(db_session)
-        full_eval = LLMEval(name=eval_name, **eval_config.model_dump())
-        return llm_eval_service.save_llm_item(task.id, full_eval)
+        return llm_eval_service.save_llm_item(task.id, eval_name, eval_config)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/genai-engine/src/schemas/agentic_prompt_schemas.py
+++ b/genai-engine/src/schemas/agentic_prompt_schemas.py
@@ -6,7 +6,6 @@ from pydantic import (
     Field,
 )
 
-from db_models.agentic_prompt_models import DatabaseAgenticPrompt
 from schemas.enums import (
     ModelProvider,
 )
@@ -37,12 +36,12 @@ class AgenticPrompt(BaseModel):
         default=None,
         description="LLM configurations for this prompt (e.g. temperature, max_tokens, etc.)",
     )
-    created_at: Optional[datetime] = Field(
-        default=None,
+    created_at: datetime = Field(
+        ...,
         description="Timestamp when the prompt was created.",
     )
     deleted_at: Optional[datetime] = Field(
-        None,
+        default=None,
         description="Time that this prompt was deleted",
     )
 
@@ -51,14 +50,3 @@ class AgenticPrompt(BaseModel):
 
     def has_been_deleted(self) -> bool:
         return self.deleted_at is not None
-
-    @classmethod
-    def from_db_model(cls, db_prompt: DatabaseAgenticPrompt) -> "AgenticPrompt":
-        return cls.model_validate(db_prompt.__dict__)
-
-    def to_db_model(self, task_id: str) -> DatabaseAgenticPrompt:
-        """Convert this AgenticPrompt into a DatabaseAgenticPrompt"""
-        return DatabaseAgenticPrompt(
-            **self.model_dump(mode="python", exclude_none=True),
-            task_id=task_id,
-        )

--- a/genai-engine/src/schemas/llm_eval_schemas.py
+++ b/genai-engine/src/schemas/llm_eval_schemas.py
@@ -26,8 +26,8 @@ class LLMEval(BaseModel):
         default=None,
         description="LLM configurations for this eval (e.g. temperature, max_tokens, etc.)",
     )
-    created_at: Optional[datetime] = Field(
-        default=None,
+    created_at: datetime = Field(
+        ...,
         description="Timestamp when the llm eval was created.",
     )
     deleted_at: Optional[datetime] = Field(

--- a/genai-engine/src/services/prompt/chat_completion_service.py
+++ b/genai-engine/src/services/prompt/chat_completion_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Dict, List, Set, Tuple, Union
 
 from fastapi.responses import StreamingResponse
@@ -115,6 +116,7 @@ class ChatCompletionService:
         """
         prompt = AgenticPrompt(
             name="test_unsaved_prompt",
+            created_at=datetime.now(timezone.utc),
             **unsaved_prompt.model_dump(exclude={"completion_request"}),
         )
         return prompt, unsaved_prompt.completion_request

--- a/genai-engine/staging.openapi.json
+++ b/genai-engine/staging.openapi.json
@@ -9371,15 +9371,8 @@
                         "description": "LLM configurations for this prompt (e.g. temperature, max_tokens, etc.)"
                     },
                     "created_at": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "type": "string",
+                        "format": "date-time",
                         "title": "Created At",
                         "description": "Timestamp when the prompt was created."
                     },
@@ -9402,7 +9395,8 @@
                     "name",
                     "messages",
                     "model_name",
-                    "model_provider"
+                    "model_provider",
+                    "created_at"
                 ],
                 "title": "AgenticPrompt"
             },
@@ -11905,15 +11899,8 @@
                         "description": "LLM configurations for this eval (e.g. temperature, max_tokens, etc.)"
                     },
                     "created_at": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "type": "string",
+                        "format": "date-time",
                         "title": "Created At",
                         "description": "Timestamp when the llm eval was created."
                     },
@@ -11942,7 +11929,8 @@
                     "name",
                     "model_name",
                     "model_provider",
-                    "instructions"
+                    "instructions",
+                    "created_at"
                 ],
                 "title": "LLMEval"
             },


### PR DESCRIPTION
## Description
- Made the created_at property for both prompts and llm evals required
- Setting the created_at property in the save_llm_item now instead of offsetting it to use the db default
- Updated the save api call to not need to convert from the create request objects to the full objects. Now the full object is just the response object
- Updated tests to use the new save format