### PR TITLE
Fix Prompt Notebook Experiment Bug

### DIFF
--- a/genai-engine/src/repositories/prompt_experiment_repository.py
+++ b/genai-engine/src/repositories/prompt_experiment_repository.py
@@ -679,7 +679,7 @@ class PromptExperimentRepository:
             total_rows=0,  # Will be updated after creating test cases
             completed_rows=0,
             failed_rows=0,
-            notebook_id=None,
+            notebook_id=request.notebook_id,
         )
 
         self.db_session.add(db_experiment)

--- a/genai-engine/src/schemas/base_experiment_schemas.py
+++ b/genai-engine/src/schemas/base_experiment_schemas.py
@@ -226,6 +226,10 @@ class BaseCreateExperimentRequest(BaseModel):
         "Only rows matching ALL specified column name-value pairs (AND condition) will be included in the experiment. "
         "If not specified, all rows from the dataset will be used.",
     )
+    notebook_id: Optional[str] = Field(
+        default=None,
+        description="Optional notebook ID to link this experiment to",
+    )
 
 
 class BaseExperimentDetail(BaseModel):

--- a/genai-engine/ui/src/components/prompt-experiments/CreateExperimentModal.tsx
+++ b/genai-engine/ui/src/components/prompt-experiments/CreateExperimentModal.tsx
@@ -585,8 +585,11 @@ export const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({
       // Transform formData to match API expectations
       // The parent component will handle the actual API call
       const result = await onSubmit(formData);
-      // Show success toast
-      showSnackbar(`Experiment "${formData.name}" created successfully!`, "success");
+      // Show success toast - different message for notebook config mode vs actual experiment creation
+      const successMessage = disableNavigation
+        ? `Experiment configuration "${formData.name}" saved! Click "Run All" to create and run the experiment.`
+        : `Experiment "${formData.name}" created successfully!`;
+      showSnackbar(successMessage, "success");
       // Reset form on success
       setFormData({
         name: "",
@@ -618,8 +621,11 @@ export const CreateExperimentModal: React.FC<CreateExperimentModalProps> = ({
       }
     } catch (error) {
       console.error("Failed to create experiment:", error);
-      setErrors({ general: "Failed to create experiment. Please try again." });
-      showSnackbar("Failed to create experiment. Please try again.", "error");
+      const errorMessage = disableNavigation
+        ? "Failed to save experiment configuration. Please try again."
+        : "Failed to create experiment. Please try again.";
+      setErrors({ general: errorMessage });
+      showSnackbar(errorMessage, "error");
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
The frontend was sending notebook_id in the experiment creation request, but the backend schema did not accept this field. Pydantic was silently stripping the field, causing experiments to be created with notebook_id=NULL.

This fix:
- Adds notebook_id field to BaseCreateExperimentRequest schema
- Updates create_experiment to use request.notebook_id instead of None

This allows experiments created from notebooks to be properly linked, so they appear in the notebook history and can be found on the experiments page.

Slack: https://arthur-ai.slack.com/archives/C095P231EEB/p1767898687506399