### PR TITLE
chore: add Gas Town runtime dirs to .gitignore (ae-zq3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ ml-engine/src/genai_client/**
 models/
 arthur-engine.code-workspace
 
+
+# Gas Town (added by gt)
+.runtime/
+.claude/commands/
+.logs/


### PR DESCRIPTION
Adds Gas Town runtime directories to `.gitignore` so they don't show up as untracked files in polecat worktrees.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>