### PR TITLE
Fix Add Row dialog not clearing form fields after submission

### DIFF
--- a/genai-engine/ui/src/components/datasets/EditRowModal.tsx
+++ b/genai-engine/ui/src/components/datasets/EditRowModal.tsx
@@ -26,6 +26,7 @@ export const EditRowModal: React.FC<EditRowModalProps> = ({ open, onClose, onSub
     defaultValues: stringData,
     onSubmit: async ({ value }) => {
       await onSubmit(value);
+      form.reset();
     },
   });
 


### PR DESCRIPTION
## Summary
- Fix the "Add Row" dialog in Datasets to clear form fields after clicking "Apply", so users don't have to manually delete the previous row's data before entering new data

## Details
The `EditRowModal` uses `@tanstack/react-form`'s `useForm` with `defaultValues` set on initial mount. When adding rows, the `rowId` is always `"new"`, so the `key` on the `<form>` element never changes and React doesn't remount it — leaving previous values in the fields. Adding `form.reset()` after successful submission clears all fields back to defaults.

## Test plan
- [x] Open a dataset with columns defined
- [x] Click "+ Add Row" and fill in data for each column
- [x] Click "Apply" to add the row
- [x] Click "+ Add Row" again — verify all fields are now empty
- [x] Confirm editing existing rows still pre-fills correctly

🤖 Generated with [Claude Code](https://claude.ai/code)