### PR TITLE
feat: enhance synthetic data generation modal

### DIFF
--- a/genai-engine/ui/src/components/datasets/synthetic/SyntheticDataCanvas.tsx
+++ b/genai-engine/ui/src/components/datasets/synthetic/SyntheticDataCanvas.tsx
@@ -1,0 +1,132 @@
+import { ArrowBack, Check } from "@mui/icons-material";
+import { Box, Button, Divider, Alert } from "@mui/material";
+import React from "react";
+
+import { SyntheticDataChat } from "./SyntheticDataChat";
+import { SyntheticDataTable } from "./SyntheticDataTable";
+import type { SyntheticRow } from "./types";
+
+import type { OpenAIMessageInput } from "@/lib/api-client/api-client";
+
+interface SyntheticDataCanvasProps {
+  rows: SyntheticRow[];
+  conversation: OpenAIMessageInput[];
+  columns: string[];
+  isLoading: boolean;
+  error: Error | null;
+  onSendMessage: (message: string) => void;
+  onUpdateRow: (id: string, data: Record<string, string>) => void;
+  onAddRow: (data: Record<string, string>) => void;
+  onDeleteRows: (ids: string[]) => void;
+  onToggleLock: (id: string) => void;
+  onBack: () => void;
+  onAccept: () => void;
+}
+
+export const SyntheticDataCanvas: React.FC<SyntheticDataCanvasProps> = ({
+  rows,
+  conversation,
+  columns,
+  isLoading,
+  error,
+  onSendMessage,
+  onUpdateRow,
+  onAddRow,
+  onDeleteRows,
+  onToggleLock,
+  onBack,
+  onAccept,
+}) => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        overflow: "hidden",
+      }}
+    >
+      {/* Main content area - split view */}
+      <Box
+        sx={{
+          display: "flex",
+          flex: 1,
+          overflow: "hidden",
+        }}
+      >
+        {/* Left panel - Chat */}
+        <Box
+          sx={{
+            width: "40%",
+            minWidth: 300,
+            maxWidth: 500,
+            display: "flex",
+            flexDirection: "column",
+            borderRight: 1,
+            borderColor: "divider",
+          }}
+        >
+          <SyntheticDataChat
+            conversation={conversation}
+            isLoading={isLoading}
+            onSendMessage={onSendMessage}
+          />
+        </Box>
+
+        {/* Right panel - Table */}
+        <Box
+          sx={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+          }}
+        >
+          {error && (
+            <Alert severity="error" sx={{ m: 2 }}>
+              {error.message}
+            </Alert>
+          )}
+          <SyntheticDataTable
+            rows={rows}
+            columns={columns}
+            onUpdateRow={onUpdateRow}
+            onAddRow={onAddRow}
+            onDeleteRows={onDeleteRows}
+            onToggleLock={onToggleLock}
+          />
+        </Box>
+      </Box>
+
+      {/* Footer with actions */}
+      <Divider />
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          p: 2,
+          bgcolor: "grey.50",
+        }}
+      >
+        <Button
+          startIcon={<ArrowBack />}
+          onClick={onBack}
+          disabled={isLoading}
+          variant="outlined"
+        >
+          Back to Configure
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<Check />}
+          onClick={onAccept}
+          disabled={rows.length === 0 || isLoading}
+        >
+          Accept {rows.length} Row{rows.length !== 1 ? "s" : ""}
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/genai-engine/ui/src/components/datasets/synthetic/SyntheticDataConfigForm.tsx
+++ b/genai-engine/ui/src/components/datasets/synthetic/SyntheticDataConfigForm.tsx
@@ -1,0 +1,326 @@
+import {
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  Slider,
+  Switch,
+  TextField,
+  Typography,
+  Autocomplete,
+  Alert,
+} from "@mui/material";
+import React, { useCallback, useEffect, useState } from "react";
+
+import type { GenerationConfig } from "./types";
+
+import { useApi } from "@/hooks/useApi";
+import type {
+  DatasetVersionRowResponse,
+  ModelProvider,
+  ModelProviderResponse,
+} from "@/lib/api-client/api-client";
+
+interface SyntheticDataConfigFormProps {
+  columns: string[];
+  existingRowsSample: DatasetVersionRowResponse[];
+  onSubmit: (config: GenerationConfig) => void;
+  onCancel: () => void;
+  isLoading: boolean;
+}
+
+interface ColumnDescription {
+  columnName: string;
+  description: string;
+}
+
+export const SyntheticDataConfigForm: React.FC<SyntheticDataConfigFormProps> = ({
+  columns,
+  existingRowsSample: _existingRowsSample,
+  onSubmit,
+  onCancel,
+  isLoading,
+}) => {
+  const api = useApi();
+
+  // Form state
+  const [datasetPurpose, setDatasetPurpose] = useState("");
+  const [columnDescriptions, setColumnDescriptions] = useState<ColumnDescription[]>(
+    columns.map((col) => ({ columnName: col, description: "" }))
+  );
+  const [numRows, setNumRows] = useState(10);
+  const [modelProvider, setModelProvider] = useState<ModelProvider | null>(null);
+  const [modelName, setModelName] = useState<string | null>(null);
+  const [editExisting, setEditExisting] = useState(false);
+
+  // Provider/model loading state
+  const [providers, setProviders] = useState<ModelProviderResponse[]>([]);
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [isLoadingProviders, setIsLoadingProviders] = useState(true);
+  const [isLoadingModels, setIsLoadingModels] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load providers on mount
+  useEffect(() => {
+    const fetchProviders = async () => {
+      if (!api) return;
+
+      try {
+        setIsLoadingProviders(true);
+        const response = await api.api.getModelProvidersApiV1ModelProvidersGet();
+        const enabledProviders = (response.data.providers || []).filter(
+          (p) => p.enabled
+        );
+        setProviders(enabledProviders);
+
+        // Auto-select first enabled provider
+        if (enabledProviders.length > 0) {
+          setModelProvider(enabledProviders[0].provider);
+        }
+      } catch (err) {
+        console.error("Failed to fetch model providers:", err);
+        setError("Failed to load model providers");
+      } finally {
+        setIsLoadingProviders(false);
+      }
+    };
+
+    fetchProviders();
+  }, [api]);
+
+  // Load models when provider changes
+  useEffect(() => {
+    const fetchModels = async () => {
+      if (!api || !modelProvider) {
+        setAvailableModels([]);
+        return;
+      }
+
+      try {
+        setIsLoadingModels(true);
+        setModelName(null);
+        const response =
+          await api.api.getModelProvidersAvailableModelsApiV1ModelProvidersProviderAvailableModelsGet(
+            modelProvider
+          );
+        setAvailableModels(response.data.available_models || []);
+      } catch (err) {
+        console.error("Failed to fetch available models:", err);
+        setAvailableModels([]);
+      } finally {
+        setIsLoadingModels(false);
+      }
+    };
+
+    fetchModels();
+  }, [api, modelProvider]);
+
+  const handleColumnDescriptionChange = useCallback(
+    (columnName: string, description: string) => {
+      setColumnDescriptions((prev) =>
+        prev.map((col) =>
+          col.columnName === columnName ? { ...col, description } : col
+        )
+      );
+    },
+    []
+  );
+
+  const handleSubmit = useCallback(() => {
+    if (!modelProvider || !modelName) return;
+
+    onSubmit({
+      datasetPurpose,
+      columnDescriptions,
+      numRows,
+      modelProvider,
+      modelName,
+      editExisting,
+    });
+  }, [
+    datasetPurpose,
+    columnDescriptions,
+    numRows,
+    modelProvider,
+    modelName,
+    editExisting,
+    onSubmit,
+  ]);
+
+  const enabledProviders = providers.filter((p) => p.enabled);
+  const canSubmit =
+    datasetPurpose.trim() &&
+    modelProvider &&
+    modelName &&
+    columnDescriptions.every((col) => col.description.trim());
+
+  if (isLoadingProviders) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (enabledProviders.length === 0) {
+    return (
+      <Box sx={{ py: 2 }}>
+        <Alert severity="warning">
+          No model providers are configured. Please configure at least one model
+          provider in Settings to use synthetic data generation.
+        </Alert>
+        <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 2 }}>
+          <Button onClick={onCancel}>Close</Button>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3, py: 1 }}>
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {/* Dataset Purpose */}
+      <TextField
+        label="Dataset Purpose"
+        placeholder="Describe what this dataset is for and what kind of data it contains..."
+        multiline
+        rows={3}
+        value={datasetPurpose}
+        onChange={(e) => setDatasetPurpose(e.target.value)}
+        fullWidth
+        required
+        helperText="Help the AI understand the context and purpose of your data"
+      />
+
+      {/* Column Descriptions */}
+      <Box>
+        <Typography variant="subtitle2" sx={{ mb: 1 }}>
+          Column Descriptions
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Describe what each column contains to guide realistic data generation
+        </Typography>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          {columnDescriptions.map((col) => (
+            <TextField
+              key={col.columnName}
+              label={col.columnName}
+              placeholder={`Describe what "${col.columnName}" contains...`}
+              value={col.description}
+              onChange={(e) =>
+                handleColumnDescriptionChange(col.columnName, e.target.value)
+              }
+              fullWidth
+              size="small"
+              required
+            />
+          ))}
+        </Box>
+      </Box>
+
+      {/* Model Selection */}
+      <Box sx={{ display: "flex", gap: 2 }}>
+        <FormControl fullWidth size="small">
+          <InputLabel>Model Provider</InputLabel>
+          <Select
+            value={modelProvider || ""}
+            label="Model Provider"
+            onChange={(e) => setModelProvider(e.target.value as ModelProvider)}
+          >
+            {enabledProviders.map((provider) => (
+              <MenuItem key={provider.provider} value={provider.provider}>
+                {provider.provider.charAt(0).toUpperCase() +
+                  provider.provider.slice(1)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Autocomplete
+          fullWidth
+          size="small"
+          options={availableModels}
+          value={modelName}
+          onChange={(_, newValue) => setModelName(newValue)}
+          loading={isLoadingModels}
+          disabled={!modelProvider || isLoadingModels}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Model"
+              placeholder="Select a model"
+              InputProps={{
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {isLoadingModels ? (
+                      <CircularProgress color="inherit" size={20} />
+                    ) : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              }}
+            />
+          )}
+        />
+      </Box>
+
+      {/* Number of Rows */}
+      <Box>
+        <Typography variant="subtitle2" gutterBottom>
+          Number of Rows to Generate: {numRows}
+        </Typography>
+        <Slider
+          value={numRows}
+          onChange={(_, value) => setNumRows(value as number)}
+          min={1}
+          max={25}
+          marks={[
+            { value: 1, label: "1" },
+            { value: 10, label: "10" },
+            { value: 25, label: "25" },
+          ]}
+          valueLabelDisplay="auto"
+        />
+      </Box>
+
+      {/* Edit Existing Data Toggle */}
+      <Box>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={editExisting}
+              onChange={(e) => setEditExisting(e.target.checked)}
+            />
+          }
+          label="Edit existing data"
+        />
+        <Typography variant="body2" color="text.secondary" sx={{ ml: 4 }}>
+          {editExisting
+            ? "Existing dataset rows will be loaded into the canvas for editing and synthetic generation will update them"
+            : "Only new rows will be generated without modifying existing data"}
+        </Typography>
+      </Box>
+
+      {/* Actions */}
+      <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2, pt: 2 }}>
+        <Button onClick={onCancel} disabled={isLoading}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={!canSubmit || isLoading}
+          startIcon={isLoading ? <CircularProgress size={16} /> : null}
+        >
+          {isLoading ? "Generating..." : "Start Generating"}
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/genai-engine/ui/src/components/datasets/synthetic/SyntheticDataModal.tsx
+++ b/genai-engine/ui/src/components/datasets/synthetic/SyntheticDataModal.tsx
@@ -1,0 +1,156 @@
+import { AutoAwesome, Close } from "@mui/icons-material";
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import React, { useCallback, useState } from "react";
+
+import { SyntheticDataCanvas } from "./SyntheticDataCanvas";
+import { SyntheticDataConfigForm } from "./SyntheticDataConfigForm";
+import type { GenerationConfig } from "./types";
+
+import { useSyntheticDataSession } from "@/hooks/datasets/useSyntheticDataSession";
+import type { DatasetVersionRowResponse } from "@/lib/api-client/api-client";
+
+interface SyntheticDataModalProps {
+  open: boolean;
+  onClose: () => void;
+  columns: string[];
+  existingRowsSample: DatasetVersionRowResponse[];
+  datasetId: string;
+  versionNumber: number;
+  onAcceptRows: (rows: { data: { column_name: string; column_value: string }[] }[]) => void;
+}
+
+type ModalPhase = "configure" | "canvas";
+
+export const SyntheticDataModal: React.FC<SyntheticDataModalProps> = ({
+  open,
+  onClose,
+  columns,
+  existingRowsSample,
+  datasetId,
+  versionNumber,
+  onAcceptRows,
+}) => {
+  const [phase, setPhase] = useState<ModalPhase>("configure");
+  const [config, setConfig] = useState<GenerationConfig | null>(null);
+
+  const session = useSyntheticDataSession(datasetId, versionNumber, columns);
+
+  const handleStartGeneration = useCallback(
+    async (generationConfig: GenerationConfig) => {
+      setConfig(generationConfig);
+      await session.startGeneration(generationConfig, existingRowsSample);
+      setPhase("canvas");
+    },
+    [session, existingRowsSample]
+  );
+
+  const handleSendMessage = useCallback(
+    async (message: string) => {
+      if (config) {
+        await session.sendMessage(message, config);
+      }
+    },
+    [session, config]
+  );
+
+  const handleClose = useCallback(() => {
+    setPhase("configure");
+    setConfig(null);
+    session.reset();
+    onClose();
+  }, [session, onClose]);
+
+  const handleAcceptRows = useCallback(() => {
+    // Convert synthetic rows to the format expected by the dataset
+    const rowsToAdd = session.rows.map((row) => ({
+      data: Object.entries(row.data).map(([column_name, column_value]) => ({
+        column_name,
+        column_value,
+      })),
+    }));
+    onAcceptRows(rowsToAdd);
+    handleClose();
+  }, [session.rows, onAcceptRows, handleClose]);
+
+  const handleBack = useCallback(() => {
+    setPhase("configure");
+    session.reset();
+  }, [session]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth={phase === "canvas" ? "xl" : "md"}
+      fullWidth
+      PaperProps={{
+        sx: {
+          height: phase === "canvas" ? "90vh" : "auto",
+          maxHeight: phase === "canvas" ? "90vh" : "auto",
+        },
+      }}
+    >
+      <DialogTitle
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          pb: 1,
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <AutoAwesome color="primary" />
+          <Typography variant="h6">
+            {phase === "configure"
+              ? "Generate Synthetic Data"
+              : "Synthetic Data Generation"}
+          </Typography>
+        </Box>
+        <IconButton onClick={handleClose} size="small">
+          <Close />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: phase === "canvas" ? "calc(100% - 64px)" : "auto",
+          p: phase === "canvas" ? 0 : 3,
+        }}
+      >
+        {phase === "configure" ? (
+          <SyntheticDataConfigForm
+            columns={columns}
+            existingRowsSample={existingRowsSample}
+            onSubmit={handleStartGeneration}
+            onCancel={handleClose}
+            isLoading={session.isLoading}
+          />
+        ) : (
+          <SyntheticDataCanvas
+            rows={session.rows}
+            conversation={session.conversation}
+            columns={columns}
+            isLoading={session.isLoading}
+            error={session.error}
+            onSendMessage={handleSendMessage}
+            onUpdateRow={session.updateRow}
+            onAddRow={session.addRow}
+            onDeleteRows={session.deleteRows}
+            onToggleLock={session.toggleLock}
+            onBack={handleBack}
+            onAccept={handleAcceptRows}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/genai-engine/ui/src/components/datasets/synthetic/SyntheticDataTable.tsx
+++ b/genai-engine/ui/src/components/datasets/synthetic/SyntheticDataTable.tsx
@@ -1,0 +1,328 @@
+import { Add, Delete, Lock, LockOpen } from "@mui/icons-material";
+import {
+  Box,
+  Button,
+  Checkbox,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import React, { useCallback, useState } from "react";
+
+import type { SyntheticRow } from "./types";
+
+interface SyntheticDataTableProps {
+  rows: SyntheticRow[];
+  columns: string[];
+  onUpdateRow: (id: string, data: Record<string, string>) => void;
+  onAddRow: (data: Record<string, string>) => void;
+  onDeleteRows: (ids: string[]) => void;
+  onToggleLock: (id: string) => void;
+}
+
+export const SyntheticDataTable: React.FC<SyntheticDataTableProps> = ({
+  rows,
+  columns,
+  onUpdateRow,
+  onAddRow,
+  onDeleteRows,
+  onToggleLock,
+}) => {
+  const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
+  const [editingCell, setEditingCell] = useState<{
+    rowId: string;
+    column: string;
+  } | null>(null);
+  const [editValue, setEditValue] = useState("");
+
+  const handleSelectAll = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        // Only select unlocked rows
+        setSelectedRows(new Set(rows.filter((r) => !r.locked).map((r) => r.id)));
+      } else {
+        setSelectedRows(new Set());
+      }
+    },
+    [rows]
+  );
+
+  const handleSelectRow = useCallback((rowId: string, checked: boolean) => {
+    setSelectedRows((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(rowId);
+      } else {
+        next.delete(rowId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleDeleteSelected = useCallback(() => {
+    onDeleteRows(Array.from(selectedRows));
+    setSelectedRows(new Set());
+  }, [selectedRows, onDeleteRows]);
+
+  const handleCellClick = useCallback(
+    (rowId: string, column: string, currentValue: string, isLocked: boolean) => {
+      // Prevent editing locked rows
+      if (isLocked) return;
+
+      setEditingCell({ rowId, column });
+      setEditValue(currentValue);
+    },
+    []
+  );
+
+  const handleCellBlur = useCallback(() => {
+    if (editingCell) {
+      const row = rows.find((r) => r.id === editingCell.rowId);
+      if (row) {
+        const newData = { ...row.data, [editingCell.column]: editValue };
+        onUpdateRow(editingCell.rowId, newData);
+      }
+    }
+    setEditingCell(null);
+    setEditValue("");
+  }, [editingCell, editValue, rows, onUpdateRow]);
+
+  const handleCellKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleCellBlur();
+      } else if (e.key === "Escape") {
+        setEditingCell(null);
+        setEditValue("");
+      }
+    },
+    [handleCellBlur]
+  );
+
+  const handleAddRow = useCallback(() => {
+    const emptyRow: Record<string, string> = {};
+    columns.forEach((col) => {
+      emptyRow[col] = "";
+    });
+    onAddRow(emptyRow);
+  }, [columns, onAddRow]);
+
+  const unlockedRows = rows.filter((r) => !r.locked);
+  const allSelected = unlockedRows.length > 0 && selectedRows.size === unlockedRows.length;
+  const someSelected = selectedRows.size > 0 && selectedRows.size < unlockedRows.length;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        overflow: "hidden",
+      }}
+    >
+      {/* Toolbar */}
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          p: 2,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
+        <Typography variant="subtitle2">
+          Generated Data ({rows.length} row{rows.length !== 1 ? "s" : ""})
+        </Typography>
+        <Box sx={{ display: "flex", gap: 1 }}>
+          {selectedRows.size > 0 && (
+            <Button
+              size="small"
+              color="error"
+              startIcon={<Delete />}
+              onClick={handleDeleteSelected}
+            >
+              Delete ({selectedRows.size})
+            </Button>
+          )}
+          <Button size="small" startIcon={<Add />} onClick={handleAddRow}>
+            Add Row
+          </Button>
+        </Box>
+      </Box>
+
+      {/* Table */}
+      <TableContainer sx={{ flex: 1, overflow: "auto" }}>
+        {rows.length === 0 ? (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              height: "100%",
+              color: "text.secondary",
+            }}
+          >
+            <Typography variant="body2">
+              No data generated yet. Use the chat to generate or refine data.
+            </Typography>
+          </Box>
+        ) : (
+          <Table size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell padding="checkbox" sx={{ bgcolor: "grey.100" }}>
+                  <Checkbox
+                    checked={allSelected}
+                    indeterminate={someSelected}
+                    onChange={(e) => handleSelectAll(e.target.checked)}
+                  />
+                </TableCell>
+                <TableCell
+                  sx={{
+                    fontWeight: "bold",
+                    bgcolor: "grey.100",
+                    width: 60,
+                  }}
+                >
+                  Lock
+                </TableCell>
+                {columns.map((column) => (
+                  <TableCell
+                    key={column}
+                    sx={{
+                      fontWeight: "bold",
+                      bgcolor: "grey.100",
+                      minWidth: 150,
+                    }}
+                  >
+                    {column}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  hover
+                  selected={selectedRows.has(row.id)}
+                  sx={{
+                    bgcolor:
+                      row.locked
+                        ? "grey.100"
+                        : row.status === "added"
+                          ? "success.50"
+                          : row.status === "modified"
+                            ? "warning.50"
+                            : "inherit",
+                    opacity: row.locked ? 0.7 : 1,
+                  }}
+                >
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={selectedRows.has(row.id)}
+                      onChange={(e) => handleSelectRow(row.id, e.target.checked)}
+                      disabled={row.locked}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Tooltip title={row.locked ? "Unlock row" : "Lock row"}>
+                      <IconButton
+                        size="small"
+                        onClick={() => onToggleLock(row.id)}
+                        color={row.locked ? "primary" : "default"}
+                      >
+                        {row.locked ? <Lock fontSize="small" /> : <LockOpen fontSize="small" />}
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                  {columns.map((column) => {
+                    const isEditing =
+                      editingCell?.rowId === row.id &&
+                      editingCell?.column === column;
+                    const value = row.data[column] || "";
+
+                    return (
+                      <TableCell key={column}>
+                        {isEditing ? (
+                          <TextField
+                            autoFocus
+                            size="small"
+                            value={editValue}
+                            onChange={(e) => setEditValue(e.target.value)}
+                            onBlur={handleCellBlur}
+                            onKeyDown={handleCellKeyDown}
+                            fullWidth
+                            multiline
+                            maxRows={4}
+                            variant="outlined"
+                            sx={{
+                              "& .MuiOutlinedInput-root": {
+                                fontSize: "0.875rem",
+                              },
+                            }}
+                          />
+                        ) : (
+                          <Tooltip
+                            title={
+                              row.locked
+                                ? "Unlock row to edit"
+                                : value.length > 100
+                                  ? value
+                                  : ""
+                            }
+                            placement="top"
+                          >
+                            <Box
+                              onClick={() =>
+                                handleCellClick(row.id, column, value, !!row.locked)
+                              }
+                              sx={{
+                                cursor: row.locked ? "not-allowed" : "pointer",
+                                p: 0.5,
+                                borderRadius: 1,
+                                "&:hover": {
+                                  bgcolor: row.locked ? "transparent" : "action.hover",
+                                },
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                                maxWidth: 300,
+                              }}
+                            >
+                              <Typography variant="body2" noWrap>
+                                {value || (
+                                  <Typography
+                                    component="span"
+                                    variant="body2"
+                                    color="text.secondary"
+                                    fontStyle="italic"
+                                  >
+                                    Click to edit
+                                  </Typography>
+                                )}
+                              </Typography>
+                            </Box>
+                          </Tooltip>
+                        )}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </TableContainer>
+    </Box>
+  );
+};

--- a/genai-engine/ui/src/components/datasets/synthetic/types.ts
+++ b/genai-engine/ui/src/components/datasets/synthetic/types.ts
@@ -1,0 +1,18 @@
+import type { ModelProvider } from "@/lib/api-client/api-client";
+
+export interface GenerationConfig {
+  datasetPurpose: string;
+  columnDescriptions: { columnName: string; description: string }[];
+  numRows: number;
+  modelProvider: ModelProvider;
+  modelName: string;
+  temperature?: number;
+  editExisting?: boolean;
+}
+
+export interface SyntheticRow {
+  id: string;
+  data: Record<string, string>;
+  status: "generated" | "modified" | "added";
+  locked?: boolean;
+}

--- a/genai-engine/ui/src/hooks/datasets/useSyntheticDataSession.ts
+++ b/genai-engine/ui/src/hooks/datasets/useSyntheticDataSession.ts
@@ -1,0 +1,313 @@
+import { useCallback, useState } from "react";
+
+import type { GenerationConfig, SyntheticRow } from "@/components/datasets/synthetic/types";
+import { useApi } from "@/hooks/useApi";
+import type {
+  OpenAIMessageInput,
+  SyntheticDataRowResponse,
+  NewDatasetVersionRowColumnItemRequest,
+  DatasetVersionRowResponse,
+} from "@/lib/api-client/api-client";
+import { generateTempRowId } from "@/utils/datasetRowUtils";
+
+export type { GenerationConfig, SyntheticRow };
+
+export interface UseSyntheticDataSessionReturn {
+  // State
+  rows: SyntheticRow[];
+  conversation: OpenAIMessageInput[];
+  isLoading: boolean;
+  error: Error | null;
+
+  // Initial generation
+  startGeneration: (config: GenerationConfig, existingRowsSample?: DatasetVersionRowResponse[]) => Promise<void>;
+
+  // Conversation
+  sendMessage: (message: string, config: GenerationConfig) => Promise<void>;
+
+  // Manual edits
+  updateRow: (id: string, data: Record<string, string>) => void;
+  addRow: (data: Record<string, string>) => void;
+  deleteRows: (ids: string[]) => void;
+  toggleLock: (id: string) => void;
+
+  // Session management
+  reset: () => void;
+}
+
+function datasetVersionRowsToSyntheticRows(
+  datasetRows: DatasetVersionRowResponse[]
+): SyntheticRow[] {
+  return datasetRows.map((datasetRow) => {
+    const data: Record<string, string> = {};
+    datasetRow.data.forEach((col) => {
+      data[col.column_name] = col.column_value;
+    });
+
+    return {
+      id: datasetRow.id,
+      data,
+      status: "generated" as const,
+    };
+  });
+}
+
+function apiRowsToSyntheticRows(
+  apiRows: SyntheticDataRowResponse[],
+  rowsAdded: string[],
+  rowsModified: string[],
+  existingRows: SyntheticRow[]
+): SyntheticRow[] {
+  const rowsAddedSet = new Set(rowsAdded);
+  const rowsModifiedSet = new Set(rowsModified);
+  const existingRowMap = new Map(existingRows.map((r) => [r.id, r]));
+
+  return apiRows.map((apiRow) => {
+    // If this row exists and is locked, keep it unchanged
+    const existingRow = existingRowMap.get(apiRow.id);
+    if (existingRow?.locked) {
+      return existingRow;
+    }
+
+    const data: Record<string, string> = {};
+    apiRow.data.forEach((col) => {
+      data[col.column_name] = col.column_value;
+    });
+
+    let status: SyntheticRow["status"] = "generated";
+    if (rowsAddedSet.has(apiRow.id)) {
+      status = "generated";
+    } else if (rowsModifiedSet.has(apiRow.id)) {
+      status = "modified";
+    } else {
+      // Keep existing status if row wasn't changed
+      if (existingRow) {
+        status = existingRow.status;
+      }
+    }
+
+    return {
+      id: apiRow.id,
+      data,
+      status,
+      locked: existingRow?.locked,
+    };
+  });
+}
+
+function syntheticRowsToApiFormat(
+  rows: SyntheticRow[]
+): { data: NewDatasetVersionRowColumnItemRequest[] }[] {
+  return rows.map((row) => ({
+    data: Object.entries(row.data).map(([column_name, column_value]) => ({
+      column_name,
+      column_value,
+    })),
+  }));
+}
+
+export function useSyntheticDataSession(
+  datasetId: string,
+  versionNumber: number,
+  _columns: string[]
+): UseSyntheticDataSessionReturn {
+  const api = useApi();
+
+  const [rows, setRows] = useState<SyntheticRow[]>([]);
+  const [conversation, setConversation] = useState<OpenAIMessageInput[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const startGeneration = useCallback(
+    async (config: GenerationConfig, existingRowsSample?: DatasetVersionRowResponse[]) => {
+      if (!api) {
+        setError(new Error("API client not available"));
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        // If editExisting is enabled and we have existing rows, load them into the canvas first
+        if (config.editExisting && existingRowsSample && existingRowsSample.length > 0) {
+          const existingRows = datasetVersionRowsToSyntheticRows(existingRowsSample);
+          setRows(existingRows);
+
+          // Initialize conversation without calling the API - just show the existing data
+          setConversation([
+            {
+              role: "assistant",
+              content: `I've loaded ${existingRows.length} existing row${existingRows.length !== 1 ? 's' : ''} from your dataset. You can now edit them directly in the table, or ask me to modify or generate additional data.`,
+            },
+          ]);
+        } else {
+          // Generate new data
+          const response =
+            await api.api.generateSyntheticDataApiV2DatasetsDatasetIdVersionsVersionNumberGenerateSyntheticPost(
+              datasetId,
+              versionNumber,
+              {
+                dataset_purpose: config.datasetPurpose,
+                column_descriptions: config.columnDescriptions.map((col) => ({
+                  column_name: col.columnName,
+                  description: col.description,
+                })),
+                num_rows: config.numRows,
+                model_provider: config.modelProvider,
+                model_name: config.modelName,
+                config: config.temperature
+                  ? { temperature: config.temperature }
+                  : undefined,
+              }
+            );
+
+          const newRows = apiRowsToSyntheticRows(
+            response.data.rows,
+            response.data.rows_added ?? [],
+            response.data.rows_modified ?? [],
+            []
+          );
+          setRows(newRows);
+
+          // Initialize conversation with the assistant's response
+          setConversation([
+            {
+              role: "assistant",
+              content: response.data.assistant_message.content as string,
+            },
+          ]);
+        }
+      } catch (err) {
+        console.error("Failed to generate synthetic data:", err);
+        setError(err as Error);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [api, datasetId, versionNumber]
+  );
+
+  const sendMessage = useCallback(
+    async (message: string, config: GenerationConfig) => {
+      if (!api) {
+        setError(new Error("API client not available"));
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        // Add user message to conversation first
+        const userMessage: OpenAIMessageInput = {
+          role: "user",
+          content: message,
+        };
+        const updatedConversation = [...conversation, userMessage];
+
+        const response =
+          await api.api.sendSyntheticDataMessageApiV2DatasetsDatasetIdVersionsVersionNumberGenerateSyntheticMessagePost(
+            datasetId,
+            versionNumber,
+            {
+              message,
+              current_rows: syntheticRowsToApiFormat(rows),
+              conversation_history: updatedConversation,
+              dataset_purpose: config.datasetPurpose,
+              column_descriptions: config.columnDescriptions.map((col) => ({
+                column_name: col.columnName,
+                description: col.description,
+              })),
+              model_provider: config.modelProvider,
+              model_name: config.modelName,
+              config: config.temperature
+                ? { temperature: config.temperature }
+                : undefined,
+            }
+          );
+
+        const newRows = apiRowsToSyntheticRows(
+          response.data.rows,
+          response.data.rows_added ?? [],
+          response.data.rows_modified ?? [],
+          rows
+        );
+        setRows(newRows);
+
+        // Add assistant response to conversation
+        setConversation([
+          ...updatedConversation,
+          {
+            role: "assistant",
+            content: response.data.assistant_message.content as string,
+          },
+        ]);
+      } catch (err) {
+        console.error("Failed to send message:", err);
+        setError(err as Error);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [api, datasetId, versionNumber, rows, conversation]
+  );
+
+  const updateRow = useCallback(
+    (id: string, data: Record<string, string>) => {
+      setRows((prevRows) =>
+        prevRows.map((row) =>
+          row.id === id
+            ? { ...row, data, status: "modified" as const }
+            : row
+        )
+      );
+    },
+    []
+  );
+
+  const addRow = useCallback(
+    (data: Record<string, string>) => {
+      const newRow: SyntheticRow = {
+        id: generateTempRowId(),
+        data,
+        status: "added",
+      };
+      setRows((prevRows) => [...prevRows, newRow]);
+    },
+    []
+  );
+
+  const deleteRows = useCallback((ids: string[]) => {
+    const idsSet = new Set(ids);
+    setRows((prevRows) => prevRows.filter((row) => !idsSet.has(row.id)));
+  }, []);
+
+  const toggleLock = useCallback((id: string) => {
+    setRows((prevRows) =>
+      prevRows.map((row) =>
+        row.id === id ? { ...row, locked: !row.locked } : row
+      )
+    );
+  }, []);
+
+  const reset = useCallback(() => {
+    setRows([]);
+    setConversation([]);
+    setError(null);
+  }, []);
+
+  return {
+    rows,
+    conversation,
+    isLoading,
+    error,
+    startGeneration,
+    sendMessage,
+    updateRow,
+    addRow,
+    deleteRows,
+    toggleLock,
+    reset,
+  };
+}


### PR DESCRIPTION
- Remove temperature slider from initial creation modal
- Add toggle to edit existing dataset rows in canvas view
- Add row locking functionality to prevent updates
  - Locked rows cannot be edited manually
  - Locked rows are not updated by synthetic generation
  - Visual indicators for locked state (lock icon, grayed out)
- Update session hook to preserve locked rows during regeneration
- Load existing rows into canvas when edit mode is enabled