### PR TITLE
Update Observe nav item and match TracesView tab styling to continuou…

### DIFF
--- a/genai-engine/ui/src/components/SidebarNavigation.tsx
+++ b/genai-engine/ui/src/components/SidebarNavigation.tsx
@@ -9,6 +9,7 @@ import {
   ArrowBackOutlined,
   LiveTvOutlined,
   InsightsOutlined,
+  ChevronRightOutlined,
 } from "@mui/icons-material";
 import { Link, Typography } from "@mui/material";
 import React from "react";
@@ -38,7 +39,7 @@ const navigationSections: NavigationSection[] = [
   {
     id: "observability",
     label: "Observability",
-    items: [{ id: "traces", label: "Traces", icon: <TrendingUpOutlined /> }],
+    items: [{ id: "traces", label: "Observe", icon: <TrendingUpOutlined /> }],
   },
   {
     id: "prompts",
@@ -119,15 +120,15 @@ export const SidebarNavigation: React.FC<SidebarNavigationProps> = ({ onBackToDa
                 <InsightsOutlined />
               </span>
               <span>Analyze</span>
-              <svg className="ml-auto h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
+              {activeSection === "overview" && <ChevronRightOutlined sx={{ ml: "auto", fontSize: 16 }} />}
             </Link>
           </div>
 
           {navigationSections.map((section) => (
             <div key={section.id} className="mb-4">
-              <div className="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">{section.label}</div>
+              {section.id !== "observability" && (
+                <div className="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">{section.label}</div>
+              )}
 
               <ul className="mt-1 space-y-1">
                 {section.items.map((item) => {
@@ -150,6 +151,7 @@ export const SidebarNavigation: React.FC<SidebarNavigationProps> = ({ onBackToDa
                       >
                         <span className="shrink-0">{item.icon}</span>
                         <span>{item.label}</span>
+                        {isActive && <ChevronRightOutlined sx={{ ml: "auto", fontSize: 16 }} />}
                       </Link>
                     </li>
                   );

--- a/genai-engine/ui/src/components/traces/components/TracesViewLayout.tsx
+++ b/genai-engine/ui/src/components/traces/components/TracesViewLayout.tsx
@@ -39,39 +39,34 @@ export const TracesViewLayout = ({ level, timeRange, onLevelChange, onTimeRangeC
           backgroundColor: "background.paper",
         }}
       >
-        <Typography variant="h5" fontWeight={600} color="text.primary">
-          Traces
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-          Monitor and analyze inference traces
-        </Typography>
+        <Stack direction="row" alignItems="flex-start" justifyContent="space-between">
+          <Box>
+            <Typography variant="h5" fontWeight={600} color="text.primary">
+              Traces
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              Monitor and analyze inference traces
+            </Typography>
+          </Box>
+          {welcomeDismissed && <TimeRangeSelect value={timeRange} onValueChange={onTimeRangeChange} />}
+        </Stack>
       </Box>
 
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          p: 2,
-          gap: 2,
-          flex: 1,
-          overflow: "hidden",
-        }}
-      >
-        {welcomeDismissed && (
-          <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ flexShrink: 0 }}>
-            <Tabs value={level} onChange={(_, newValue) => onLevelChange(newValue as Level)}>
-              <Tab value="trace" label="Traces" />
-              <Tab value="span" label="Spans" />
-              <Tab value="session" label="Sessions" />
-              <Tab value="user" label="Users" />
-            </Tabs>
+      {welcomeDismissed && (
+        <Tabs
+          variant="fullWidth"
+          value={level}
+          onChange={(_, newValue) => onLevelChange(newValue as Level)}
+          sx={{ backgroundColor: "background.paper", borderBottom: 1, borderColor: "divider" }}
+        >
+          <Tab value="trace" label="Traces" />
+          <Tab value="span" label="Spans" />
+          <Tab value="session" label="Sessions" />
+          <Tab value="user" label="Users" />
+        </Tabs>
+      )}
 
-            <TimeRangeSelect value={timeRange} onValueChange={onTimeRangeChange} />
-          </Stack>
-        )}
-
-        <Box sx={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column" }}>{children}</Box>
-      </Box>
+      <Box sx={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column" }}>{children}</Box>
     </Box>
   );
 };


### PR DESCRIPTION
…s evals

- Revert sidebar to single Observe item, removing sub-items
- Move TimeRangeSelect into TracesViewLayout header row
- Apply fullWidth variant and background.paper styling to Tabs