### PR TITLE
fix: add default fallback for GENAI_ENGINE_THREAD_POOL_MAX_WORKERS (ae-40g)

### DIFF
--- a/genai-engine/src/metrics_engine.py
+++ b/genai-engine/src/metrics_engine.py
@@ -48,9 +48,8 @@ class MetricsEngine:
         num_threads = int(
             get_env_var(
                 constants.GENAI_ENGINE_THREAD_POOL_MAX_WORKERS_ENV_VAR,
-                none_on_missing=True,
+                default=str(constants.DEFAULT_THREAD_POOL_MAX_WORKERS),
             )
-            or constants.DEFAULT_THREAD_POOL_MAX_WORKERS,
         )
         with TracedThreadPoolExecutor(tracer, max_workers=num_threads) as executor:
             for metric in metrics:

--- a/genai-engine/src/rules_engine.py
+++ b/genai-engine/src/rules_engine.py
@@ -86,9 +86,8 @@ class RuleEngine:
         num_threads = int(
             get_env_var(
                 constants.GENAI_ENGINE_THREAD_POOL_MAX_WORKERS_ENV_VAR,
-                none_on_missing=True,
+                default=str(constants.DEFAULT_THREAD_POOL_MAX_WORKERS),
             )
-            or constants.DEFAULT_THREAD_POOL_MAX_WORKERS,
         )
         with TracedThreadPoolExecutor(tracer, max_workers=num_threads) as executor:
             for rule in rules:

--- a/genai-engine/src/utils/utils.py
+++ b/genai-engine/src/utils/utils.py
@@ -190,8 +190,18 @@ def get_env_var(
     none_on_missing: bool = False,
     default: str | None = None,
 ) -> str | None:
-    value = os.environ.get(env_var, default)
-    logger.debug(f"Environment variable {env_var} has value {value}")
+    env_value = os.environ.get(env_var)
+    if env_value is not None:
+        value: str | None = env_value
+        logger.debug(f"Environment variable {env_var} has value {value}")
+    elif default is not None:
+        value = default
+        logger.debug(
+            f"Environment variable {env_var} not set, using default: {value}"
+        )
+    else:
+        value = None
+        logger.debug(f"Environment variable {env_var} is not set")
     if none_on_missing and not value:
         return None
     elif not value:


### PR DESCRIPTION
## Summary
- Add default fallback for `GENAI_ENGINE_THREAD_POOL_MAX_WORKERS` env var to prevent ValueError when unset
- Use `get_env_var`'s `default=` parameter instead of none_on_missing + or-fallback pattern
- Log distinctly when using default value vs explicitly set env var

Fixes: UP-3807

## Test plan
- [ ] Verify engine starts without `GENAI_ENGINE_THREAD_POOL_MAX_WORKERS` set
- [ ] Verify thread pool uses sensible default (cpu_count/2 + 1)
- [ ] Verify unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)