### PR TITLE
fix(tests): replace sync mock with polling in prompt experiment tests (ae-4d5)

### DIFF
--- a/genai-engine/tests/unit/routes/tasks/test_prompt_experiment_routes.py
+++ b/genai-engine/tests/unit/routes/tasks/test_prompt_experiment_routes.py
@@ -13,6 +13,7 @@ and clean up test state after execution.
 """
 
 import random
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -43,6 +44,81 @@ from schemas.prompt_experiment_schemas import (
 from tests.clients.base_test_client import GenaiEngineTestClientBase
 from tests.unit.routes.conftest import setup_db_session_context_mock
 
+# Maximum time to wait for experiment completion (in seconds)
+MAX_WAIT_TIME = 30
+# Polling interval (in seconds)
+POLL_INTERVAL = 0.5
+
+
+def wait_for_experiment_completion(
+    client: GenaiEngineTestClientBase,
+    experiment_id: str,
+    max_wait_time: float = MAX_WAIT_TIME,
+    poll_interval: float = POLL_INTERVAL,
+    allow_failure: bool = False,
+) -> PromptExperimentDetail:
+    """
+    Poll the experiment details endpoint until the experiment completes.
+
+    Args:
+        client: Test client instance
+        experiment_id: ID of the experiment to poll
+        max_wait_time: Maximum time to wait (in seconds)
+        poll_interval: Time between polls (in seconds)
+        allow_failure: If True, return the experiment detail even if it failed.
+                       If False (default), raise AssertionError if experiment failed.
+
+    Returns:
+        PromptExperimentDetail: The completed experiment details
+
+    Raises:
+        TimeoutError: If experiment doesn't complete within max_wait_time
+        AssertionError: If experiment failed and allow_failure is False
+    """
+    start_time = time.time()
+    last_status = None
+    while time.time() - start_time < max_wait_time:
+        status_code, experiment_data = client.get_prompt_experiment(experiment_id)
+        assert status_code == 200, f"Failed to get experiment: {experiment_data}"
+
+        experiment_detail = PromptExperimentDetail.model_validate(experiment_data)
+        current_status = experiment_detail.status
+
+        # Log status changes for debugging
+        if current_status != last_status:
+            last_status = current_status
+
+        if current_status in [
+            ExperimentStatus.COMPLETED,
+            ExperimentStatus.FAILED,
+        ]:
+            if current_status == ExperimentStatus.FAILED and not allow_failure:
+                raise AssertionError(
+                    f"Experiment {experiment_id} failed. "
+                    f"Completed rows: {experiment_detail.completed_rows}, "
+                    f"Failed rows: {experiment_detail.failed_rows}",
+                )
+            # Return the experiment detail (either completed or failed if allowed)
+            return experiment_detail
+
+        time.sleep(poll_interval)
+
+    # Get final status for error message
+    status_code, experiment_data = client.get_prompt_experiment(experiment_id)
+    if status_code == 200:
+        experiment_detail = PromptExperimentDetail.model_validate(experiment_data)
+        raise TimeoutError(
+            f"Experiment {experiment_id} did not complete within {max_wait_time} seconds. "
+            f"Final status: {experiment_detail.status}, "
+            f"Completed rows: {experiment_detail.completed_rows}/{experiment_detail.total_rows}, "
+            f"Failed rows: {experiment_detail.failed_rows}",
+        )
+    else:
+        raise TimeoutError(
+            f"Experiment {experiment_id} did not complete within {max_wait_time} seconds. "
+            f"Could not get final status: {experiment_data}",
+        )
+
 
 @pytest.mark.unit_tests
 @patch("services.experiment_executor.db_session_context")
@@ -51,12 +127,7 @@ from tests.unit.routes.conftest import setup_db_session_context_mock
 @patch("clients.llm.llm_client.litellm.completion")
 @patch("services.prompt_experiment_executor.logger")
 @patch("services.experiment_executor.logger")
-@patch(
-    "services.experiment_executor.BaseExperimentExecutor.execute_experiment_async",
-    autospec=True,
-)
 def test_prompt_experiment_routes_happy_path(
-    mock_execute_async,
     mock_experiment_logger,
     mock_prompt_logger,
     mock_completion,
@@ -83,10 +154,6 @@ def test_prompt_experiment_routes_happy_path(
 
     # Mock db_session_context for background thread execution to use test database
     setup_db_session_context_mock(mock_db_session_context)
-    # Run experiment synchronously so there's no background thread race
-    mock_execute_async.side_effect = (
-        lambda self, experiment_id, **kwargs: self._execute_experiment(experiment_id)
-    )
 
     # Setup: Create task
     task_name = f"prompt_experiment_task_{random.random()}"
@@ -311,10 +378,8 @@ def test_prompt_experiment_routes_happy_path(
     assert experiment_summary["prompt_configs"][0]["name"] == prompt_name
     assert experiment_summary["prompt_configs"][0]["version"] == prompt_version
 
-    # Test 2: Get prompt experiment details
-    status_code, experiment_data = client.get_prompt_experiment(experiment_id)
-    assert status_code == 200, f"Failed to get experiment: {experiment_data}"
-    experiment_detail = PromptExperimentDetail.model_validate(experiment_data)
+    # Test 2: Get prompt experiment details (polling until completion)
+    experiment_detail = wait_for_experiment_completion(client, experiment_id)
 
     # Validate experiment detail response fields
     assert experiment_detail.id == experiment_id
@@ -540,13 +605,12 @@ def test_prompt_experiment_routes_happy_path(
     ), f"Failed to create failed experiment: {failed_experiment_summary}"
     failed_experiment_id = failed_experiment_summary["id"]
 
-    # Get experiment details (experiment already complete since it ran synchronously)
-    status_code, failed_experiment_data = client.get_prompt_experiment(
+    # Wait for the experiment to complete (should fail)
+    # Pass allow_failure=True since we expect this experiment to fail
+    failed_experiment_detail = wait_for_experiment_completion(
+        client,
         failed_experiment_id,
-    )
-    assert status_code == 200, f"Failed to get experiment: {failed_experiment_data}"
-    failed_experiment_detail = PromptExperimentDetail.model_validate(
-        failed_experiment_data,
+        allow_failure=True,
     )
 
     # Validate that the experiment is marked as failed
@@ -611,12 +675,7 @@ def test_prompt_experiment_routes_happy_path(
 @patch("services.prompt_experiment_executor.logger")
 @patch("services.experiment_executor.logger")
 @patch("repositories.prompt_experiment_repository.logger")
-@patch(
-    "services.experiment_executor.BaseExperimentExecutor.execute_experiment_async",
-    autospec=True,
-)
 def test_prompt_experiment_none_value_conversion(
-    mock_execute_async,
     mock_repo_logger,
     mock_experiment_logger,
     mock_prompt_logger,
@@ -636,10 +695,6 @@ def test_prompt_experiment_none_value_conversion(
     """
     # Mock db_session_context for background thread execution to use test database
     setup_db_session_context_mock(mock_db_session_context)
