### PR TITLE
fix: Correct back navigation from Prompt Notebook and Experiment Details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ ml-engine/src/genai_client/**
 models/
 arthur-engine.code-workspace
 
+
+# Gas Town (added by gt)
+.runtime/
+.claude/commands/
+.logs/

--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,3 @@ ml-engine/src/genai_client/**
 models/
 arthur-engine.code-workspace
 
-
-# Gas Town (added by gt)
-.runtime/
-.claude/commands/
-.logs/

--- a/genai-engine/ui/src/components/prompt-experiments/ExperimentDetailView.tsx
+++ b/genai-engine/ui/src/components/prompt-experiments/ExperimentDetailView.tsx
@@ -188,7 +188,7 @@ export const ExperimentDetailView: React.FC = () => {
       await deleteExperiment.mutateAsync(experimentId);
       setIsDeleteDialogOpen(false);
       // Navigate back to experiments list after successful deletion
-      navigate(`/tasks/${taskId}/prompt-experiments`);
+      navigate(`/tasks/${taskId}/prompts?tab=prompt-experiments`);
     } catch (err) {
       console.error("Failed to delete experiment:", err);
       setIsDeleting(false);
@@ -219,7 +219,7 @@ export const ExperimentDetailView: React.FC = () => {
         <Box className="mb-4">
           <Box
             className="flex items-center gap-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer w-fit"
-            onClick={() => navigate(`/tasks/${taskId}/prompt-experiments`)}
+            onClick={() => navigate(`/tasks/${taskId}/prompts?tab=prompt-experiments`)}
           >
             <ArrowBackIcon fontSize="small" />
             <Typography variant="body2" className="font-medium">

--- a/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
@@ -87,7 +87,7 @@ export default function PlaygroundHeader({
             <>
               <IconButton
                 size="small"
-                onClick={() => navigate(`/tasks/${task?.id}/prompts?tab=notebooks`)}
+                onClick={() => navigate(`/tasks/${task?.id}/prompts`)}
                 sx={{
                   color: "text.secondary",
                   "&:hover": { backgroundColor: "action.hover" },


### PR DESCRIPTION
## Summary
Fixes incorrect redirect URLs when users navigate back from Prompt Notebook and Experiment Details views, ensuring they land on the expected pages within the task workflow.

## Problem
Users navigating back from Prompt Notebook were incorrectly redirected to the notebooks tab instead of the main prompts view, and users returning from Experiment Details weren't being directed to the prompt experiments tab as expected.

## Solution
Updated navigation logic in both components to redirect to the correct URLs: Prompt Notebook now returns to `/tasks/id/prompts` and Experiment Details returns to `/tasks/id/prompts?tab=prompt-experiments`.

## User Impact
Users now experience consistent and intuitive back navigation when working with prompts and experiments. When leaving the Prompt Notebook, they return to the main prompts view, and when leaving Experiment Details, they return directly to the prompt experiments tab where they can continue their workflow seamlessly.

## Changed Areas
• **Prompt Experiments module** — Updated ExperimentDetailView component back navigation target
• **Prompts Playground module** — Fixed PlaygroundHeader component redirect URL for notebook back navigation

## Type
Bug Fix

## Breaking Changes
None

<!-- enriched-by-louisa -->