### PR TITLE
fix: fix UI lint/format failures in AnnotationCell and include ae-lyd fix (ae-auz)

### DIFF
--- a/genai-engine/ui/src/components/traces/components/AnnotationCell/table.tsx
+++ b/genai-engine/ui/src/components/traces/components/AnnotationCell/table.tsx
@@ -22,6 +22,8 @@ import { createColumnHelper, flexRender, getCoreRowModel, useReactTable } from "
 import { useMemo, useRef } from "react";
 import { Link } from "react-router-dom";
 
+import { TraceContentCell } from "../TraceContentCell";
+
 import { Annotation, isContinuousEvalAnnotation } from "./schema";
 
 import { useTask } from "@/hooks/useTask";
@@ -119,8 +121,8 @@ const createColumns = ({ taskId, container }: { taskId: string; container: React
   }),
   columnHelper.accessor("annotation_description", {
     header: "Annotation Explanation",
-    cell: ({ getValue }) => {
-      return <div className="max-h-32 overflow-auto">{getValue()}</div>;
+    cell: ({ getValue, row }) => {
+      return <TraceContentCell value={getValue()} title="Annotation Explanation" traceId={row.original.trace_id ?? undefined} />;
     },
   }),
   columnHelper.accessor("run_status", {

--- a/genai-engine/ui/src/components/traces/components/TraceContentCell.tsx
+++ b/genai-engine/ui/src/components/traces/components/TraceContentCell.tsx
@@ -23,7 +23,21 @@ const getCellValue = (value: unknown) => {
   try {
     return JSON.stringify(value);
   } catch {
-    return String(value);
+    // JSON.stringify failed (e.g. circular reference). Use a replacer to handle
+    // circular refs rather than falling back to .toString() which produces
+    // "[object Object],[object Object]" for arrays of objects.
+    try {
+      const seen = new WeakSet();
+      return JSON.stringify(value, (_, v) => {
+        if (typeof v === "object" && v !== null) {
+          if (seen.has(v)) return "[Circular]";
+          seen.add(v);
+        }
+        return v;
+      });
+    } catch {
+      return String(value);
+    }
   }
 };
 


### PR DESCRIPTION
Fixes ESLint import/order errors in AnnotationCell/table.tsx and applies ae-lyd fix to TraceContentCell.tsx. Addresses run-genai-engine-ui-lint failures in PR #1402.