### PR TITLE
Replace Tailwind dark mode classes with MUI theme colors

### DIFF
--- a/genai-engine/ui/src/components/TraceDetailsPanel.tsx
+++ b/genai-engine/ui/src/components/TraceDetailsPanel.tsx
@@ -1,4 +1,6 @@
 import { OpenInferenceSpanKind, SemanticConventions } from "@arizeai/openinference-semantic-conventions";
+import Chip from "@mui/material/Chip";
+import { alpha, type Theme, useTheme } from "@mui/material/styles";
 import { motion, AnimatePresence } from "framer-motion";
 import React, { useState, useEffect } from "react";
 
@@ -47,6 +49,7 @@ const getSpanTotalCost = (span: NestedSpanWithMetricsResponse) => {
 };
 
 const SpanNode: React.FC<SpanNodeProps> = ({ span, level, onSpanClick, selectedSpanId }) => {
+  const theme = useTheme();
   const [isExpanded, setIsExpanded] = useState(true);
   const hasChildren = span.children && span.children.length > 0;
   const isSelected = span.span_id === selectedSpanId;
@@ -92,29 +95,19 @@ const SpanNode: React.FC<SpanNodeProps> = ({ span, level, onSpanClick, selectedS
     return null;
   };
 
-  const getSpanTypeColor = (spanType: string | null) => {
-    switch (spanType) {
-      case OpenInferenceSpanKind.LLM:
-        return "text-blue-600 dark:text-blue-400";
-      case OpenInferenceSpanKind.RETRIEVER:
-        return "text-green-600 dark:text-green-400";
-      case OpenInferenceSpanKind.EMBEDDING:
-        return "text-purple-600 dark:text-purple-400";
-      case OpenInferenceSpanKind.CHAIN:
-        return "text-orange-600 dark:text-orange-400";
-      case OpenInferenceSpanKind.AGENT:
-        return "text-red-600 dark:text-red-400";
-      case OpenInferenceSpanKind.TOOL:
-        return "text-yellow-600 dark:text-yellow-400";
-      case OpenInferenceSpanKind.RERANKER:
-        return "text-indigo-600 dark:text-indigo-400";
-      case OpenInferenceSpanKind.GUARDRAIL:
-        return "text-red-700 dark:text-red-400";
-      case OpenInferenceSpanKind.EVALUATOR:
-        return "text-green-700 dark:text-green-400";
-      default:
-        return "text-gray-600 dark:text-gray-400";
-    }
+  const getSpanTypeColor = (theme: Theme, spanType: string | null): string => {
+    const colorMap: Record<string, string> = {
+      [OpenInferenceSpanKind.LLM]: theme.palette.info.main,
+      [OpenInferenceSpanKind.RETRIEVER]: theme.palette.success.main,
+      [OpenInferenceSpanKind.EMBEDDING]: theme.palette.secondary.main,
+      [OpenInferenceSpanKind.CHAIN]: theme.palette.warning.main,
+      [OpenInferenceSpanKind.AGENT]: theme.palette.error.main,
+      [OpenInferenceSpanKind.TOOL]: theme.palette.warning.light,
+      [OpenInferenceSpanKind.RERANKER]: theme.palette.primary.main,
+      [OpenInferenceSpanKind.GUARDRAIL]: theme.palette.error.dark,
+      [OpenInferenceSpanKind.EVALUATOR]: theme.palette.success.dark,
+    };
+    return spanType ? (colorMap[spanType] ?? theme.palette.text.secondary) : theme.palette.text.secondary;
   };
 
   const inputTokens = getInputTokens(span);
@@ -130,7 +123,21 @@ const SpanNode: React.FC<SpanNodeProps> = ({ span, level, onSpanClick, selectedS
       >
         <div className="flex-1 cursor-pointer flex items-center" onClick={() => onSpanClick(span)}>
           {spanType && (
-            <span className={`mr-2 text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 ${getSpanTypeColor(spanType)}`}>{spanType}</span>
+            <Chip
+              label={spanType}
+              size="small"
+              sx={{
+                mr: 1,
+                height: 20,
+                fontSize: "0.75rem",
+                color: getSpanTypeColor(theme, spanType),
+                backgroundColor: (theme) => alpha(getSpanTypeColor(theme, spanType), 0.12),
+                "& .MuiChip-label": {
+                  px: 1,
+                  py: 0,
+                },
+              }}
+            />
           )}
           <span className="text-gray-900 dark:text-gray-100 font-medium">{span.span_name}</span>
           <span className="text-gray-600 dark:text-gray-400 ml-2">({formatDuration(span.start_time, span.end_time)})</span>

--- a/genai-engine/ui/src/components/prompt-experiments/ExperimentResultsTable.tsx
+++ b/genai-engine/ui/src/components/prompt-experiments/ExperimentResultsTable.tsx
@@ -168,7 +168,7 @@ const TestCaseDetailModal: React.FC<TestCaseDetailModalProps> = ({
         <Box className="p-6">
           {/* Input Variables Section */}
           <Box className="mb-6">
-            <Typography variant="h6" className="font-bold mb-4 pb-2 border-b-2 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100">
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 2, pb: 1, borderBottom: 2, borderColor: "divider", color: "text.primary" }}>
               Input Variables
             </Typography>
             <Box className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -180,7 +180,7 @@ const TestCaseDetailModal: React.FC<TestCaseDetailModalProps> = ({
 
           {/* Prompt Results Section */}
           <Box>
-            <Typography variant="h6" className="font-bold mb-4 pb-2 border-b-2 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100">
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 2, pb: 1, borderBottom: 2, borderColor: "divider", color: "text.primary" }}>
               Prompt Results
             </Typography>
             <Box className="space-y-4">
@@ -216,8 +216,16 @@ const TestCaseDetailModal: React.FC<TestCaseDetailModalProps> = ({
                               } catch {
                                 // If not JSON, display as plain text
                                 return (
-                                  <Box className="p-3 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded">
-                                    <Typography variant="body2" className="whitespace-pre-wrap text-gray-900 dark:text-gray-100">
+                                  <Box
+                                    sx={{
+                                      p: 1.5,
+                                      backgroundColor: "action.hover",
+                                      border: 1,
+                                      borderColor: "divider",
+                                      borderRadius: 1,
+                                    }}
+                                  >
+                                    <Typography variant="body2" sx={{ whiteSpace: "pre-wrap", color: "text.primary" }}>
                                       {promptResult.rendered_prompt}
                                     </Typography>
                                   </Box>
@@ -266,8 +274,16 @@ const TestCaseDetailModal: React.FC<TestCaseDetailModalProps> = ({
                                 )}
                               </>
                             ) : (
-                              <Box className="p-3 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded">
-                                <Typography variant="body2" className="text-gray-500 italic">
+                              <Box
+                                sx={{
+                                  p: 1.5,
+                                  backgroundColor: "action.hover",
+                                  border: 1,
+                                  borderColor: "divider",
+                                  borderRadius: 1,
+                                }}
+                              >
+                                <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
                                   No output available
                                 </Typography>
                               </Box>

--- a/genai-engine/ui/src/components/prompt-experiments/NotebookExperimentModal.tsx
+++ b/genai-engine/ui/src/components/prompt-experiments/NotebookExperimentModal.tsx
@@ -1250,9 +1250,9 @@ export const NotebookExperimentModal: React.FC<NotebookExperimentModalProps> = (
               const sourceType = mapping?.sourceType || "dataset_column";
 
               return (
-                <Box key={varName} className="border border-gray-300 dark:border-gray-600 rounded p-3">
+                <Box key={varName} sx={{ border: 1, borderColor: "divider", borderRadius: 1, p: 1.5 }}>
                   <Box className="flex items-center justify-between mb-3">
-                    <Typography variant="subtitle2" className="font-medium">
+                    <Typography variant="subtitle2" sx={{ fontWeight: 500 }}>
                       {varName} *
                     </Typography>
 

--- a/genai-engine/ui/src/components/prompt-experiments/PromptResultDetailModal.tsx
+++ b/genai-engine/ui/src/components/prompt-experiments/PromptResultDetailModal.tsx
@@ -137,7 +137,7 @@ export const PromptResultDetailModal: React.FC<PromptResultDetailModalProps> = (
         <Box className="p-6">
           {/* Input Variables Section */}
           <Box className="mb-6">
-            <Typography variant="h6" className="font-bold mb-4 pb-2 border-b-2 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100">
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 2, pb: 1, borderBottom: 2, borderColor: "divider", color: "text.primary" }}>
               Input Variables
             </Typography>
             <Box className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -149,7 +149,7 @@ export const PromptResultDetailModal: React.FC<PromptResultDetailModalProps> = (
 
           {/* Messages: Rendered Prompt and Output */}
           <Box className="mb-6">
-            <Typography variant="h6" className="font-bold mb-4 pb-2 border-b-2 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100">
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 2, pb: 1, borderBottom: 2, borderColor: "divider", color: "text.primary" }}>
               Messages
             </Typography>
             <Box className="grid grid-cols-2 gap-4">
@@ -165,8 +165,16 @@ export const PromptResultDetailModal: React.FC<PromptResultDetailModalProps> = (
                       return messages.map((message, msgIndex) => <MessageDisplay key={msgIndex} message={message} />);
                     } catch {
                       return (
-                        <Box className="p-3 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded">
-                          <Typography variant="body2" className="whitespace-pre-wrap text-gray-900 dark:text-gray-100">
+                        <Box
+                          sx={{
+                            p: 1.5,
+                            backgroundColor: "action.hover",
+                            border: 1,
+                            borderColor: "divider",
+                            borderRadius: 1,
+                          }}
+                        >
+                          <Typography variant="body2" sx={{ whiteSpace: "pre-wrap", color: "text.primary" }}>
                             {renderedPrompt}
                           </Typography>
                         </Box>
@@ -207,8 +215,16 @@ export const PromptResultDetailModal: React.FC<PromptResultDetailModalProps> = (
                       )}
                     </>
                   ) : (
-                    <Box className="p-3 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded">
-                      <Typography variant="body2" className="text-gray-500 dark:text-gray-400 italic">
+                    <Box
+                      sx={{
+                        p: 1.5,
+                        backgroundColor: "action.hover",
+                        border: 1,
+                        borderColor: "divider",
+                        borderRadius: 1,
+                      }}
+                    >
+                      <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
                         No output available
                       </Typography>
                     </Box>
@@ -221,10 +237,7 @@ export const PromptResultDetailModal: React.FC<PromptResultDetailModalProps> = (
           {/* Evals */}
           {evals.length > 0 && (
             <Box>
-              <Typography
-                variant="h6"
-                className="font-bold mb-4 pb-2 border-b-2 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
-              >
+              <Typography variant="h6" sx={{ fontWeight: 700, mb: 2, pb: 1, borderBottom: 2, borderColor: "divider", color: "text.primary" }}>
                 Evaluations
               </Typography>
               <Box className="space-y-2">

--- a/genai-engine/ui/src/components/prompts-playground/prompts/ResultsTable.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/prompts/ResultsTable.tsx
@@ -14,6 +14,7 @@ import IconButton from "@mui/material/IconButton";
 import Modal from "@mui/material/Modal";
 import Paper from "@mui/material/Paper";
 import Snackbar from "@mui/material/Snackbar";
+import { alpha, useTheme } from "@mui/material/styles";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
@@ -42,18 +43,48 @@ interface Message {
 }
 
 const MessageDisplay: React.FC<{ message: Message }> = ({ message }) => {
-  const roleColors: Record<string, string> = {
-    system: "bg-purple-100 dark:bg-purple-900/30 border-purple-300 dark:border-purple-700",
-    user: "bg-blue-100 dark:bg-blue-900/30 border-blue-300 dark:border-blue-700",
-    assistant: "bg-green-100 dark:bg-green-900/30 border-green-300 dark:border-green-700",
+  const theme = useTheme();
+
+  const getRoleStyles = (role: string) => {
+    const styleMap: Record<string, { bgColor: string; borderColor: string }> = {
+      system: {
+        bgColor: alpha(theme.palette.secondary.main, 0.12),
+        borderColor: theme.palette.secondary.main,
+      },
+      user: {
+        bgColor: alpha(theme.palette.info.main, 0.12),
+        borderColor: theme.palette.info.main,
+      },
+      assistant: {
+        bgColor: alpha(theme.palette.success.main, 0.12),
+        borderColor: theme.palette.success.main,
+      },
+    };
+    return (
+      styleMap[role] || {
+        bgColor: theme.palette.action.hover,
+        borderColor: theme.palette.divider,
+      }
+    );
   };
 
+  const styles = getRoleStyles(message.role);
+
   return (
-    <Box className={`p-3 border rounded mb-2 ${roleColors[message.role] || "bg-gray-100 dark:bg-gray-800 border-gray-300 dark:border-gray-600"}`}>
-      <Typography variant="caption" className="font-medium uppercase text-gray-600 dark:text-gray-400 mb-1 block">
+    <Box
+      sx={{
+        p: 1.5,
+        border: 1,
+        borderColor: styles.borderColor,
+        borderRadius: 1,
+        mb: 1,
+        backgroundColor: styles.bgColor,
+      }}
+    >
+      <Typography variant="caption" sx={{ fontWeight: 500, textTransform: "uppercase", color: "text.secondary", mb: 0.5, display: "block" }}>
         {message.role}
       </Typography>
-      <Typography variant="body2" className="whitespace-pre-wrap text-gray-900 dark:text-gray-100">
+      <Typography variant="body2" sx={{ whiteSpace: "pre-wrap", color: "text.primary" }}>
         {message.content}
       </Typography>
     </Box>
@@ -167,8 +198,16 @@ const TestCaseDetailModal: React.FC<TestCaseDetailModalProps> = ({
                             return messages.map((message, msgIndex) => <MessageDisplay key={msgIndex} message={message} />);
                           } catch {
                             return (
-                              <Box className="p-3 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded">
-                                <Typography variant="body2" className="whitespace-pre-wrap text-gray-900 dark:text-gray-100">
+                              <Box
+                                sx={{
+                                  p: 1.5,
+                                  backgroundColor: "action.hover",
+                                  border: 1,
+                                  borderColor: "divider",
+                                  borderRadius: 1,
+                                }}
+                              >
+                                <Typography variant="body2" sx={{ whiteSpace: "pre-wrap", color: "text.primary" }}>
                                   {promptResult.rendered_prompt}
                                 </Typography>
                               </Box>
@@ -176,8 +215,16 @@ const TestCaseDetailModal: React.FC<TestCaseDetailModalProps> = ({
                           }
                         })()
                       ) : (
-                        <Box className="p-3 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded">
-                          <Typography variant="body2" className="text-gray-500 dark:text-gray-400 italic">
+                        <Box
+                          sx={{
+                            p: 1.5,
+                            backgroundColor: "action.hover",
+                            border: 1,
+                            borderColor: "divider",
+                            borderRadius: 1,
+                          }}
+                        >
+                          <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
                             No input messages available
                           </Typography>
                         </Box>
@@ -207,8 +254,16 @@ const TestCaseDetailModal: React.FC<TestCaseDetailModalProps> = ({
                       {promptResult?.output?.content ? (
                         <MessageDisplay message={{ role: "assistant", content: promptResult.output.content }} />
                       ) : (
-                        <Box className="p-3 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded">
-                          <Typography variant="body2" className="text-gray-500 dark:text-gray-400 italic">
+                        <Box
+                          sx={{
+                            p: 1.5,
+                            backgroundColor: "action.hover",
+                            border: 1,
+                            borderColor: "divider",
+                            borderRadius: 1,
+                          }}
+                        >
+                          <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
                             No output available
                           </Typography>
                         </Box>

--- a/genai-engine/ui/src/components/retrievals/CreateRagConfigurationModal.tsx
+++ b/genai-engine/ui/src/components/retrievals/CreateRagConfigurationModal.tsx
@@ -10,6 +10,9 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Divider from "@mui/material/Divider";
+import FormControl from "@mui/material/FormControl";
+import MenuItem from "@mui/material/MenuItem";
+import Select, { type SelectChangeEvent } from "@mui/material/Select";
 import Snackbar from "@mui/material/Snackbar";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
@@ -133,20 +136,20 @@ export const CreateRagConfigurationModal: React.FC<CreateRagConfigurationModalPr
     onClose();
   }, [form, resetLocalState, onClose]);
 
-  const handleProviderChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleProviderChange = useCallback((e: SelectChangeEvent<string>) => {
     setSelectedProviderId(e.target.value);
     setSelectedCollection(null);
   }, []);
 
   const handleCollectionChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
+    (e: SelectChangeEvent<string>) => {
       const collection = collections.find((c) => c.identifier === e.target.value);
       setSelectedCollection(collection ?? null);
     },
     [collections]
   );
 
-  const handleMethodChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleMethodChange = useCallback((e: SelectChangeEvent<SearchMethod>) => {
     setSearchMethod(e.target.value as SearchMethod);
   }, []);
 
@@ -194,57 +197,71 @@ export const CreateRagConfigurationModal: React.FC<CreateRagConfigurationModalPr
                 {/* Provider Selection */}
                 <Box>
                   <Box className="flex items-center justify-between mb-1">
-                    <label htmlFor="provider-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <Typography variant="body2" sx={{ fontWeight: 500, color: "text.primary" }}>
                       Provider
-                    </label>
+                    </Typography>
                     <Button size="small" startIcon={<Add />} onClick={() => setCreateProviderModalOpen(true)} sx={{ textTransform: "none" }}>
                       Add Provider
                     </Button>
                   </Box>
-                  <select
-                    id="provider-select"
-                    value={selectedProviderId}
-                    onChange={handleProviderChange}
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-900 dark:text-gray-100 dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  >
-                    <option value="">Select a provider</option>
-                    {providers.map((provider) => (
-                      <option key={provider.id} value={provider.id}>
-                        {provider.name}
-                      </option>
-                    ))}
-                  </select>
+                  <FormControl fullWidth size="small">
+                    <Select
+                      id="provider-select"
+                      value={selectedProviderId}
+                      onChange={handleProviderChange}
+                      displayEmpty
+                      sx={{ fontSize: "0.875rem" }}
+                    >
+                      <MenuItem value="">
+                        <em>Select a provider</em>
+                      </MenuItem>
+                      {providers.map((provider) => (
+                        <MenuItem key={provider.id} value={provider.id}>
+                          {provider.name}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
                 </Box>
 
                 {/* Collection Selection */}
                 {selectedProviderId && (
                   <Box>
-                    <label htmlFor="collection-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    <Typography variant="body2" sx={{ fontWeight: 500, color: "text.primary", mb: 0.5 }}>
                       Collection
-                    </label>
+                    </Typography>
                     <Box className="flex items-center gap-2">
-                      <select
-                        id="collection-select"
-                        value={selectedCollection?.identifier ?? ""}
-                        onChange={handleCollectionChange}
-                        disabled={isLoadingCollections}
-                        className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-900 dark:text-gray-100 dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-100 dark:disabled:bg-gray-800"
-                      >
-                        {isLoadingCollections ? (
-                          <option value="">Loading collections...</option>
-                        ) : collections.length === 0 ? (
-                          <option value="">No collections available</option>
-                        ) : (
-                          <>
-                            <option value="">Select a collection</option>
-                            {collections.map((collection) => (
-                              <option key={collection.identifier} value={collection.identifier}>
-                                {collection.identifier}
-                              </option>
-                            ))}
-                          </>
-                        )}
-                      </select>
+                      <FormControl fullWidth size="small">
+                        <Select
+                          id="collection-select"
+                          value={selectedCollection?.identifier ?? ""}
+                          onChange={handleCollectionChange}
+                          disabled={isLoadingCollections}
+                          displayEmpty
+                          sx={{ fontSize: "0.875rem" }}
+                        >
+                          {isLoadingCollections ? (
+                            <MenuItem value="">
+                              <em>Loading collections...</em>
+                            </MenuItem>
+                          ) : collections.length === 0 ? (
+                            <MenuItem value="">
+                              <em>No collections available</em>
+                            </MenuItem>
+                          ) : (
+                            <>
+                              <MenuItem value="">
+                                <em>Select a collection</em>
+                              </MenuItem>
+                              {collections.map((collection) => (
+                                <MenuItem key={collection.identifier} value={collection.identifier}>
+                                  {collection.identifier}
+                                </MenuItem>
+                              ))}
+                            </>
+                          )}
+                        </Select>
+                      </FormControl>
                       {isLoadingCollections && <CircularProgress size={20} />}
                     </Box>
                   </Box>
@@ -253,19 +270,16 @@ export const CreateRagConfigurationModal: React.FC<CreateRagConfigurationModalPr
                 {/* Search Method */}
                 {hasRequiredSelections && (
                   <Box>
-                    <label htmlFor="method-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    <Typography variant="body2" sx={{ fontWeight: 500, color: "text.primary", mb: 0.5 }}>
                       Search Method
-                    </label>
-                    <select
-                      id="method-select"
-                      value={searchMethod}
-                      onChange={handleMethodChange}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm text-gray-900 dark:text-gray-100 dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    >
-                      <option value="nearText">Near Text (Vector)</option>
-                      <option value="bm25">BM25 (Keyword)</option>
-                      <option value="hybrid">Hybrid</option>
-                    </select>
+                    </Typography>
+                    <FormControl fullWidth size="small">
+                      <Select id="method-select" value={searchMethod} onChange={handleMethodChange} sx={{ fontSize: "0.875rem" }}>
+                        <MenuItem value="nearText">Near Text (Vector)</MenuItem>
+                        <MenuItem value="bm25">BM25 (Keyword)</MenuItem>
+                        <MenuItem value="hybrid">Hybrid</MenuItem>
+                      </Select>
+                    </FormControl>
                   </Box>
                 )}
 

--- a/genai-engine/ui/src/components/retrievals/ResultsDisplay.tsx
+++ b/genai-engine/ui/src/components/retrievals/ResultsDisplay.tsx
@@ -1,4 +1,5 @@
 import { ErrorOutline, Search, SearchOff, ExpandMore } from "@mui/icons-material";
+import { useTheme, type Theme } from "@mui/material/styles";
 import React, { useState } from "react";
 
 import type { SearchMethod } from "./types";
@@ -56,6 +57,7 @@ const VectorEmbeddingDisplay: React.FC<VectorEmbeddingDisplayProps> = ({ vector 
 };
 
 export const ResultsDisplay: React.FC<ResultsDisplayProps> = React.memo(({ results, isLoading, error, query, searchMethod }) => {
+  const theme = useTheme();
   const [expandedResults, setExpandedResults] = useState<Set<string>>(new Set());
 
   const toggleExpanded = (resultId: string) => {
@@ -85,19 +87,19 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = React.memo(({ resul
     }
   };
 
-  const getScoreColor = (score: number | null | undefined, searchMethod: SearchMethod): string => {
-    if (score === undefined || score === null) return "text-gray-500 dark:text-gray-400";
+  const getScoreColor = (theme: Theme, score: number | null | undefined, searchMethod: SearchMethod): string => {
+    if (score === undefined || score === null) return theme.palette.text.secondary;
 
     if (searchMethod === "nearText") {
       // For distance: lower is better
-      if (score < SCORE_THRESHOLDS.nearText.good) return "text-green-600 dark:text-green-400";
-      if (score < SCORE_THRESHOLDS.nearText.medium) return "text-yellow-600 dark:text-yellow-400";
-      return "text-red-600 dark:text-red-400";
+      if (score < SCORE_THRESHOLDS.nearText.good) return theme.palette.success.main;
+      if (score < SCORE_THRESHOLDS.nearText.medium) return theme.palette.warning.main;
+      return theme.palette.error.main;
     } else {
       // For BM25/hybrid: higher is better
-      if (score > SCORE_THRESHOLDS.bm25.good) return "text-green-600 dark:text-green-400";
-      if (score > SCORE_THRESHOLDS.bm25.medium) return "text-yellow-600 dark:text-yellow-400";
-      return "text-red-600 dark:text-red-400";
+      if (score > SCORE_THRESHOLDS.bm25.good) return theme.palette.success.main;
+      if (score > SCORE_THRESHOLDS.bm25.medium) return theme.palette.warning.main;
+      return theme.palette.error.main;
     }
   };
 
@@ -226,10 +228,14 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = React.memo(({ resul
                         <div className="text-right">
                           <div className="text-xs text-gray-500 dark:text-gray-400">{getScoreLabel(searchMethod)}</div>
                           <div
-                            className={`text-sm font-medium ${getScoreColor(
-                              searchMethod === "nearText" ? result.metadata.distance : result.metadata.score,
-                              searchMethod === "nearText" ? "nearText" : "bm25"
-                            )}`}
+                            className="text-sm font-medium"
+                            style={{
+                              color: getScoreColor(
+                                theme,
+                                searchMethod === "nearText" ? result.metadata.distance : result.metadata.score,
+                                searchMethod === "nearText" ? "nearText" : "bm25"
+                              ),
+                            }}
                           >
                             {(() => {
                               if (searchMethod === "nearText") {
@@ -278,7 +284,7 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = React.memo(({ resul
                               {result.metadata.distance !== undefined && (
                                 <div className="flex justify-between">
                                   <span className="text-gray-600 dark:text-gray-400">Distance:</span>
-                                  <span className={`font-medium ${getScoreColor(result.metadata.distance, "nearText")}`}>
+                                  <span className="font-medium" style={{ color: getScoreColor(theme, result.metadata.distance, "nearText") }}>
                                     {typeof result.metadata.distance === "number"
                                       ? result.metadata.distance.toFixed(6)
                                       : (result.metadata.distance ?? "N/A")}
@@ -288,7 +294,10 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = React.memo(({ resul
                               {result.metadata.certainty !== undefined && result.metadata.certainty !== null && (
                                 <div className="flex justify-between">
                                   <span className="text-gray-600 dark:text-gray-400">Certainty:</span>
-                                  <span className={`font-medium ${getScoreColor(1 - (result.metadata.certainty || 0), "nearText")}`}>
+                                  <span
+                                    className="font-medium"
+                                    style={{ color: getScoreColor(theme, 1 - (result.metadata.certainty || 0), "nearText") }}
+                                  >
                                     {typeof result.metadata.certainty === "number" ? result.metadata.certainty.toFixed(6) : "N/A"}
                                   </span>
                                 </div>
@@ -296,7 +305,7 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = React.memo(({ resul
                               {result.metadata.score !== undefined && result.metadata.score !== null && result.metadata.score !== 0 && (
                                 <div className="flex justify-between">
                                   <span className="text-gray-600 dark:text-gray-400">Score:</span>
-                                  <span className={`font-medium ${getScoreColor(result.metadata.score, "bm25")}`}>
+                                  <span className="font-medium" style={{ color: getScoreColor(theme, result.metadata.score, "bm25") }}>
                                     {(() => {
                                       const score = result.metadata.score;
                                       if (typeof score === "number") {

--- a/genai-engine/ui/src/components/retrievals/settings/IncludeOptions.tsx
+++ b/genai-engine/ui/src/components/retrievals/settings/IncludeOptions.tsx
@@ -1,3 +1,8 @@
+import Box from "@mui/material/Box";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormGroup from "@mui/material/FormGroup";
+import Typography from "@mui/material/Typography";
 import React from "react";
 
 interface IncludeOptionsProps {
@@ -11,38 +16,33 @@ interface IncludeOptionsProps {
 export const IncludeOptions: React.FC<IncludeOptionsProps> = React.memo(
   ({ includeMetadata, includeVector, onIncludeMetadataChange, onIncludeVectorChange, isExecuting }) => {
     return (
-      <div>
-        <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-3">Include in Results</h4>
-        <div className="space-y-2">
-          <div className="flex items-center">
-            <input
-              type="checkbox"
-              id="includeMetadata"
-              checked={includeMetadata}
-              onChange={(e) => onIncludeMetadataChange(e.target.checked)}
-              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
-              disabled={isExecuting}
-            />
-            <label htmlFor="includeMetadata" className="ml-2 text-sm text-gray-900 dark:text-gray-100">
-              Metadata (distance, score, explainScore)
-            </label>
-          </div>
-
-          <div className="flex items-center">
-            <input
-              type="checkbox"
-              id="includeVector"
-              checked={includeVector}
-              onChange={(e) => onIncludeVectorChange(e.target.checked)}
-              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
-              disabled={isExecuting}
-            />
-            <label htmlFor="includeVector" className="ml-2 text-sm text-gray-900 dark:text-gray-100">
-              Vector embeddings
-            </label>
-          </div>
-        </div>
-      </div>
+      <Box>
+        <Typography variant="body2" sx={{ fontWeight: 500, color: "text.primary", mb: 1.5 }}>
+          Include in Results
+        </Typography>
+        <FormGroup>
+          <FormControlLabel
+            control={
+              <Checkbox checked={includeMetadata} onChange={(e) => onIncludeMetadataChange(e.target.checked)} disabled={isExecuting} size="small" />
+            }
+            label={
+              <Typography variant="body2" sx={{ color: "text.primary" }}>
+                Metadata (distance, score, explainScore)
+              </Typography>
+            }
+          />
+          <FormControlLabel
+            control={
+              <Checkbox checked={includeVector} onChange={(e) => onIncludeVectorChange(e.target.checked)} disabled={isExecuting} size="small" />
+            }
+            label={
+              <Typography variant="body2" sx={{ color: "text.primary" }}>
+                Vector embeddings
+              </Typography>
+            }
+          />
+        </FormGroup>
+      </Box>
     );
   }
 );


### PR DESCRIPTION
Address all ClaudeBot feedback from MR #1306 by converting Tailwind color classes to MUI theme-based styling for proper dark mode support.

Changes:
- Convert getSpanTypeColor() and getScoreColor() helper functions to accept theme parameter and return MUI palette colors
- Replace native select elements with MUI Select components
- Replace native checkbox inputs with MUI Checkbox components
- Remove dark:border-gray-600, dark:text-*, dark:bg-* classes from Box, Typography, and other MUI components
- Replace className-based styling with sx prop using theme tokens

Benefits:
- Automatic dark mode support through MUI theme system
- Consistent styling with MUI design system
- Better accessibility with built-in ARIA attributes
- Type-safe event handlers with SelectChangeEvent
- No manual dark: classes needed for any future changes

Files modified (8):
- TraceDetailsPanel.tsx: Convert span type color helper + Chip component
- ResultsTable.tsx: Convert message display colors to theme-based
- ExperimentResultsTable.tsx: Replace Tailwind classes with sx prop
- PromptResultDetailModal.tsx: Replace Tailwind classes with sx prop
- NotebookExperimentModal.tsx: Replace border classes with sx prop
- CreateRagConfigurationModal.tsx: Convert select to MUI Select
- ResultsDisplay.tsx: Convert score color helper to theme-based
- IncludeOptions.tsx: Convert native checkboxes to MUI Checkbox

All changes are backward compatible with no breaking changes to component interfaces or external APIs.

Verified:
- TypeScript compilation passes
- ESLint passes with no errors
- Prettier formatting consistent
- Production build successful
- No breaking changes to component props or event handlers