### PR TITLE
[no-ref] allow exporting + importing dataset transforms to JSON files

### DIFF
--- a/genai-engine/ui/src/components/datasets/transforms/TransformDetailsModal.tsx
+++ b/genai-engine/ui/src/components/datasets/transforms/TransformDetailsModal.tsx
@@ -1,3 +1,4 @@
+import DownloadIcon from "@mui/icons-material/Download";
 import {
   Dialog,
   DialogTitle,
@@ -7,6 +8,7 @@ import {
   Box,
   Typography,
 } from "@mui/material";
+
 import { DatasetTransform } from "./types";
 
 interface TransformDetailsModalProps {
@@ -21,6 +23,29 @@ export const TransformDetailsModal: React.FC<TransformDetailsModalProps> = ({
   transform,
 }) => {
   if (!transform) return null;
+
+  const handleDownload = () => {
+    // Create the export object with name, description, and definition
+    const exportData = {
+      name: transform.name,
+      description: transform.description,
+      definition: transform.definition,
+    };
+
+    // Convert to JSON string
+    const jsonString = JSON.stringify(exportData, null, 2);
+
+    // Create a blob and download link
+    const blob = new Blob([jsonString], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${transform.name.replace(/[^a-z0-9]/gi, "_").toLowerCase()}_transform.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
@@ -91,6 +116,9 @@ export const TransformDetailsModal: React.FC<TransformDetailsModalProps> = ({
         </Box>
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={handleDownload} startIcon={<DownloadIcon />}>
+          Download JSON
+        </Button>
         <Button onClick={onClose} variant="contained">
           Close
         </Button>


### PR DESCRIPTION
Adding UX to allow importing/exporting transforms to make it easy to duplicate / share them.

<img width="1119" height="604" alt="Screenshot 2025-11-18 at 12 56 49 PM" src="https://github.com/user-attachments/assets/414008b2-fec7-4f39-ac75-9884c74663e7" />
<img width="1050" height="845" alt="Screenshot 2025-11-18 at 12 56 57 PM" src="https://github.com/user-attachments/assets/45d12781-3edd-4200-bf57-fc81c54e493e" />
