### PR TITLE
CEs error when missing variables but skip when missing spans

### DIFF
--- a/genai-engine/src/api_changelog.md
+++ b/genai-engine/src/api_changelog.md
@@ -2,6 +2,9 @@ The intention of this changelog is to document API changes as they happen to eff
 
 ---
 
+# 01/22/2026
+- **CHANGE** for **URL**: /api/v1/traces/{trace_id}/transforms/{transform_id}/extractions  added the required property 'missing_spans' to the response with the '200' status
+
 # 01/16/2026
 - **BREAKING CHANGE** for **URL**: /api/v1/agentic_experiments/{experiment_id}  the 'http_template/request_body' response's property type/format changed from 'object'/'' to 'string'/'' for status '200'
 - **BREAKING CHANGE** for **URL**: /api/v1/agentic_experiments/{experiment_id}/notebook  the 'http_template/request_body' response's property type/format changed from 'object'/'' to 'string'/'' for status '200'

--- a/genai-engine/src/schemas/response_schemas.py
+++ b/genai-engine/src/schemas/response_schemas.py
@@ -742,6 +742,9 @@ class TransformExtractionResponseList(BaseModel):
     missing_variables: List[str] = Field(
         description="List of variable names that had missing values (no matching span or attribute path).",
     )
+    missing_spans: list[str] = Field(
+        description="List of matching spans for the variables.",
+    )
 
 
 class ContinuousEvalVariableMappingResponse(BaseModel):

--- a/genai-engine/src/services/continuous_eval/continuous_eval_queue_service.py
+++ b/genai-engine/src/services/continuous_eval/continuous_eval_queue_service.py
@@ -254,11 +254,19 @@ class ContinuousEvalQueueService:
 
             # Execute the transform over the trace
             transform_results = execute_transform(trace, trace_transform.definition)
-            if len(transform_results.missing_variables) > 0:
+            if len(transform_results.missing_spans) > 0:
                 self._update_annotation_status(
                     db_session,
                     job.annotation_id,
                     ContinuousEvalRunStatus.SKIPPED.value,
+                    annotation_description=f"Spans {', '.join(transform_results.missing_spans)} not found in trace {job.trace_id} skipping continuous eval execution for eval {job.continuous_eval_id}",
+                )
+                return
+            if len(transform_results.missing_variables) > 0:
+                self._update_annotation_status(
+                    db_session,
+                    job.annotation_id,
+                    ContinuousEvalRunStatus.ERROR.value,
                     annotation_description=f"Could not extract variables: {', '.join(transform_results.missing_variables)} using transform {continuous_eval.transform_id} on trace {job.trace_id}",
                 )
                 return

--- a/genai-engine/src/utils/transform_executor.py
+++ b/genai-engine/src/utils/transform_executor.py
@@ -84,6 +84,7 @@ def execute_transform(
         flat_spans.extend(_flatten_spans(span))
 
     variables = []
+    missing_spans = []
     missing_variables = []
 
     # Iterate through variable definitions
@@ -99,9 +100,11 @@ def execute_transform(
         is_missing = False
         if not matching_spans:
             # No matching span found, use fallback
-            value = fallback if fallback is not None else ""
             if fallback is None:
-                is_missing = True
+                missing_spans.append(span_name)
+                value = ""
+            else:
+                value = fallback
         else:
             # Use the first matching span
             span = matching_spans[0]
@@ -126,4 +129,5 @@ def execute_transform(
     return TransformExtractionResponseList(
         variables=variables,
         missing_variables=missing_variables,
+        missing_spans=missing_spans,
     )

--- a/genai-engine/staging.openapi.json
+++ b/genai-engine/staging.openapi.json
@@ -27713,12 +27713,21 @@
                         "type": "array",
                         "title": "Missing Variables",
                         "description": "List of variable names that had missing values (no matching span or attribute path)."
+                    },
+                    "missing_spans": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Missing Spans",
+                        "description": "List of matching spans for the variables."
                     }
                 },
                 "type": "object",
                 "required": [
                     "variables",
-                    "missing_variables"
+                    "missing_variables",
+                    "missing_spans"
                 ],
                 "title": "TransformExtractionResponseList"
             },

