### PR TITLE
chore: add Gas Town runtime directories to .gitignore (da-bfa)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ ml-engine/src/genai_client/**
 
 models/
 arthur-engine.code-workspace
+
+# Gas Town (added by gt)
+.runtime/
+.claude/commands/
+.logs/


### PR DESCRIPTION
Add Gas Town runtime directories (`.runtime/`, `.claude/commands/`, `.logs/`) to `.gitignore` to prevent accidental commits of Gas Town agent state files.

Source issue: da-bfa
Worker: dust
MR: ae-wisp-5imi4