### PR TITLE
chore: add Gas Town entries to .gitignore (ae-o4x)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ ml-engine/src/genai_client/**
 models/
 arthur-engine.code-workspace
 
+
+# Gas Town (added by gt)
+.runtime/
+.claude/commands/
+.logs/


### PR DESCRIPTION
## Summary
- Add Gas Town runtime entries to `.gitignore`

## Test plan
- [ ] Verify .gitignore additions are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)