### PR TITLE
Fixup for test_get_llm_eval_by_version_route flakiness

### DIFF
--- a/genai-engine/tests/unit/routes/tasks/conftest.py
+++ b/genai-engine/tests/unit/routes/tasks/conftest.py
@@ -1,0 +1,89 @@
+import random
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Generator
+
+import pytest
+
+from db_models.llm_eval_models import DatabaseLLMEval, DatabaseLLMEvalVersionTag
+from db_models.task_models import DatabaseTask
+from tests.clients.base_test_client import override_get_db_session
+
+
+@dataclass
+class TaskWithLLMEval:
+    """Container for task and LLM eval data created directly in the database"""
+
+    task_id: str
+    task_name: str
+    eval_name: str
+    eval_data: dict
+    created_at: datetime
+
+
+@pytest.fixture
+def task_with_llm_eval_in_db() -> Generator[TaskWithLLMEval, None, None]:
+    """
+    Create an agentic task and LLM eval directly in the database.
+    Cleans up both objects after the test completes.
+    """
+    db_session = override_get_db_session()
+
+    # Create the task directly in DB
+    task_id = str(uuid.uuid4())
+    task_name = f"agentic_task_{random.random()}"
+    # Use a fixed date to avoid flaky tests with datetime-based version lookups
+    fixed_date = datetime(2024, 1, 15, 12, 0, 0)
+
+    db_task = DatabaseTask(
+        id=task_id,
+        name=task_name,
+        created_at=fixed_date,
+        updated_at=fixed_date,
+        is_agentic=True,
+    )
+    db_session.add(db_task)
+    db_session.commit()
+
+    # Create the LLM eval directly in DB
+    eval_name = "test_llm_eval"
+    eval_data = {
+        "model_name": "gpt-4o",
+        "model_provider": "openai",
+        "instructions": "Test instructions",
+    }
+
+    db_llm_eval = DatabaseLLMEval(
+        task_id=task_id,
+        name=eval_name,
+        model_name=eval_data["model_name"],
+        model_provider=eval_data["model_provider"],
+        instructions=eval_data["instructions"],
+        variables=[],
+        version=1,
+        created_at=fixed_date,
+    )
+    db_session.add(db_llm_eval)
+    db_session.commit()
+
+    yield TaskWithLLMEval(
+        task_id=task_id,
+        task_name=task_name,
+        eval_name=eval_name,
+        eval_data=eval_data,
+        created_at=fixed_date,
+    )
+
+    # Cleanup: delete tags first, then LLM eval (due to FK constraint), then the task
+    db_session.query(DatabaseLLMEvalVersionTag).filter(
+        DatabaseLLMEvalVersionTag.task_id == task_id,
+        DatabaseLLMEvalVersionTag.name == eval_name,
+    ).delete()
+    db_session.query(DatabaseLLMEval).filter(
+        DatabaseLLMEval.task_id == task_id,
+        DatabaseLLMEval.name == eval_name,
+    ).delete()
+    db_session.query(DatabaseTask).filter(DatabaseTask.id == task_id).delete()
+    db_session.commit()
+    db_session.close()

--- a/genai-engine/tests/unit/routes/tasks/test_llm_eval_routes.py
+++ b/genai-engine/tests/unit/routes/tasks/test_llm_eval_routes.py
@@ -7,6 +7,7 @@ from litellm.types.utils import ModelResponse
 
 from schemas.internal_schemas import Task
 from tests.clients.base_test_client import GenaiEngineTestClientBase
+from tests.unit.routes.tasks.conftest import TaskWithLLMEval
 
 
 @pytest.fixture
@@ -524,36 +525,23 @@ def test_get_llm_eval_does_not_raise_err_for_deleted_eval(
 @pytest.mark.parametrize("eval_version", ["latest", "1", "datetime", "tag"])
 def test_get_llm_eval_by_version_route(
     client: GenaiEngineTestClientBase,
-    eval_version,
+    task_with_llm_eval_in_db: TaskWithLLMEval,
+    eval_version: str,
 ):
     """Test getting an llm eval with different version formats (latest, version number, datetime, tag)"""
-    # Create an agentic task
-    task_name = f"agentic_task_{random.random()}"
-    status_code, task = client.create_task(task_name, is_agentic=True)
-    assert status_code == 200
+    task_id = task_with_llm_eval_in_db.task_id
+    eval_name = task_with_llm_eval_in_db.eval_name
+    eval_data = task_with_llm_eval_in_db.eval_data
 
-    # Save an llm eval
-    eval_name = "test_llm_eval"
-    eval_data = {
-        "model_name": "gpt-4o",
-        "model_provider": "openai",
-        "instructions": "Test instructions",
-    }
+    # For datetime version, use the created_at timestamp from the fixture
     if eval_version == "datetime":
-        eval_version = datetime.now().isoformat()
-
-    save_response = client.base_client.post(
-        f"/api/v1/tasks/{task.id}/llm_evals/{eval_name}",
-        json=eval_data,
-        headers=client.authorized_user_api_key_headers,
-    )
-    assert save_response.status_code == 200
+        eval_version = task_with_llm_eval_in_db.created_at.isoformat()
 
     # Add a tag if testing tag-based version
     if eval_version == "tag":
         test_tag = "test_tag"
         tag_response = client.base_client.put(
-            f"/api/v1/tasks/{task.id}/llm_evals/{eval_name}/versions/1/tags",
+            f"/api/v1/tasks/{task_id}/llm_evals/{eval_name}/versions/1/tags",
             json={"tag": test_tag},
             headers=client.authorized_user_api_key_headers,
         )
@@ -562,7 +550,7 @@ def test_get_llm_eval_by_version_route(
 
     # Get the llm eval using different version formats
     response = client.base_client.get(
-        f"/api/v1/tasks/{task.id}/llm_evals/{eval_name}/versions/{eval_version}",
+        f"/api/v1/tasks/{task_id}/llm_evals/{eval_name}/versions/{eval_version}",
         headers=client.authorized_user_api_key_headers,
     )
     assert response.status_code == 200


### PR DESCRIPTION
Test `test_get_llm_eval_by_version_route` was flaky, because it was using `datetime.now()` method. Modified tests, so we directly input object to DB with fixed value for created_at. This fix will prevent test from failing.