### PR TITLE
raise an error for malformed response formats on prompt save

### DIFF
--- a/genai-engine/ui/src/components/prompts-playground/prompts/OutputField.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/prompts/OutputField.tsx
@@ -20,8 +20,31 @@ import { OutputFieldProps } from "../types";
 
 const DEFAULT_RESPONSE_FORMAT = JSON.stringify(
   {
-    type: "json_schema",
-    schema: {},
+    "type": "json_schema",
+    "json_schema": {
+      "name": "schema_name_here",
+      "description": "description of the response schema",
+      "strict": true,
+      "schema": {
+        "type": "object",
+        "properties": {
+          "field1": {
+            "type": "string",
+            "description": "Describe what this string should contain"
+          },
+          "field2": {
+            "type": "number",
+            "description": "Describe what this number represents"
+          },
+          "field3": {
+            "type": "boolean",
+            "description": "Explain what true/false means in this context"
+          }
+        },
+        "required": ["field1", "field2"],
+        "additionalProperties": false
+      }
+    }
   },
   null,
   2

--- a/genai-engine/ui/src/components/prompts-playground/utils/toFrontendPrompt.ts
+++ b/genai-engine/ui/src/components/prompts-playground/utils/toFrontendPrompt.ts
@@ -49,7 +49,7 @@ export const toFrontendPrompt = (backendPrompt: AgenticPrompt): PromptType => ({
     thinking: backendPrompt.config?.thinking,
   },
   runResponse: null,
-  responseFormat: backendPrompt.config?.response_format ? JSON.stringify(backendPrompt.config.response_format) : undefined,
+  responseFormat: backendPrompt.config?.response_format ? JSON.stringify(backendPrompt.config.response_format, null, 2) : undefined,
   running: false,
   version: backendPrompt.version || null,
   isDirty: false, // Prompts loaded from backend should not be marked as dirty


### PR DESCRIPTION
## Description
- Adds a model validator to the LLMResponseFormat object to require the LLMResponseSchema object when using json_schema mode
- Raises an error if that same object is included when using JSON Mode ('json_object') or text mode 
- Adds unit tests on both the creation of the object and in the route to validate the error is being raised and with the proper 400 error
- Modifies the frontend default response format object to be in proper json_schema response format
- Fixes a small visual bug when loading a pre-existing response format that kept it all in one line to have the same formatting as the default response format object
- Not in the code, but I also validated that the response format is getting loaded in properly from the backend when loading a pre-existing prompt (from [this slack thread](https://arthur-ai.slack.com/archives/C095P231EEB/p1763479371710809?thread_ts=1763422707.546359&cid=C095P231EEB))

## Jira Ticket
- https://arthurai.atlassian.net/browse/UP-3356