-    # Run experiment synchronously so there's no background thread race
-    mock_execute_async.side_effect = (
-        lambda self, experiment_id, **kwargs: self._execute_experiment(experiment_id)
-    )
 
     # Setup: Create task
     task_name = f"prompt_experiment_none_test_{random.random()}"
@@ -847,10 +902,8 @@ def test_prompt_experiment_none_value_conversion(
     ), f"Failed to create prompt experiment: {experiment_summary}"
     experiment_id = experiment_summary["id"]
 
-    # Get experiment details
-    status_code, experiment_data = client.get_prompt_experiment(experiment_id)
-    assert status_code == 200, f"Failed to get experiment: {experiment_data}"
-    experiment_detail = PromptExperimentDetail.model_validate(experiment_data)
+    # Wait for experiment to complete
+    experiment_detail = wait_for_experiment_completion(client, experiment_id)
 
     # Verify that the experiment completed successfully
     assert experiment_detail.status == ExperimentStatus.COMPLETED
@@ -917,12 +970,7 @@ def test_prompt_experiment_none_value_conversion(
 @patch("clients.llm.llm_client.litellm.completion")
 @patch("services.prompt_experiment_executor.logger")
 @patch("services.experiment_executor.logger")
-@patch(
-    "services.experiment_executor.BaseExperimentExecutor.execute_experiment_async",
-    autospec=True,
-)
 def test_prompt_experiment_unsaved_prompt(
-    mock_execute_async,
     mock_experiment_logger,
     mock_prompt_logger,
     mock_completion,
@@ -938,10 +986,6 @@ def test_prompt_experiment_unsaved_prompt(
     """
     # Mock db_session_context for background thread execution to use test database
     setup_db_session_context_mock(mock_db_session_context)
-    # Run experiment synchronously so there's no background thread race
-    mock_execute_async.side_effect = (
-        lambda self, experiment_id, **kwargs: self._execute_experiment(experiment_id)
-    )
 
     # Setup: Create task
     task_name = f"prompt_experiment_unsaved_{random.random()}"
@@ -1108,10 +1152,8 @@ def test_prompt_experiment_unsaved_prompt(
     assert experiment_summary["prompt_configs"][0]["type"] == "unsaved"
     assert "auto_name" in experiment_summary["prompt_configs"][0]
 
-    # Get experiment details
-    status_code, experiment_data = client.get_prompt_experiment(experiment_id)
-    assert status_code == 200, f"Failed to get experiment: {experiment_data}"
-    experiment_detail = PromptExperimentDetail.model_validate(experiment_data)
+    # Wait for experiment to complete
+    experiment_detail = wait_for_experiment_completion(client, experiment_id)
 
     # Verify completion
     assert experiment_detail.status == ExperimentStatus.COMPLETED


### PR DESCRIPTION
## Summary
- Fixes `test_prompt_experiment_none_value_conversion` which has been failing since 2026-03-05 with `AssertionError: assert 0 == 1`
- Removes `mock_execute_async.side_effect` hack and replaces synchronous experiment execution with a proper `wait_for_experiment_completion` polling helper
- Updates all 4 test functions in `test_prompt_experiment_routes.py` consistently
- This is a pre-existing test failure unrelated to UI work but blocking auto-merge for PRs #1399/#1400/#1401/#1402

## Test plan
- [ ] `run-genai-engine-unit-tests` passes
- [ ] PRs #1399/#1400/#1401/#1402 can proceed through merge queue after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)