### PR TITLE
UP-3778 Broken Config

### DIFF
--- a/genai-engine/src/metrics_engine.py
+++ b/genai-engine/src/metrics_engine.py
@@ -48,6 +48,7 @@ class MetricsEngine:
         num_threads = int(
             get_env_var(
                 constants.GENAI_ENGINE_THREAD_POOL_MAX_WORKERS_ENV_VAR,
+                none_on_missing=True,
             )
             or constants.DEFAULT_THREAD_POOL_MAX_WORKERS,
         )

--- a/genai-engine/src/rules_engine.py
+++ b/genai-engine/src/rules_engine.py
@@ -86,6 +86,7 @@ class RuleEngine:
         num_threads = int(
             get_env_var(
                 constants.GENAI_ENGINE_THREAD_POOL_MAX_WORKERS_ENV_VAR,
+                none_on_missing=True,
             )
             or constants.DEFAULT_THREAD_POOL_MAX_WORKERS,
         )


### PR DESCRIPTION
[UP-3778](https://arthurai.atlassian.net/browse/UP-3778)

The following error is breaking the API call: `ValueError: Environment variable GENAI_ENGINE_THREAD_POOL_MAX_WORKERS not defined`

Since the env variable isn't defined the call to get_env_var will fail and throw an error instead of continuing the parent logic to use the DEFAULT_THREAD_POOL_MAX_WORKERS=... value. Changed the function invocation to allow NONE

**THROWS ERROR**
<img width="589" height="245" alt="Screenshot 2026-02-13 at 14 13 15" src="https://github.com/user-attachments/assets/0bd53fce-df00-415b-b7d9-4ca8363b8f8d" />

**DOESN'T HIT THE OR**
<img width="589" height="245" alt="Screenshot 2026-02-13 at 14 15 49" src="https://github.com/user-attachments/assets/838db3de-b750-48ff-9f5d-95c7bff89304" />

