### PR TITLE
[no-ref] fix Arthur typescript api client circular import

### DIFF
--- a/genai-engine/examples/agents/analytics-agent/src/mastra/lib/arthur-api-client/client.ts
+++ b/genai-engine/examples/agents/analytics-agent/src/mastra/lib/arthur-api-client/client.ts
@@ -4,19 +4,11 @@ import { Api } from "./api-client";
  * Creates and returns a configured Arthur API client instance
  * using environment variables for authentication
  */
-export function getArthurApiClient(): Api {
-  return new Api({
+export function getArthurApiClient(): Api<unknown> {
+  return new Api<unknown>({
     baseURL: process.env.ARTHUR_BASE_URL,
     headers: {
       Authorization: `Bearer ${process.env.ARTHUR_API_KEY}`,
     },
   });
 }
-
-// Re-export prompt templating utilities
-export { getTemplatedPrompt } from "./prompt-templating";
-export type {
-  PromptVariable,
-  GetTemplatedPromptOptions,
-  TemplatedPromptResult,
-} from "./prompt-templating";

--- a/genai-engine/examples/agents/analytics-agent/src/mastra/lib/arthur-api-client/index.ts
+++ b/genai-engine/examples/agents/analytics-agent/src/mastra/lib/arthur-api-client/index.ts
@@ -1,0 +1,13 @@
+// Export the API client factory
+export { getArthurApiClient } from "./client";
+
+// Export prompt templating utilities
+export {
+  getTemplatedPrompt,
+  type PromptVariable,
+  type GetTemplatedPromptOptions,
+  type TemplatedPromptResult,
+} from "./prompt-templating";
+
+// Re-export the Api class if needed
+export { Api } from "./api-client";

--- a/genai-engine/examples/agents/analytics-agent/src/mastra/tools/textToSql.ts
+++ b/genai-engine/examples/agents/analytics-agent/src/mastra/tools/textToSql.ts
@@ -1,7 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { AISpanType, TracingContext } from "@mastra/core/ai-tracing";
-import { getTemplatedPrompt } from "@/mastra/lib/arthur-api-client/client";
+import { getTemplatedPrompt } from "@/mastra/lib/arthur-api-client";
 
 export type TextToSqlToolResult = z.infer<typeof TextToSqlToolResultSchema>;
 


### PR DESCRIPTION
1. reorganizing the Arthur client because of circular import
2. added some additional functionality to the template prompt function to support variable formats that are record objects