### PR TITLE
Add count to transforms list endpoint response

### DIFF
--- a/genai-engine/src/repositories/trace_transform_repository.py
+++ b/genai-engine/src/repositories/trace_transform_repository.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List
+from typing import List, Tuple
 from uuid import UUID
 
 from arthur_common.models.common_schemas import PaginationParameters
@@ -79,7 +79,7 @@ class TraceTransformRepository:
         task_id: str,
         pagination_parameters: PaginationParameters,
         filter_request: TransformListFilterRequest,
-    ) -> List[TraceTransform]:
+    ) -> Tuple[List[TraceTransform], int]:
         base_query = self.db_session.query(DatabaseTraceTransform).filter(
             DatabaseTraceTransform.task_id == task_id,
         )
@@ -98,6 +98,9 @@ class TraceTransformRepository:
                 DatabaseTraceTransform.created_at < filter_request.created_before,
             )
 
+        # Get total count before pagination
+        total_count = base_query.count()
+
         base_query = self._apply_sorting_pagination_and_count(
             base_query,
             pagination_parameters,
@@ -110,7 +113,7 @@ class TraceTransformRepository:
         for db_transform in db_transforms:
             transforms.append(TraceTransform.from_db_model(db_transform))
 
-        return transforms
+        return transforms, total_count
 
     def create_transform(
         self,

--- a/genai-engine/src/routers/v1/transform_routes.py
+++ b/genai-engine/src/routers/v1/transform_routes.py
@@ -64,13 +64,14 @@ def list_transforms_for_task(
 ) -> ListTraceTransformsResponse:
     try:
         trace_transform_repo = TraceTransformRepository(db_session)
-        transforms = trace_transform_repo.list_transforms(
+        transforms, count = trace_transform_repo.list_transforms(
             task.id,
             pagination_parameters,
             filter_request,
         )
         return ListTraceTransformsResponse(
             transforms=[transform.to_response_model() for transform in transforms],
+            count=count,
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/genai-engine/tests/unit/routes/transforms/test_transform_crud.py
+++ b/genai-engine/tests/unit/routes/transforms/test_transform_crud.py
@@ -165,6 +165,8 @@ def test_list_all_transforms_success(
         status_code, retrieved_transforms = client.list_transforms(task_id=task.id)
         assert status_code == 200
         assert len(retrieved_transforms.transforms) == 10
+        # TODO: Uncomment once arthur-common is updated with count field
+        # assert retrieved_transforms.count == 10
 
         for i, transform in enumerate(retrieved_transforms.transforms):
             assert transform.id == transforms[i].id
@@ -223,6 +225,9 @@ def test_list_all_transforms_pagination(
         )
         assert status_code == 200
         assert len(retrieved_transforms.transforms) == 5
+        # TODO: Uncomment once arthur-common is updated with count field
+        # Count should still reflect total matching transforms, not page size
+        # assert retrieved_transforms.count == 10
 
         for i, transform in enumerate(retrieved_transforms.transforms):
             assert transform.id == transforms[i].id


### PR DESCRIPTION
## Summary
- Updates the transforms list endpoint to return `count` alongside the paginated transforms list
- This enables proper pagination UI without over-fetching data

## Changes
- `trace_transform_repository.py`: Update `list_transforms()` to return tuple of (transforms, total_count)
- `transform_routes.py`: Pass count to `ListTraceTransformsResponse`
- `test_transform_crud.py`: Add test placeholders for count verification (commented until arthur-common is updated)

## Dependencies
**This PR depends on** [arthur-ai/arthur-common#92](https://github.com/arthur-ai/arthur-common/pull/92) being merged and a new version published.

The CI will fail until the arthur-common dependency is updated with the new `count` field.

## Test plan
- [x] Transform CRUD tests pass locally (11 tests)
- [ ] CI will pass once arthur-common is updated
- [ ] Manual testing after dependency update

🤖 Generated with [Claude Code](https://claude.com/claude-code)