--- a/genai-engine/tests/routes/trace_api/test_continuous_eval_execution.py
+++ b/genai-engine/tests/routes/trace_api/test_continuous_eval_execution.py
@@ -952,7 +952,7 @@ def test_continuous_eval_execution_transform_errors(
         run_status=ContinuousEvalRunStatus.PENDING,
     )
 
-    # test executing for a non-existent trace variables
+    # test executing for a missing span should skip
     job = ContinuousEvalJob(
         annotation_id=annotation.id,
         trace_id=test_data["trace_id"],
@@ -964,6 +964,68 @@ def test_continuous_eval_execution_transform_errors(
     status_code, received_annotation = client.get_annotation_by_id(annotation.id)
     assert status_code == 200
     assert received_annotation.run_status == ContinuousEvalRunStatus.SKIPPED.value
+    assert (
+        received_annotation.annotation_description
+        == f"Spans api_test_span not found in trace {test_data['trace_id']} skipping continuous eval execution for eval {bad_continuous_eval.id}"
+    )
+
+    delete_mock_annotation(annotation.id)
+
+    transform_definition = {
+        "variables": [
+            {
+                "variable_name": "model_name",
+                "span_name": "rag-retrieval-savedQueries",
+                "attribute_path": "fake_path",
+            },
+        ],
+    }
+    status_code, incorrect_transform = client.create_transform(
+        task_id=agentic_task.id,
+        name="incorrect_transform",
+        description="Test transform description",
+        definition=transform_definition,
+    )
+    assert status_code == 200
+
+    status_code, bad_continuous_eval = client.save_continuous_eval(
+        task_id=agentic_task.id,
+        continuous_eval_data={
+            "name": "test_continuous_eval",
+            "description": "Test continuous eval description",
+            "llm_eval_name": "test_llm_eval",
+            "llm_eval_version": 1,
+            "transform_id": str(incorrect_transform.id),
+            "transform_variable_mapping": [
+                {
+                    "transform_variable": "model_name",
+                    "eval_variable": "model_name",
+                },
+            ],
+        },
+    )
+    assert status_code == 200
+
+    # create a real mock annotation
+    annotation = create_mock_annotation(
+        trace_id=test_data["trace_id"],
+        annotation_type=AgenticAnnotationType.CONTINUOUS_EVAL,
+        continuous_eval_id=bad_continuous_eval.id,
+        run_status=ContinuousEvalRunStatus.PENDING,
+    )
+
+    # test executing for a missing variables should error
+    job = ContinuousEvalJob(
+        annotation_id=annotation.id,
+        trace_id=test_data["trace_id"],
+        continuous_eval_id=bad_continuous_eval.id,
+        task_id=test_data["task_id"],
+        delay_seconds=0,
+    )
+    continuous_eval_queue_service._execute_job(job)
+    status_code, received_annotation = client.get_annotation_by_id(annotation.id)
+    assert status_code == 200
+    assert received_annotation.run_status == ContinuousEvalRunStatus.ERROR.value
     assert (
         received_annotation.annotation_description
         == f"Could not extract variables: model_name using transform {incorrect_transform.id} on trace {test_data['trace_id']}"


### PR DESCRIPTION
## Description
Changed the CE Skip vs Error logic:
- Previously, if any variables were unable to be extracted or spans not found we marked the CE as Skipped
- Now, if any variables are unable to be extracted we report it as an error, but if the span was not found we mark the CE as Skipped
***Note: If a transform variable has a fallback value we will not skip or error a CE. It will use the fallback value***

## Jira Ticket
- https://arthurai.atlassian.net/browse/UP-3637