### PR TITLE
fix chat completion not working for gemini models

### DIFF
--- a/genai-engine/src/services/prompt/chat_completion_service.py
+++ b/genai-engine/src/services/prompt/chat_completion_service.py
@@ -133,7 +133,11 @@ class ChatCompletionService:
         prompt: AgenticPrompt,
         completion_request: PromptCompletionRequest = PromptCompletionRequest(),
     ) -> Tuple[str, Dict[str, Any]]:
-        model = prompt.model_provider + "/" + prompt.model_name
+        model = (
+            prompt.model_name
+            if prompt.model_name.startswith(prompt.model_provider + "/")
+            else prompt.model_provider + "/" + prompt.model_name
+        )
 
         completion_params: dict[str, Any] = {
             "messages": [


### PR DESCRIPTION
## Description
Gemini model names in litellm are already prefixed with "gemini/" This PR adds a check to not manually add "{provider}/" to the model passed in to litellm if a model_name already contains a prefix of "{provider}/"

## Jira Ticket
- https://arthurai.atlassian.net/browse/UP-3623