### PR TITLE
fix: truncate long prompt version names in drawer and detail view (ae-7gf)

### DIFF
--- a/genai-engine/ui/src/components/prompts-management/fullscreen/PromptDetailView.tsx
+++ b/genai-engine/ui/src/components/prompts-management/fullscreen/PromptDetailView.tsx
@@ -245,7 +245,7 @@ const PromptDetailView = ({
   return (
     <Box sx={{ p: 3, height: "100%", display: "flex", flexDirection: "column", overflow: "hidden" }}>
       <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 3, flexShrink: 0 }}>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap", minWidth: 0, overflow: "hidden" }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap", minWidth: 0, overflow: "hidden", flex: 1 }}>
           <Typography variant="h5" noWrap sx={{ fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", maxWidth: "100%" }}>
             {promptName}
           </Typography>

--- a/genai-engine/ui/src/components/prompts-management/fullscreen/PromptVersionDrawer.tsx
+++ b/genai-engine/ui/src/components/prompts-management/fullscreen/PromptVersionDrawer.tsx
@@ -107,8 +107,8 @@ const PromptVersionDrawer = ({
         },
       }}
     >
-      <Box sx={{ p: 2, display: "flex", flexDirection: "column", height: "100%" }}>
-        <Typography variant="h6" noWrap sx={{ mb: 2, fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis" }}>
+      <Box sx={{ p: 2, display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
+        <Typography variant="h6" noWrap sx={{ mb: 2, fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", maxWidth: "100%" }}>
           Versions: {promptName}
         </Typography>
 


### PR DESCRIPTION
## Summary
- Fixes overflow of long prompt version names in `PromptDetailView` and `PromptVersionDrawer`
- Adds `flex: 1` to title container in `PromptDetailView` so it uses available space
- Adds `overflow: hidden` + `maxWidth: 100%` to `PromptVersionDrawer` for proper truncation

Closes ae-7gf

## Test plan
- [ ] Verify long prompt version names are truncated with ellipsis in the detail view header
- [ ] Verify long prompt version names are truncated with ellipsis in the versions drawer header
- [ ] Verify layout is not broken for short names

🤖 Generated with [Claude Code](https://claude.com/claude-code)