### PR TITLE
feat(ui): unify notebook experience across Prompt, RAG, and Agent types

### DIFF
--- a/genai-engine/ui/src/components/agent-experiments/[experimentId]/index.tsx
+++ b/genai-engine/ui/src/components/agent-experiments/[experimentId]/index.tsx
@@ -47,7 +47,7 @@ export const AgentExperimentDetail = () => {
           <Stack alignItems="flex-start">
             <Button
               component={Link}
-              to=".."
+              to={`/tasks/${task?.id}/test?section=agent-experiments`}
               size="small"
               variant="text"
               startIcon={<ArrowBackIcon />}

--- a/genai-engine/ui/src/components/agent-experiments/[experimentId]/index.tsx
+++ b/genai-engine/ui/src/components/agent-experiments/[experimentId]/index.tsx
@@ -1,7 +1,7 @@
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { Box, Button, Stack, Typography, Link as MuiLink, ButtonGroup } from "@mui/material";
+import { Box, Button, CircularProgress, Stack, Typography, Link as MuiLink, ButtonGroup } from "@mui/material";
 import { Link, useParams } from "react-router-dom";
 
 import { StatusBadge } from "../components/status-badge";
@@ -23,12 +23,24 @@ export const AgentExperimentDetail = () => {
   const { experimentId } = useParams<{ experimentId: string }>();
   const { timezone, use24Hour } = useDisplaySettings();
 
-  const { data: agentExperiment } = usePollAgentExperiment(experimentId);
+  const { data: agentExperiment, isLoading } = usePollAgentExperiment(experimentId);
 
   const deleteAgentExperimentMutation = useDeleteAgentExperiment();
 
+  if (isLoading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: getContentHeight() }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
   if (!agentExperiment) {
-    return <div>Experiment not found</div>;
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: getContentHeight() }}>
+        <Typography color="text.secondary">Experiment not found</Typography>
+      </Box>
+    );
   }
 
   return (

--- a/genai-engine/ui/src/components/agent-notebook/AgentNotebookDetailModal.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/AgentNotebookDetailModal.tsx
@@ -10,6 +10,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
 import TableCell from "@mui/material/TableCell";
@@ -21,29 +22,28 @@ import Typography from "@mui/material/Typography";
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { useRagNotebook, useRagNotebookHistoryWithPolling, useUpdateRagNotebookMutation } from "@/hooks/useRagNotebooks";
+import { useAgenticNotebook } from "./hooks/useAgenticNotebook";
+import { useUpdateAgenticNotebook } from "./hooks/useUpdateAgenticNotebook";
+
 import { getStatusChipSx } from "@/utils/statusChipStyles";
 
-interface RagNotebookDetailModalProps {
+interface AgentNotebookDetailModalProps {
   open: boolean;
   notebookId: string | null;
   onClose: () => void;
 }
 
-const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, notebookId, onClose }) => {
+const AgentNotebookDetailModal: React.FC<AgentNotebookDetailModalProps> = ({ open, notebookId, onClose }) => {
   const navigate = useNavigate();
   const { id: taskId } = useParams<{ id: string }>();
-  const { notebook, isLoading: isLoadingNotebook } = useRagNotebook(notebookId ?? undefined);
-  const { experiments, isLoading: isLoadingHistory } = useRagNotebookHistoryWithPolling(notebookId ?? undefined);
-  const updateMutation = useUpdateRagNotebookMutation();
+  const { data: notebook, isLoading } = useAgenticNotebook(notebookId ?? "");
+  const updateMutation = useUpdateAgenticNotebook();
 
   const [isRenaming, setIsRenaming] = useState(false);
   const [newNotebookName, setNewNotebookName] = useState("");
 
   useEffect(() => {
-    if (notebook?.name) {
-      setNewNotebookName(notebook.name);
-    }
+    if (notebook?.name) setNewNotebookName(notebook.name);
   }, [notebook?.name]);
 
   const handleStartRename = () => {
@@ -68,16 +68,14 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
 
   const handleLaunchNotebook = () => {
     if (taskId && notebookId) {
-      navigate(`/tasks/${taskId}/rag-notebooks/${notebookId}`);
+      navigate(`/tasks/${taskId}/agentic-notebooks/${notebookId}`);
       onClose();
     }
   };
 
-  const isLoading = isLoadingNotebook || isLoadingHistory;
-
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth aria-labelledby="rag-notebook-detail-dialog-title">
-      <DialogTitle id="rag-notebook-detail-dialog-title" sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           {isRenaming ? (
             <TextField
@@ -86,25 +84,19 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
               value={newNotebookName}
               onChange={(e) => setNewNotebookName(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  handleSaveRename();
-                } else if (e.key === "Escape") {
-                  handleCancelRename();
-                }
+                if (e.key === "Enter") handleSaveRename();
+                else if (e.key === "Escape") handleCancelRename();
               }}
               onBlur={handleSaveRename}
               autoFocus
               sx={{
-                "& .MuiInputBase-root": {
-                  fontSize: "1.25rem",
-                  fontWeight: 600,
-                },
+                "& .MuiInputBase-root": { fontSize: "1.25rem", fontWeight: 600 },
               }}
             />
           ) : (
             <>
               <Typography variant="h6" component="span">
-                {notebook?.name || "RAG Notebook Details"}
+                {notebook?.name || "Notebook Details"}
               </Typography>
               {notebook && (
                 <IconButton
@@ -131,83 +123,93 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
           </IconButton>
         </Box>
       </DialogTitle>
-      <DialogContent>
+
+      <DialogContent dividers>
         {isLoading ? (
           <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
             <CircularProgress />
           </Box>
+        ) : !notebook ? (
+          <Box sx={{ py: 4, textAlign: "center" }}>
+            <Typography color="error">Failed to load notebook details</Typography>
+          </Box>
         ) : (
-          <>
-            <Box sx={{ mb: 3 }}>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                {notebook?.description || "No description"}
+          <Stack spacing={3}>
+            {/* Metadata */}
+            <Box>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 2, color: "text.secondary" }}>
+                METADATA
               </Typography>
-              <Box sx={{ display: "flex", gap: 3, mt: 2 }}>
-                <Box>
-                  <Typography variant="caption" color="text.secondary">
-                    Created
-                  </Typography>
-                  <Typography variant="body2">{notebook?.created_at ? new Date(notebook.created_at).toLocaleString() : "—"}</Typography>
+              <Stack spacing={1.5}>
+                {notebook.description && (
+                  <Box>
+                    <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                      Description
+                    </Typography>
+                    <Typography variant="body2">{notebook.description}</Typography>
+                  </Box>
+                )}
+                <Box sx={{ display: "flex", gap: 3 }}>
+                  <Box>
+                    <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                      Created
+                    </Typography>
+                    <Typography variant="body2">{new Date(notebook.created_at).toLocaleString()}</Typography>
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                      Updated
+                    </Typography>
+                    <Typography variant="body2">{new Date(notebook.updated_at).toLocaleString()}</Typography>
+                  </Box>
                 </Box>
-                <Box>
-                  <Typography variant="caption" color="text.secondary">
-                    Last Updated
-                  </Typography>
-                  <Typography variant="body2">{notebook?.updated_at ? new Date(notebook.updated_at).toLocaleString() : "—"}</Typography>
-                </Box>
-              </Box>
+              </Stack>
             </Box>
 
-            <Divider sx={{ my: 2 }} />
+            <Divider />
 
+            {/* Experiment History */}
             <Box>
-              <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 2 }}>
-                Experiment History
-              </Typography>
-              {experiments.length === 0 ? (
-                <Box sx={{ py: 3, textAlign: "center" }}>
-                  <Typography variant="body2" color="text.secondary">
-                    No experiments have been run from this notebook yet.
+              <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+                <Typography variant="subtitle2" sx={{ fontWeight: 600, color: "text.secondary" }}>
+                  EXPERIMENT HISTORY
+                </Typography>
+                {notebook.experiments.length > 0 && (
+                  <Typography variant="caption" color="text.secondary">
+                    {notebook.experiments.length} run{notebook.experiments.length !== 1 ? "s" : ""}
                   </Typography>
-                </Box>
+                )}
+              </Box>
+              {notebook.experiments.length === 0 ? (
+                <Typography variant="body2" color="text.secondary" sx={{ fontStyle: "italic", py: 2 }}>
+                  No experiments run yet
+                </Typography>
               ) : (
                 <TableContainer sx={{ maxHeight: 300 }}>
                   <Table size="small" stickyHeader>
                     <TableHead>
                       <TableRow>
-                        <TableCell>
-                          <Typography variant="caption" sx={{ fontWeight: 600 }}>
-                            Name
-                          </Typography>
-                        </TableCell>
-                        <TableCell>
-                          <Typography variant="caption" sx={{ fontWeight: 600 }}>
-                            Status
-                          </Typography>
-                        </TableCell>
-                        <TableCell>
-                          <Typography variant="caption" sx={{ fontWeight: 600 }}>
-                            Configs
-                          </Typography>
-                        </TableCell>
-                        <TableCell>
-                          <Typography variant="caption" sx={{ fontWeight: 600 }}>
-                            Created
-                          </Typography>
-                        </TableCell>
+                        <TableCell sx={{ fontWeight: 600 }}>Name</TableCell>
+                        <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
+                        <TableCell sx={{ fontWeight: 600 }}>Created</TableCell>
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      {experiments.map((experiment) => (
-                        <TableRow key={experiment.id} hover>
+                      {notebook.experiments.map((experiment) => (
+                        <TableRow
+                          key={experiment.id}
+                          hover
+                          sx={{ cursor: "pointer" }}
+                          onClick={() => {
+                            navigate(`/tasks/${taskId}/agent-experiments/${experiment.id}`);
+                            onClose();
+                          }}
+                        >
                           <TableCell>
                             <Typography variant="body2">{experiment.name}</Typography>
                           </TableCell>
                           <TableCell>
                             <Chip label={experiment.status} size="small" sx={getStatusChipSx(experiment.status)} />
-                          </TableCell>
-                          <TableCell>
-                            <Typography variant="body2">{experiment.rag_configs?.length || 0}</Typography>
                           </TableCell>
                           <TableCell>
                             <Typography variant="body2" color="text.secondary">
@@ -221,11 +223,11 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
                 </TableContainer>
               )}
             </Box>
-          </>
+          </Stack>
         )}
       </DialogContent>
     </Dialog>
   );
 };
 
-export default RagNotebookDetailModal;
+export default AgentNotebookDetailModal;

--- a/genai-engine/ui/src/components/agent-notebook/AgentNotebookDetailModal.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/AgentNotebookDetailModal.tsx
@@ -19,7 +19,7 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useAgenticNotebook } from "./hooks/useAgenticNotebook";
@@ -41,6 +41,7 @@ const AgentNotebookDetailModal: React.FC<AgentNotebookDetailModalProps> = ({ ope
 
   const [isRenaming, setIsRenaming] = useState(false);
   const [newNotebookName, setNewNotebookName] = useState("");
+  const isSavingRenameRef = useRef(false);
 
   useEffect(() => {
     if (notebook?.name) setNewNotebookName(notebook.name);
@@ -57,13 +58,19 @@ const AgentNotebookDetailModal: React.FC<AgentNotebookDetailModalProps> = ({ ope
   };
 
   const handleSaveRename = async () => {
+    if (isSavingRenameRef.current) return;
     const trimmed = newNotebookName.trim();
     if (!trimmed || !notebookId || trimmed === notebook?.name) {
       handleCancelRename();
       return;
     }
+    isSavingRenameRef.current = true;
     setIsRenaming(false);
-    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
+    try {
+      await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
+    } finally {
+      isSavingRenameRef.current = false;
+    }
   };
 
   const handleLaunchNotebook = () => {
@@ -115,7 +122,7 @@ const AgentNotebookDetailModal: React.FC<AgentNotebookDetailModalProps> = ({ ope
           )}
         </Box>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <Button variant="outlined" size="small" startIcon={<LaunchIcon />} onClick={handleLaunchNotebook} disabled={!notebookId}>
+          <Button variant="contained" size="small" startIcon={<LaunchIcon />} onClick={handleLaunchNotebook} disabled={!notebookId}>
             Launch
           </Button>
           <IconButton onClick={onClose} size="small">

--- a/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
@@ -8,10 +8,10 @@ import { Link as MuiLink } from "@mui/material";
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
+import { useUpdateAgenticNotebook } from "../../../hooks/useUpdateAgenticNotebook";
 import { agentNotebookStateFormOpts } from "../../form";
 import { useMetaStore } from "../../store/meta.store";
 import { SubmitButton } from "../submit-button";
-import { useUpdateAgenticNotebook } from "../../../hooks/useUpdateAgenticNotebook";
 
 import { useDisplaySettings } from "@/contexts/DisplaySettingsContext";
 import { AgenticNotebookDetail } from "@/lib/api-client/api-client";

--- a/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
@@ -1,14 +1,17 @@
 import { withForm } from "@arthur/shared-components";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import EditIcon from "@mui/icons-material/Edit";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import SaveIcon from "@mui/icons-material/Save";
-import { Box, Button, ButtonGroup, Chip, CircularProgress, Stack, Tooltip, Typography } from "@mui/material";
+import { Box, Button, ButtonGroup, Chip, CircularProgress, IconButton, Stack, TextField, Tooltip, Typography } from "@mui/material";
 import { Link as MuiLink } from "@mui/material";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { agentNotebookStateFormOpts } from "../../form";
 import { useMetaStore } from "../../store/meta.store";
 import { SubmitButton } from "../submit-button";
+import { useUpdateAgenticNotebook } from "../../../hooks/useUpdateAgenticNotebook";
 
 import { useDisplaySettings } from "@/contexts/DisplaySettingsContext";
 import { AgenticNotebookDetail } from "@/lib/api-client/api-client";
@@ -27,6 +30,33 @@ export const Header = withForm({
   render: function Render({ form, notebook, onLoadConfig, onSave, isSaving }) {
     const edited = useMetaStore((state) => state.edited);
     const { timezone, use24Hour } = useDisplaySettings();
+    const updateMutation = useUpdateAgenticNotebook();
+    const [isRenaming, setIsRenaming] = useState(false);
+    const [newNotebookName, setNewNotebookName] = useState(notebook.name);
+
+    useEffect(() => {
+      setNewNotebookName(notebook.name);
+    }, [notebook.name]);
+
+    const handleStartRename = () => {
+      setNewNotebookName(notebook.name);
+      setIsRenaming(true);
+    };
+
+    const handleCancelRename = () => {
+      setIsRenaming(false);
+      setNewNotebookName(notebook.name);
+    };
+
+    const handleSaveRename = async () => {
+      const trimmed = newNotebookName.trim();
+      if (!trimmed || trimmed === notebook.name) {
+        handleCancelRename();
+        return;
+      }
+      setIsRenaming(false);
+      await updateMutation.mutateAsync({ notebookId: notebook.id, request: { name: trimmed, description: notebook.description } });
+    };
 
     return (
       <Box
@@ -54,9 +84,40 @@ export const Header = withForm({
             </Button>
             <Stack mb={1}>
               <Stack direction="row" alignItems="center" gap={1}>
-                <Typography variant="h5" color="text.primary" fontWeight="bold">
-                  {notebook.name}
-                </Typography>
+                {isRenaming ? (
+                  <TextField
+                    variant="filled"
+                    size="small"
+                    value={newNotebookName}
+                    onChange={(e) => setNewNotebookName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleSaveRename();
+                      else if (e.key === "Escape") handleCancelRename();
+                    }}
+                    onBlur={handleSaveRename}
+                    autoFocus
+                    sx={{
+                      "& .MuiInputBase-root": { fontSize: "1.5rem", fontWeight: 700 },
+                    }}
+                  />
+                ) : (
+                  <>
+                    <Typography variant="h5" color="text.primary" fontWeight="bold">
+                      {notebook.name}
+                    </Typography>
+                    <IconButton
+                      size="small"
+                      onClick={handleStartRename}
+                      sx={{
+                        padding: 0.5,
+                        color: "text.secondary",
+                        "&:hover": { color: "text.primary", backgroundColor: "action.hover" },
+                      }}
+                    >
+                      <EditIcon sx={{ fontSize: "1rem" }} />
+                    </IconButton>
+                  </>
+                )}
                 {edited && (
                   <Chip
                     label={

--- a/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
@@ -6,7 +6,7 @@ import SaveIcon from "@mui/icons-material/Save";
 import { Box, Button, ButtonGroup, Chip, CircularProgress, IconButton, Stack, TextField, Tooltip, Typography } from "@mui/material";
 import { Link as MuiLink } from "@mui/material";
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 
 import { agentNotebookStateFormOpts } from "../../form";
 import { useMetaStore } from "../../store/meta.store";
@@ -28,6 +28,7 @@ export const Header = withForm({
   ...agentNotebookStateFormOpts,
   props: {} as Props,
   render: function Render({ form, notebook, onLoadConfig, onSave, isSaving }) {
+    const { id: taskId } = useParams<{ id: string }>();
     const edited = useMetaStore((state) => state.edited);
     const { timezone, use24Hour } = useDisplaySettings();
     const updateMutation = useUpdateAgenticNotebook();
@@ -74,7 +75,7 @@ export const Header = withForm({
             <Button
               size="small"
               component={Link}
-              to=".."
+              to={`/tasks/${taskId}/test?section=agentic-notebooks`}
               variant="text"
               startIcon={<ArrowBackIcon />}
               color="inherit"

--- a/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
@@ -1,11 +1,9 @@
 import { withForm } from "@arthur/shared-components";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import EditIcon from "@mui/icons-material/Edit";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import SaveIcon from "@mui/icons-material/Save";
-import { Box, Button, ButtonGroup, Chip, CircularProgress, IconButton, Stack, TextField, Tooltip, Typography } from "@mui/material";
+import { Box, Button, ButtonGroup, Chip, CircularProgress, Stack, Tooltip, Typography } from "@mui/material";
 import { Link as MuiLink } from "@mui/material";
-import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import { useUpdateAgenticNotebook } from "../../../hooks/useUpdateAgenticNotebook";
@@ -13,6 +11,7 @@ import { agentNotebookStateFormOpts } from "../../form";
 import { useMetaStore } from "../../store/meta.store";
 import { SubmitButton } from "../submit-button";
 
+import { EditableTitle } from "@/components/common";
 import { useDisplaySettings } from "@/contexts/DisplaySettingsContext";
 import { AgenticNotebookDetail } from "@/lib/api-client/api-client";
 import { formatDateInTimezone } from "@/utils/formatters";
@@ -32,39 +31,6 @@ export const Header = withForm({
     const edited = useMetaStore((state) => state.edited);
     const { timezone, use24Hour } = useDisplaySettings();
     const updateMutation = useUpdateAgenticNotebook();
-    const [isRenaming, setIsRenaming] = useState(false);
-    const [newNotebookName, setNewNotebookName] = useState(notebook.name);
-    const isSavingRenameRef = useRef(false);
-
-    useEffect(() => {
-      setNewNotebookName(notebook.name);
-    }, [notebook.name]);
-
-    const handleStartRename = () => {
-      setNewNotebookName(notebook.name);
-      setIsRenaming(true);
-    };
-
-    const handleCancelRename = () => {
-      setIsRenaming(false);
-      setNewNotebookName(notebook.name);
-    };
-
-    const handleSaveRename = async () => {
-      if (isSavingRenameRef.current) return;
-      const trimmed = newNotebookName.trim();
-      if (!trimmed || trimmed === notebook.name) {
-        handleCancelRename();
-        return;
-      }
-      isSavingRenameRef.current = true;
-      setIsRenaming(false);
-      try {
-        await updateMutation.mutateAsync({ notebookId: notebook.id, request: { name: trimmed, description: notebook.description } });
-      } finally {
-        isSavingRenameRef.current = false;
-      }
-    };
 
     return (
       <Box
@@ -92,40 +58,15 @@ export const Header = withForm({
             </Button>
             <Stack mb={1}>
               <Stack direction="row" alignItems="center" gap={1}>
-                {isRenaming ? (
-                  <TextField
-                    variant="filled"
-                    size="small"
-                    value={newNotebookName}
-                    onChange={(e) => setNewNotebookName(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") handleSaveRename();
-                      else if (e.key === "Escape") handleCancelRename();
-                    }}
-                    onBlur={handleSaveRename}
-                    autoFocus
-                    sx={{
-                      "& .MuiInputBase-root": { fontSize: "1.25rem", fontWeight: 600 },
-                    }}
-                  />
-                ) : (
-                  <>
-                    <Typography variant="h6" sx={{ fontWeight: 600, color: "text.primary" }}>
-                      {notebook.name}
-                    </Typography>
-                    <IconButton
-                      size="small"
-                      onClick={handleStartRename}
-                      sx={{
-                        padding: 0.5,
-                        color: "text.secondary",
-                        "&:hover": { color: "text.primary", backgroundColor: "action.hover" },
-                      }}
-                    >
-                      <EditIcon sx={{ fontSize: "1rem" }} />
-                    </IconButton>
-                  </>
-                )}
+                <EditableTitle
+                  value={notebook.name}
+                  onSave={async (newName) => {
+                    await updateMutation.mutateAsync({ notebookId: notebook.id, request: { name: newName, description: notebook.description } });
+                  }}
+                  isPending={updateMutation.isPending}
+                  typographyVariant="h6"
+                  typographySx={{ fontWeight: 600, color: "text.primary" }}
+                />
                 {edited && (
                   <Chip
                     label={

--- a/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
@@ -98,12 +98,12 @@ export const Header = withForm({
                     onBlur={handleSaveRename}
                     autoFocus
                     sx={{
-                      "& .MuiInputBase-root": { fontSize: "1.5rem", fontWeight: 700 },
+                      "& .MuiInputBase-root": { fontSize: "1.25rem", fontWeight: 600 },
                     }}
                   />
                 ) : (
                   <>
-                    <Typography variant="h5" color="text.primary" fontWeight="bold">
+                    <Typography variant="h6" sx={{ fontWeight: 600, color: "text.primary" }}>
                       {notebook.name}
                     </Typography>
                     <IconButton

--- a/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/[notebookId]/components/header/index.tsx
@@ -5,7 +5,7 @@ import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import SaveIcon from "@mui/icons-material/Save";
 import { Box, Button, ButtonGroup, Chip, CircularProgress, IconButton, Stack, TextField, Tooltip, Typography } from "@mui/material";
 import { Link as MuiLink } from "@mui/material";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import { useUpdateAgenticNotebook } from "../../../hooks/useUpdateAgenticNotebook";
@@ -34,6 +34,7 @@ export const Header = withForm({
     const updateMutation = useUpdateAgenticNotebook();
     const [isRenaming, setIsRenaming] = useState(false);
     const [newNotebookName, setNewNotebookName] = useState(notebook.name);
+    const isSavingRenameRef = useRef(false);
 
     useEffect(() => {
       setNewNotebookName(notebook.name);
@@ -50,13 +51,19 @@ export const Header = withForm({
     };
 
     const handleSaveRename = async () => {
+      if (isSavingRenameRef.current) return;
       const trimmed = newNotebookName.trim();
       if (!trimmed || trimmed === notebook.name) {
         handleCancelRename();
         return;
       }
+      isSavingRenameRef.current = true;
       setIsRenaming(false);
-      await updateMutation.mutateAsync({ notebookId: notebook.id, request: { name: trimmed, description: notebook.description } });
+      try {
+        await updateMutation.mutateAsync({ notebookId: notebook.id, request: { name: trimmed, description: notebook.description } });
+      } finally {
+        isSavingRenameRef.current = false;
+      }
     };
 
     return (

--- a/genai-engine/ui/src/components/agent-notebook/hooks/useAgenticNotebook.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/hooks/useAgenticNotebook.tsx
@@ -14,5 +14,5 @@ export const agenticNotebookQueryOptions = ({ api, notebookId }: { api: Api<unkn
 export const useAgenticNotebook = (notebookId: string) => {
   const api = useApi()!;
 
-  return useQuery(agenticNotebookQueryOptions({ api, notebookId }));
+  return useQuery({ ...agenticNotebookQueryOptions({ api, notebookId }), enabled: !!notebookId });
 };

--- a/genai-engine/ui/src/components/agent-notebook/hooks/useUpdateAgenticNotebook.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/hooks/useUpdateAgenticNotebook.tsx
@@ -11,16 +11,17 @@ type Opts = {
 
 export const useUpdateAgenticNotebook = (opts: Opts = {}) => {
   const queryClient = useQueryClient();
-  const { api } = useApi()!;
+  const apiContext = useApi();
   const { task } = useTask();
 
   return useMutation({
     mutationFn: async ({ notebookId, request }: { notebookId: string; request: UpdateAgenticNotebookRequest }) => {
-      const response = await api.updateAgenticNotebookApiV1AgenticNotebooksNotebookIdPut(notebookId, request);
+      if (!apiContext) throw new Error("API client not available");
+      const response = await apiContext.api.updateAgenticNotebookApiV1AgenticNotebooksNotebookIdPut(notebookId, request);
       return response.data;
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.agentNotebooks.all(task!.id) });
+      if (task?.id) queryClient.invalidateQueries({ queryKey: queryKeys.agentNotebooks.all(task.id) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agentNotebooks.byId(data.id) });
       opts.onSuccess?.(data);
     },

--- a/genai-engine/ui/src/components/agent-notebook/hooks/useUpdateAgenticNotebook.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/hooks/useUpdateAgenticNotebook.tsx
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { useApi } from "@/hooks/useApi";
+import { useTask } from "@/hooks/useTask";
+import { AgenticNotebookDetail, UpdateAgenticNotebookRequest } from "@/lib/api-client/api-client";
+import { queryKeys } from "@/lib/queryKeys";
+
+type Opts = {
+  onSuccess?: (data: AgenticNotebookDetail) => void;
+};
+
+export const useUpdateAgenticNotebook = (opts: Opts = {}) => {
+  const queryClient = useQueryClient();
+  const { api } = useApi()!;
+  const { task } = useTask();
+
+  return useMutation({
+    mutationFn: async ({ notebookId, request }: { notebookId: string; request: UpdateAgenticNotebookRequest }) => {
+      const response = await api.updateAgenticNotebookApiV1AgenticNotebooksNotebookIdPut(notebookId, request);
+      return response.data;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.agentNotebooks.all(task!.id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agentNotebooks.byId(data.id) });
+      opts.onSuccess?.(data);
+    },
+  });
+};

--- a/genai-engine/ui/src/components/agent-notebook/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/index.tsx
@@ -20,6 +20,7 @@ import { useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import z from "zod";
 
+import AgentNotebookDetailModal from "./AgentNotebookDetailModal";
 import { createColumns } from "./data/columns";
 import { useAgentNotebooks } from "./hooks/useAgentNotebooks";
 import { useCreateAgenticNotebook } from "./hooks/useCreateAgenticNotebook";
@@ -57,6 +58,7 @@ export const AgentNotebook = ({ embedded = false, isCreateModalOpen, onCreateMod
     },
   });
   const [internalDialogOpen, setInternalDialogOpen] = useState(false);
+  const [selectedNotebookId, setSelectedNotebookId] = useState<string | null>(null);
   const dialogOpen = isCreateModalOpen !== undefined ? isCreateModalOpen : internalDialogOpen;
   const { data, isLoading, isRefetching } = useAgentNotebooks({ page: pagination.pageIndex, page_size: pagination.pageSize });
 
@@ -116,7 +118,7 @@ export const AgentNotebook = ({ embedded = false, isCreateModalOpen, onCreateMod
     },
     muiTableBodyRowProps: ({ row }) => ({
       onClick: () => {
-        navigate(`/tasks/${taskId}/agentic-notebooks/${row.original.id}`);
+        setSelectedNotebookId(row.original.id);
       },
       sx: {
         cursor: "pointer",
@@ -203,6 +205,8 @@ export const AgentNotebook = ({ embedded = false, isCreateModalOpen, onCreateMod
           <MaterialReactTable table={table} />
         )}
       </Stack>
+
+      <AgentNotebookDetailModal open={selectedNotebookId !== null} notebookId={selectedNotebookId} onClose={() => setSelectedNotebookId(null)} />
 
       <Dialog open={dialogOpen} onClose={handleCloseCreateNotebook} fullWidth>
         <DialogTitle>New Notebook</DialogTitle>

--- a/genai-engine/ui/src/components/agent-notebook/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/index.tsx
@@ -127,6 +127,9 @@ export const AgentNotebook = ({ embedded = false, isCreateModalOpen, onCreateMod
     }),
     enableColumnPinning: true,
     initialState: { columnPinning: { right: ["mrt-row-actions"] } },
+    displayColumnDefOptions: {
+      "mrt-row-actions": { size: 160 },
+    },
     enableRowActions: true,
     positionActionsColumn: "last",
     renderRowActions: ({ row }) => (

--- a/genai-engine/ui/src/components/agent-notebook/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/index.tsx
@@ -136,6 +136,17 @@ export const AgentNotebook = ({ embedded = false, isCreateModalOpen, onCreateMod
     positionActionsColumn: "last",
     renderRowActions: ({ row }) => (
       <Box sx={{ display: "flex", gap: 1 }}>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<LaunchIcon />}
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/tasks/${taskId}/agentic-notebooks/${row.original.id}`);
+          }}
+        >
+          Launch
+        </Button>
         <Tooltip title={row.original.latest_run_id ? "View last run" : "No runs yet"}>
           <span>
             <IconButton
@@ -152,17 +163,6 @@ export const AgentNotebook = ({ embedded = false, isCreateModalOpen, onCreateMod
             </IconButton>
           </span>
         </Tooltip>
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<LaunchIcon />}
-          onClick={(e) => {
-            e.stopPropagation();
-            navigate(`/tasks/${taskId}/agentic-notebooks/${row.original.id}`);
-          }}
-        >
-          Launch
-        </Button>
         <Tooltip title="Delete Notebook">
           <IconButton
             size="small"

--- a/genai-engine/ui/src/components/agent-notebook/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/index.tsx
@@ -1,6 +1,7 @@
 import { useAppForm } from "@arthur/shared-components";
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
+import HistoryIcon from "@mui/icons-material/History";
 import LaunchIcon from "@mui/icons-material/Launch";
 import MenuBookOutlinedIcon from "@mui/icons-material/MenuBookOutlined";
 import {
@@ -129,12 +130,28 @@ export const AgentNotebook = ({ embedded = false, isCreateModalOpen, onCreateMod
     enableColumnPinning: true,
     initialState: { columnPinning: { right: ["mrt-row-actions"] } },
     displayColumnDefOptions: {
-      "mrt-row-actions": { size: 140 },
+      "mrt-row-actions": { size: 180 },
     },
     enableRowActions: true,
     positionActionsColumn: "last",
     renderRowActions: ({ row }) => (
       <Box sx={{ display: "flex", gap: 1 }}>
+        <Tooltip title={row.original.latest_run_id ? "View last run" : "No runs yet"}>
+          <span>
+            <IconButton
+              size="small"
+              disabled={!row.original.latest_run_id}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (row.original.latest_run_id) {
+                  navigate(`/tasks/${taskId}/agent-experiments/${row.original.latest_run_id}`);
+                }
+              }}
+            >
+              <HistoryIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
         <Button
           variant="outlined"
           size="small"

--- a/genai-engine/ui/src/components/agent-notebook/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/index.tsx
@@ -1,5 +1,6 @@
 import { useAppForm } from "@arthur/shared-components";
 import AddIcon from "@mui/icons-material/Add";
+import LaunchIcon from "@mui/icons-material/Launch";
 import MenuBookOutlinedIcon from "@mui/icons-material/MenuBookOutlined";
 import {
   Box,
@@ -128,6 +129,19 @@ export const AgentNotebook = ({ embedded = false, isCreateModalOpen, onCreateMod
     initialState: { columnPinning: { right: ["mrt-row-actions"] } },
     enableRowActions: true,
     positionActionsColumn: "last",
+    renderRowActions: ({ row }) => (
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<LaunchIcon />}
+        onClick={(e) => {
+          e.stopPropagation();
+          navigate(`/tasks/${taskId}/agentic-notebooks/${row.original.id}`);
+        }}
+      >
+        Launch
+      </Button>
+    ),
     renderRowActionMenuItems: ({ row }) => [
       <MenuItem
         disabled={!row.original.latest_run_id}

--- a/genai-engine/ui/src/components/agent-notebook/index.tsx
+++ b/genai-engine/ui/src/components/agent-notebook/index.tsx
@@ -1,5 +1,6 @@
 import { useAppForm } from "@arthur/shared-components";
 import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/Delete";
 import LaunchIcon from "@mui/icons-material/Launch";
 import MenuBookOutlinedIcon from "@mui/icons-material/MenuBookOutlined";
 import {
@@ -10,15 +11,15 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Divider,
-  MenuItem,
+  IconButton,
   Stack,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { MaterialReactTable, useMaterialReactTable } from "material-react-table";
 import { useMemo, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import z from "zod";
 
 import AgentNotebookDetailModal from "./AgentNotebookDetailModal";
@@ -128,37 +129,37 @@ export const AgentNotebook = ({ embedded = false, isCreateModalOpen, onCreateMod
     enableColumnPinning: true,
     initialState: { columnPinning: { right: ["mrt-row-actions"] } },
     displayColumnDefOptions: {
-      "mrt-row-actions": { size: 160 },
+      "mrt-row-actions": { size: 140 },
     },
     enableRowActions: true,
     positionActionsColumn: "last",
     renderRowActions: ({ row }) => (
-      <Button
-        variant="outlined"
-        size="small"
-        startIcon={<LaunchIcon />}
-        onClick={(e) => {
-          e.stopPropagation();
-          navigate(`/tasks/${taskId}/agentic-notebooks/${row.original.id}`);
-        }}
-      >
-        Launch
-      </Button>
+      <Box sx={{ display: "flex", gap: 1 }}>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<LaunchIcon />}
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/tasks/${taskId}/agentic-notebooks/${row.original.id}`);
+          }}
+        >
+          Launch
+        </Button>
+        <Tooltip title="Delete Notebook">
+          <IconButton
+            size="small"
+            color="error"
+            onClick={(e) => {
+              e.stopPropagation();
+              deleteAgenticNotebook.mutate(row.original.id);
+            }}
+          >
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Box>
     ),
-    renderRowActionMenuItems: ({ row }) => [
-      <MenuItem
-        disabled={!row.original.latest_run_id}
-        key="view_run"
-        component={Link}
-        to={`/tasks/${row.original.task_id}/agent-experiments/${row.original.latest_run_id}`}
-      >
-        View Latest Run
-      </MenuItem>,
-      <Divider />,
-      <MenuItem key="delete" onClick={() => deleteAgenticNotebook.mutate(row.original.id)}>
-        Delete
-      </MenuItem>,
-    ],
   });
 
   return (

--- a/genai-engine/ui/src/components/common/EditableTitle.tsx
+++ b/genai-engine/ui/src/components/common/EditableTitle.tsx
@@ -1,0 +1,99 @@
+import EditIcon from "@mui/icons-material/Edit";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import { SxProps, Theme } from "@mui/material/styles";
+import TextField from "@mui/material/TextField";
+import Typography, { TypographyProps } from "@mui/material/Typography";
+import { useEffect, useState } from "react";
+
+interface EditableTitleProps {
+  value: string;
+  onSave: (newValue: string) => Promise<void>;
+  isPending?: boolean;
+  fallbackText?: string;
+  showEditButton?: boolean;
+  typographyVariant?: TypographyProps["variant"];
+  typographySx?: SxProps<Theme>;
+  textFieldSx?: SxProps<Theme>;
+}
+
+export const EditableTitle = ({
+  value,
+  onSave,
+  isPending = false,
+  fallbackText = "",
+  showEditButton = true,
+  typographyVariant = "h6",
+  typographySx,
+  textFieldSx,
+}: EditableTitleProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(value);
+
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  const handleStart = () => {
+    setInputValue(value);
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setInputValue(value);
+  };
+
+  const handleSave = async () => {
+    if (isPending) return;
+    const trimmed = inputValue.trim();
+    if (!trimmed || trimmed === value) {
+      handleCancel();
+      return;
+    }
+    setIsEditing(false);
+    await onSave(trimmed);
+  };
+
+  if (isEditing) {
+    return (
+      <TextField
+        variant="filled"
+        size="small"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleSave();
+          else if (e.key === "Escape") handleCancel();
+        }}
+        onBlur={handleSave}
+        autoFocus
+        sx={{
+          "& .MuiInputBase-root": { fontSize: "1.25rem", fontWeight: 600 },
+          ...textFieldSx,
+        }}
+      />
+    );
+  }
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+      <Typography variant={typographyVariant} component="span" sx={typographySx}>
+        {value || fallbackText}
+      </Typography>
+      {showEditButton && (
+        <IconButton
+          size="small"
+          onClick={handleStart}
+          sx={{
+            padding: 0.5,
+            color: "text.secondary",
+            "&:hover": { color: "text.primary", backgroundColor: "action.hover" },
+          }}
+        >
+          <EditIcon sx={{ fontSize: "1rem" }} />
+        </IconButton>
+      )}
+    </Box>
+  );
+};

--- a/genai-engine/ui/src/components/common/index.ts
+++ b/genai-engine/ui/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export { CopyableChip } from "./CopyableChip";
+export { EditableTitle } from "./EditableTitle";
 export { ResultChip } from "./ResultChip";
 export { UpdateDatasetRowModal } from "./UpdateDatasetRowModal";

--- a/genai-engine/ui/src/components/notebooks/NotebookDetailModal.tsx
+++ b/genai-engine/ui/src/components/notebooks/NotebookDetailModal.tsx
@@ -1,6 +1,9 @@
 import CloseIcon from "@mui/icons-material/Close";
+import EditIcon from "@mui/icons-material/Edit";
+import LaunchIcon from "@mui/icons-material/Launch";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
 import CircularProgress from "@mui/material/CircularProgress";
 import Dialog from "@mui/material/Dialog";
@@ -15,11 +18,12 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
+import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { useNotebook, useNotebookHistory } from "@/hooks/useNotebooks";
+import { useNotebook, useNotebookHistory, useUpdateNotebookMutation } from "@/hooks/useNotebooks";
 import {
   EvalRefOutput,
   PromptExperimentSummary,
@@ -40,6 +44,34 @@ const NotebookDetailModal: React.FC<NotebookDetailModalProps> = ({ open, noteboo
   const navigate = useNavigate();
   const { notebook, isLoading, error } = useNotebook(notebookId || undefined);
   const { experiments, isLoading: isLoadingHistory } = useNotebookHistory(notebookId || undefined, 0, 10);
+  const updateMutation = useUpdateNotebookMutation(taskId);
+
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [newNotebookName, setNewNotebookName] = useState("");
+
+  useEffect(() => {
+    if (notebook?.name) setNewNotebookName(notebook.name);
+  }, [notebook?.name]);
+
+  const handleStartRename = () => {
+    setNewNotebookName(notebook?.name ?? "");
+    setIsRenaming(true);
+  };
+
+  const handleCancelRename = () => {
+    setIsRenaming(false);
+    setNewNotebookName(notebook?.name ?? "");
+  };
+
+  const handleSaveRename = async () => {
+    const trimmed = newNotebookName.trim();
+    if (!trimmed || !notebookId || trimmed === notebook?.name) {
+      handleCancelRename();
+      return;
+    }
+    setIsRenaming(false);
+    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
+  };
 
   const handleExperimentClick = (experimentId: string) => {
     navigate(`/tasks/${taskId}/prompt-experiments/${experimentId}`);
@@ -48,11 +80,59 @@ const NotebookDetailModal: React.FC<NotebookDetailModalProps> = ({ open, noteboo
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>
-        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-          <Typography variant="h6" sx={{ fontWeight: 600 }}>
-            Notebook Details
-          </Typography>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          {isRenaming ? (
+            <TextField
+              variant="filled"
+              size="small"
+              value={newNotebookName}
+              onChange={(e) => setNewNotebookName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSaveRename();
+                else if (e.key === "Escape") handleCancelRename();
+              }}
+              onBlur={handleSaveRename}
+              autoFocus
+              sx={{
+                "& .MuiInputBase-root": { fontSize: "1.25rem", fontWeight: 600 },
+              }}
+            />
+          ) : (
+            <>
+              <Typography variant="h6" component="span">
+                {notebook?.name || "Notebook Details"}
+              </Typography>
+              {notebook && (
+                <IconButton
+                  size="small"
+                  onClick={handleStartRename}
+                  sx={{
+                    padding: 0.5,
+                    color: "text.secondary",
+                    "&:hover": { color: "text.primary", backgroundColor: "action.hover" },
+                  }}
+                >
+                  <EditIcon sx={{ fontSize: "1rem" }} />
+                </IconButton>
+              )}
+            </>
+          )}
+        </Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          {notebookId && (
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<LaunchIcon />}
+              onClick={() => {
+                navigate(`/tasks/${taskId}/playgrounds/prompts?notebookId=${notebookId}`);
+                onClose();
+              }}
+            >
+              Launch
+            </Button>
+          )}
           <IconButton onClick={onClose} size="small">
             <CloseIcon />
           </IconButton>

--- a/genai-engine/ui/src/components/notebooks/NotebookDetailModal.tsx
+++ b/genai-engine/ui/src/components/notebooks/NotebookDetailModal.tsx
@@ -20,7 +20,7 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useNotebook, useNotebookHistory, useUpdateNotebookMutation } from "@/hooks/useNotebooks";
@@ -48,7 +48,6 @@ const NotebookDetailModal: React.FC<NotebookDetailModalProps> = ({ open, noteboo
 
   const [isRenaming, setIsRenaming] = useState(false);
   const [newNotebookName, setNewNotebookName] = useState("");
-  const isSavingRenameRef = useRef(false);
 
   useEffect(() => {
     if (notebook?.name) setNewNotebookName(notebook.name);
@@ -65,19 +64,14 @@ const NotebookDetailModal: React.FC<NotebookDetailModalProps> = ({ open, noteboo
   };
 
   const handleSaveRename = async () => {
-    if (isSavingRenameRef.current) return;
+    if (updateMutation.isPending) return;
     const trimmed = newNotebookName.trim();
     if (!trimmed || !notebookId || trimmed === notebook?.name) {
       handleCancelRename();
       return;
     }
-    isSavingRenameRef.current = true;
     setIsRenaming(false);
-    try {
-      await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
-    } finally {
-      isSavingRenameRef.current = false;
-    }
+    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
   };
 
   const handleExperimentClick = (experimentId: string) => {

--- a/genai-engine/ui/src/components/notebooks/NotebookDetailModal.tsx
+++ b/genai-engine/ui/src/components/notebooks/NotebookDetailModal.tsx
@@ -20,7 +20,7 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useNotebook, useNotebookHistory, useUpdateNotebookMutation } from "@/hooks/useNotebooks";
@@ -48,6 +48,7 @@ const NotebookDetailModal: React.FC<NotebookDetailModalProps> = ({ open, noteboo
 
   const [isRenaming, setIsRenaming] = useState(false);
   const [newNotebookName, setNewNotebookName] = useState("");
+  const isSavingRenameRef = useRef(false);
 
   useEffect(() => {
     if (notebook?.name) setNewNotebookName(notebook.name);
@@ -64,13 +65,19 @@ const NotebookDetailModal: React.FC<NotebookDetailModalProps> = ({ open, noteboo
   };
 
   const handleSaveRename = async () => {
+    if (isSavingRenameRef.current) return;
     const trimmed = newNotebookName.trim();
     if (!trimmed || !notebookId || trimmed === notebook?.name) {
       handleCancelRename();
       return;
     }
+    isSavingRenameRef.current = true;
     setIsRenaming(false);
-    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
+    try {
+      await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
+    } finally {
+      isSavingRenameRef.current = false;
+    }
   };
 
   const handleExperimentClick = (experimentId: string) => {

--- a/genai-engine/ui/src/components/notebooks/NotebookDetailModal.tsx
+++ b/genai-engine/ui/src/components/notebooks/NotebookDetailModal.tsx
@@ -1,5 +1,4 @@
 import CloseIcon from "@mui/icons-material/Close";
-import EditIcon from "@mui/icons-material/Edit";
 import LaunchIcon from "@mui/icons-material/Launch";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import Box from "@mui/material/Box";
@@ -18,11 +17,11 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { EditableTitle } from "@/components/common";
 import { useNotebook, useNotebookHistory, useUpdateNotebookMutation } from "@/hooks/useNotebooks";
 import {
   EvalRefOutput,
@@ -46,34 +45,6 @@ const NotebookDetailModal: React.FC<NotebookDetailModalProps> = ({ open, noteboo
   const { experiments, isLoading: isLoadingHistory } = useNotebookHistory(notebookId || undefined, 0, 10);
   const updateMutation = useUpdateNotebookMutation(taskId);
 
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [newNotebookName, setNewNotebookName] = useState("");
-
-  useEffect(() => {
-    if (notebook?.name) setNewNotebookName(notebook.name);
-  }, [notebook?.name]);
-
-  const handleStartRename = () => {
-    setNewNotebookName(notebook?.name ?? "");
-    setIsRenaming(true);
-  };
-
-  const handleCancelRename = () => {
-    setIsRenaming(false);
-    setNewNotebookName(notebook?.name ?? "");
-  };
-
-  const handleSaveRename = async () => {
-    if (updateMutation.isPending) return;
-    const trimmed = newNotebookName.trim();
-    if (!trimmed || !notebookId || trimmed === notebook?.name) {
-      handleCancelRename();
-      return;
-    }
-    setIsRenaming(false);
-    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
-  };
-
   const handleExperimentClick = (experimentId: string) => {
     navigate(`/tasks/${taskId}/prompt-experiments/${experimentId}`);
     onClose();
@@ -82,44 +53,17 @@ const NotebookDetailModal: React.FC<NotebookDetailModalProps> = ({ open, noteboo
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          {isRenaming ? (
-            <TextField
-              variant="filled"
-              size="small"
-              value={newNotebookName}
-              onChange={(e) => setNewNotebookName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleSaveRename();
-                else if (e.key === "Escape") handleCancelRename();
-              }}
-              onBlur={handleSaveRename}
-              autoFocus
-              sx={{
-                "& .MuiInputBase-root": { fontSize: "1.25rem", fontWeight: 600 },
-              }}
-            />
-          ) : (
-            <>
-              <Typography variant="h6" component="span">
-                {notebook?.name || "Notebook Details"}
-              </Typography>
-              {notebook && (
-                <IconButton
-                  size="small"
-                  onClick={handleStartRename}
-                  sx={{
-                    padding: 0.5,
-                    color: "text.secondary",
-                    "&:hover": { color: "text.primary", backgroundColor: "action.hover" },
-                  }}
-                >
-                  <EditIcon sx={{ fontSize: "1rem" }} />
-                </IconButton>
-              )}
-            </>
-          )}
-        </Box>
+        <EditableTitle
+          value={notebook?.name ?? ""}
+          onSave={async (newName) => {
+            if (notebookId) {
+              await updateMutation.mutateAsync({ notebookId, request: { name: newName, description: notebook?.description } });
+            }
+          }}
+          isPending={updateMutation.isPending}
+          fallbackText="Notebook Details"
+          showEditButton={!!notebook}
+        />
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           {notebookId && (
             <Button

--- a/genai-engine/ui/src/components/notebooks/Notebooks.tsx
+++ b/genai-engine/ui/src/components/notebooks/Notebooks.tsx
@@ -88,6 +88,15 @@ const Notebooks: React.FC<NotebooksProps> = ({ onRegisterCreate }) => {
     [taskId, navigate]
   );
 
+  const handleViewLastRun = useCallback(
+    (experimentId: string) => {
+      if (taskId) {
+        navigate(`/tasks/${taskId}/prompt-experiments/${experimentId}`);
+      }
+    },
+    [taskId, navigate]
+  );
+
   const handleSort = useCallback(
     (column: string) => {
       if (sortColumn === column) {
@@ -199,6 +208,7 @@ const Notebooks: React.FC<NotebooksProps> = ({ onRegisterCreate }) => {
             onSort={handleSort}
             onRowClick={handleRowClick}
             onLaunchNotebook={handleLaunchNotebook}
+            onViewLastRun={handleViewLastRun}
             onDelete={deleteMutation.mutateAsync}
           />
         )}

--- a/genai-engine/ui/src/components/notebooks/NotebooksTable.tsx
+++ b/genai-engine/ui/src/components/notebooks/NotebooksTable.tsx
@@ -156,6 +156,19 @@ const NotebooksTable: React.FC<NotebooksTableProps> = ({
                 </TableCell>
                 <TableCell align="right">
                   <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                    <Tooltip title="Launch Notebook">
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={<LaunchIcon />}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onLaunchNotebook(notebook.id);
+                        }}
+                      >
+                        Launch
+                      </Button>
+                    </Tooltip>
                     <Tooltip title={notebook.latest_run_id ? "View last run" : "No runs yet"}>
                       <span>
                         <IconButton
@@ -169,19 +182,6 @@ const NotebooksTable: React.FC<NotebooksTableProps> = ({
                           <HistoryIcon fontSize="small" />
                         </IconButton>
                       </span>
-                    </Tooltip>
-                    <Tooltip title="Launch Notebook">
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        startIcon={<LaunchIcon />}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onLaunchNotebook(notebook.id);
-                        }}
-                      >
-                        Launch
-                      </Button>
                     </Tooltip>
                     <Tooltip title="Delete Notebook">
                       <IconButton size="small" onClick={(e) => handleDeleteClick(notebook, e)} color="error">

--- a/genai-engine/ui/src/components/notebooks/NotebooksTable.tsx
+++ b/genai-engine/ui/src/components/notebooks/NotebooksTable.tsx
@@ -1,4 +1,5 @@
 import DeleteIcon from "@mui/icons-material/Delete";
+import HistoryIcon from "@mui/icons-material/History";
 import LaunchIcon from "@mui/icons-material/Launch";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -27,7 +28,16 @@ import type { NotebooksTableProps } from "./types";
 import { NotebookSummary } from "@/lib/api-client/api-client";
 import { getStatusChipSx } from "@/utils/statusChipStyles";
 
-const NotebooksTable: React.FC<NotebooksTableProps> = ({ notebooks, sortColumn, sortDirection, onSort, onRowClick, onLaunchNotebook, onDelete }) => {
+const NotebooksTable: React.FC<NotebooksTableProps> = ({
+  notebooks,
+  sortColumn,
+  sortDirection,
+  onSort,
+  onRowClick,
+  onLaunchNotebook,
+  onViewLastRun,
+  onDelete,
+}) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [notebookToDelete, setNotebookToDelete] = useState<NotebookSummary | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -146,6 +156,20 @@ const NotebooksTable: React.FC<NotebooksTableProps> = ({ notebooks, sortColumn, 
                 </TableCell>
                 <TableCell align="right">
                   <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                    <Tooltip title={notebook.latest_run_id ? "View last run" : "No runs yet"}>
+                      <span>
+                        <IconButton
+                          size="small"
+                          disabled={!notebook.latest_run_id}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (notebook.latest_run_id) onViewLastRun(notebook.latest_run_id);
+                          }}
+                        >
+                          <HistoryIcon fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
                     <Tooltip title="Launch Notebook">
                       <Button
                         variant="outlined"

--- a/genai-engine/ui/src/components/notebooks/NotebooksTable.tsx
+++ b/genai-engine/ui/src/components/notebooks/NotebooksTable.tsx
@@ -117,7 +117,7 @@ const NotebooksTable: React.FC<NotebooksTableProps> = ({
                   </Typography>
                 </TableSortLabel>
               </TableCell>
-              <TableCell align="right">
+              <TableCell>
                 <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
                   Actions
                 </Typography>
@@ -154,8 +154,8 @@ const NotebooksTable: React.FC<NotebooksTableProps> = ({
                     {new Date(notebook.updated_at).toLocaleString()}
                   </Typography>
                 </TableCell>
-                <TableCell align="right">
-                  <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                <TableCell>
+                  <Box sx={{ display: "flex", gap: 1 }}>
                     <Tooltip title="Launch Notebook">
                       <Button
                         variant="outlined"

--- a/genai-engine/ui/src/components/notebooks/types.ts
+++ b/genai-engine/ui/src/components/notebooks/types.ts
@@ -11,5 +11,6 @@ export interface NotebooksTableProps {
   onSort: (column: string) => void;
   onRowClick: (notebookId: string) => void;
   onLaunchNotebook: (notebookId: string) => void;
+  onViewLastRun: (experimentId: string) => void;
   onDelete: (notebookId: string) => Promise<void>;
 }

--- a/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
@@ -84,14 +84,14 @@ export default function PlaygroundHeader({
       <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
         <Stack direction="row" alignItems="center" spacing={2}>
           {notebookId && (
-            <>
+            <Stack alignItems="flex-start">
               <Button
                 size="small"
                 variant="text"
                 startIcon={<ArrowBackIcon />}
                 color="inherit"
                 onClick={() => navigate(`/tasks/${task?.id}/prompts`)}
-                sx={{ color: "text.primary", whiteSpace: "nowrap" }}
+                sx={{ color: "text.primary" }}
               >
                 Back to Notebooks
               </Button>
@@ -181,7 +181,7 @@ export default function PlaygroundHeader({
                   </>
                 )}
               </Box>
-            </>
+            </Stack>
           )}
         </Stack>
 

--- a/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
@@ -1,7 +1,6 @@
 import AddIcon from "@mui/icons-material/Add";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import CheckIcon from "@mui/icons-material/Check";
-import EditIcon from "@mui/icons-material/Edit";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import SaveIcon from "@mui/icons-material/Save";
@@ -11,30 +10,24 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
 import Container from "@mui/material/Container";
-import IconButton from "@mui/material/IconButton";
 import Popover from "@mui/material/Popover";
 import Stack from "@mui/material/Stack";
-import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
-import Typography from "@mui/material/Typography";
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import VariableInputs from "./VariableInputs";
 
+import { EditableTitle } from "@/components/common";
 import { useTask } from "@/hooks/useTask";
 import type { PromptExperimentDetail } from "@/lib/api-client/api-client";
 
 export interface PlaygroundHeaderProps {
   notebookId: string | null;
-  isRenaming: boolean;
-  newNotebookName: string;
-  setNewNotebookName: (name: string) => void;
   saveStatus: "saved" | "saving" | "unsaved";
   notebookName: string;
-  onStartRename: () => void;
-  onSaveRename: () => void;
-  onCancelRename: () => void;
+  onSaveRename: (newName: string) => Promise<void>;
+  isRenamePending: boolean;
   onManualSave: () => void;
   configDrawerOpen: boolean;
   configModeActive: boolean;
@@ -52,14 +45,10 @@ export interface PlaygroundHeaderProps {
  */
 export default function PlaygroundHeader({
   notebookId,
-  isRenaming,
-  newNotebookName,
-  setNewNotebookName,
   saveStatus,
   notebookName,
-  onStartRename,
   onSaveRename,
-  onCancelRename,
+  isRenamePending,
   onManualSave,
   configDrawerOpen,
   configModeActive,
@@ -96,90 +85,54 @@ export default function PlaygroundHeader({
                 Back to Notebooks
               </Button>
               <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                {isRenaming ? (
-                  <TextField
-                    variant="filled"
-                    size="small"
-                    value={newNotebookName}
-                    onChange={(e) => setNewNotebookName(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        onSaveRename();
-                      } else if (e.key === "Escape") {
-                        onCancelRename();
-                      }
-                    }}
-                    onBlur={onSaveRename}
-                    autoFocus
-                    sx={{
-                      "& .MuiInputBase-root": {
-                        fontSize: "1.25rem",
-                        fontWeight: 600,
-                      },
-                    }}
-                  />
-                ) : (
-                  <>
-                    <Tooltip
-                      title={saveStatus === "saved" ? "All changes saved" : saveStatus === "saving" ? "Saving changes..." : "Click to save changes"}
-                      arrow
-                    >
-                      <span>
-                        <Button
-                          size="small"
-                          variant={saveStatus === "unsaved" ? "contained" : "outlined"}
-                          onClick={() => {
-                            if (saveStatus === "unsaved") {
-                              onManualSave();
-                            }
-                          }}
-                          disabled={saveStatus !== "unsaved"}
-                          startIcon={
-                            saveStatus === "saving" ? (
-                              <CircularProgress size={14} color="inherit" />
-                            ) : saveStatus === "saved" ? (
-                              <CheckIcon />
-                            ) : (
-                              <SaveIcon />
-                            )
-                          }
-                          sx={{
-                            minWidth: "auto",
-                            px: 1.5,
-                            py: 0.5,
-                            fontSize: "0.75rem",
-                            textTransform: "none",
-                            color: saveStatus === "saved" ? "success.main" : undefined,
-                            borderColor: saveStatus === "saved" ? "success.main" : undefined,
-                            "&.Mui-disabled": {
-                              color: saveStatus === "saved" ? "success.main" : undefined,
-                              borderColor: saveStatus === "saved" ? "success.main" : undefined,
-                            },
-                          }}
-                        >
-                          {saveStatus === "saved" ? "Saved" : saveStatus === "saving" ? "Saving..." : "Save"}
-                        </Button>
-                      </span>
-                    </Tooltip>
-                    <Typography variant="h6" sx={{ fontWeight: 600, color: "text.primary" }}>
-                      {notebookName || "Notebook"}
-                    </Typography>
-                    <IconButton
+                <Tooltip
+                  title={saveStatus === "saved" ? "All changes saved" : saveStatus === "saving" ? "Saving changes..." : "Click to save changes"}
+                  arrow
+                >
+                  <span>
+                    <Button
                       size="small"
-                      onClick={onStartRename}
+                      variant={saveStatus === "unsaved" ? "contained" : "outlined"}
+                      onClick={() => {
+                        if (saveStatus === "unsaved") {
+                          onManualSave();
+                        }
+                      }}
+                      disabled={saveStatus !== "unsaved"}
+                      startIcon={
+                        saveStatus === "saving" ? (
+                          <CircularProgress size={14} color="inherit" />
+                        ) : saveStatus === "saved" ? (
+                          <CheckIcon />
+                        ) : (
+                          <SaveIcon />
+                        )
+                      }
                       sx={{
-                        padding: 0.5,
-                        color: "text.secondary",
-                        "&:hover": {
-                          color: "text.primary",
-                          backgroundColor: "action.hover",
+                        minWidth: "auto",
+                        px: 1.5,
+                        py: 0.5,
+                        fontSize: "0.75rem",
+                        textTransform: "none",
+                        color: saveStatus === "saved" ? "success.main" : undefined,
+                        borderColor: saveStatus === "saved" ? "success.main" : undefined,
+                        "&.Mui-disabled": {
+                          color: saveStatus === "saved" ? "success.main" : undefined,
+                          borderColor: saveStatus === "saved" ? "success.main" : undefined,
                         },
                       }}
                     >
-                      <EditIcon sx={{ fontSize: "1rem" }} />
-                    </IconButton>
-                  </>
-                )}
+                      {saveStatus === "saved" ? "Saved" : saveStatus === "saving" ? "Saving..." : "Save"}
+                    </Button>
+                  </span>
+                </Tooltip>
+                <EditableTitle
+                  value={notebookName}
+                  onSave={onSaveRename}
+                  isPending={isRenamePending}
+                  fallbackText="Notebook"
+                  typographySx={{ fontWeight: 600, color: "text.primary" }}
+                />
               </Box>
             </Stack>
           )}

--- a/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
@@ -113,7 +113,7 @@ export default function PlaygroundHeader({
                     autoFocus
                     sx={{
                       "& .MuiInputBase-root": {
-                        fontSize: "0.875rem",
+                        fontSize: "1.25rem",
                         fontWeight: 600,
                       },
                     }}
@@ -161,7 +161,7 @@ export default function PlaygroundHeader({
                         </Button>
                       </span>
                     </Tooltip>
-                    <Typography variant="body2" sx={{ fontWeight: 600, color: "text.primary" }}>
+                    <Typography variant="h6" sx={{ fontWeight: 600, color: "text.primary" }}>
                       {notebookName || "Notebook"}
                     </Typography>
                     <IconButton

--- a/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
@@ -85,16 +85,16 @@ export default function PlaygroundHeader({
         <Stack direction="row" alignItems="center" spacing={2}>
           {notebookId && (
             <>
-              <IconButton
+              <Button
                 size="small"
+                variant="text"
+                startIcon={<ArrowBackIcon />}
+                color="inherit"
                 onClick={() => navigate(`/tasks/${task?.id}/prompts`)}
-                sx={{
-                  color: "text.secondary",
-                  "&:hover": { backgroundColor: "action.hover" },
-                }}
+                sx={{ color: "text.primary", whiteSpace: "nowrap" }}
               >
-                <ArrowBackIcon fontSize="small" />
-              </IconButton>
+                Back to Notebooks
+              </Button>
               <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                 {isRenaming ? (
                   <TextField

--- a/genai-engine/ui/src/components/prompts-playground/PromptsPlayground.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/PromptsPlayground.tsx
@@ -193,14 +193,10 @@ const PromptsPlayground = ({ initialData }: { initialData: PlaygroundInitialData
       <Box className="flex flex-col h-full" sx={{ position: "relative", backgroundColor: "background.default" }}>
         <PlaygroundHeader
           notebookId={notebookId}
-          isRenaming={autoSave.isRenaming}
-          newNotebookName={autoSave.newNotebookName}
-          setNewNotebookName={autoSave.setNewNotebookName}
           saveStatus={autoSave.saveStatus}
           notebookName={autoSave.notebookName}
-          onStartRename={autoSave.handleStartRename}
           onSaveRename={autoSave.handleSaveRename}
-          onCancelRename={autoSave.handleCancelRename}
+          isRenamePending={autoSave.isRenamePending}
           onManualSave={() => autoSave.autoSaveNotebookState("manual")}
           configDrawerOpen={configDrawerOpen}
           configModeActive={config.configModeActive}

--- a/genai-engine/ui/src/components/prompts-playground/hooks/useNotebookAutoSave.ts
+++ b/genai-engine/ui/src/components/prompts-playground/hooks/useNotebookAutoSave.ts
@@ -46,8 +46,6 @@ export function useNotebookAutoSave({
   const updateNotebookMutation = useUpdateNotebookMutation(task?.id);
 
   const [notebookName, setNotebookName] = useState<string>(initialName);
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [newNotebookName, setNewNotebookName] = useState<string>("");
 
   const autoSaveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const periodicSaveIntervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -154,48 +152,25 @@ export function useNotebookAutoSave({
     immediateSaveRef.current = true;
   }, []);
 
-  const handleStartRename = useCallback(() => {
-    setNewNotebookName(notebookName);
-    setIsRenaming(true);
-  }, [notebookName]);
-
-  const handleCancelRename = useCallback(() => {
-    setIsRenaming(false);
-    setNewNotebookName("");
-  }, []);
-
-  const handleSaveRename = useCallback(async () => {
-    if (!notebookId || !newNotebookName.trim()) {
-      return;
-    }
-
-    try {
+  const handleSaveRename = useCallback(
+    async (newName: string) => {
+      if (!notebookId) return;
       await updateNotebookMutation.mutateAsync({
         notebookId,
-        request: { name: newNotebookName.trim(), description: notebook?.description },
+        request: { name: newName, description: notebook?.description },
       });
-      setNotebookName(newNotebookName.trim());
-      setIsRenaming(false);
-      setNewNotebookName("");
-
-      track(EVENT_NAMES.NOTEBOOK_RENAMED, {
-        notebook_id: notebookId,
-      });
-    } catch (error) {
-      console.error("Failed to rename notebook:", error);
-    }
-  }, [notebookId, newNotebookName, updateNotebookMutation, notebook?.description]);
+      setNotebookName(newName);
+      track(EVENT_NAMES.NOTEBOOK_RENAMED, { notebook_id: notebookId });
+    },
+    [notebookId, updateNotebookMutation, notebook?.description]
+  );
 
   return {
     saveStatus,
     notebookName,
-    isRenaming,
-    newNotebookName,
-    setNewNotebookName,
+    isRenamePending: updateNotebookMutation.isPending,
     autoSaveNotebookState,
     requestImmediateSave,
-    handleStartRename,
-    handleCancelRename,
     handleSaveRename,
   };
 }

--- a/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
+++ b/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
@@ -111,21 +111,21 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
         gap: 1.5,
       }}
     >
+      {/* Back to Notebooks */}
+      {hasNotebook && (
+        <Button
+          size="small"
+          variant="text"
+          startIcon={<ArrowBack />}
+          color="inherit"
+          onClick={() => navigate(`/tasks/${taskId}/rag-notebooks`)}
+          sx={{ color: "text.primary", alignSelf: "flex-start" }}
+        >
+          Back to Notebooks
+        </Button>
+      )}
       {/* Row 1: Title + Query Input + Run */}
       <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-        {/* Back button */}
-        {hasNotebook && (
-          <Button
-            size="small"
-            variant="text"
-            startIcon={<ArrowBack />}
-            color="inherit"
-            onClick={() => navigate(`/tasks/${taskId}/rag-notebooks`)}
-            sx={{ color: "text.primary", whiteSpace: "nowrap" }}
-          >
-            Back to Notebooks
-          </Button>
-        )}
         {/* Title */}
         {hasNotebook && isRenaming ? (
           <TextField

--- a/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
+++ b/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
@@ -8,7 +8,7 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useRagPanels } from "./RagPanelsContext";
@@ -44,6 +44,7 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
   const updateMutation = useUpdateRagNotebookMutation();
   const [isRenaming, setIsRenaming] = useState(false);
   const [newNotebookName, setNewNotebookName] = useState(notebookName ?? "");
+  const isSavingRenameRef = useRef(false);
 
   useEffect(() => {
     if (notebookName) setNewNotebookName(notebookName);
@@ -60,13 +61,19 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
   };
 
   const handleSaveRename = async () => {
+    if (isSavingRenameRef.current) return;
     const trimmed = newNotebookName.trim();
     if (!trimmed || !notebookId || trimmed === notebookName) {
       handleCancelRename();
       return;
     }
+    isSavingRenameRef.current = true;
     setIsRenaming(false);
-    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebookDescription } });
+    try {
+      await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebookDescription } });
+    } finally {
+      isSavingRenameRef.current = false;
+    }
   };
 
   const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
+++ b/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
@@ -1,4 +1,4 @@
-import { Add, Clear, Edit, PlayArrow, Settings, Science, History, Save } from "@mui/icons-material";
+import { Add, ArrowBack, Clear, Edit, PlayArrow, Settings, Science, History, Save } from "@mui/icons-material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -9,6 +9,7 @@ import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import React, { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { useRagPanels } from "./RagPanelsContext";
 import { MAX_PANELS } from "./ragPanelsReducer";
@@ -36,6 +37,8 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
   hasNotebook = false,
   historyOpen = false,
 }) => {
+  const { id: taskId } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const { state, setSharedQuery, addPanel, runAllPanels, canAddPanel, saveNotebookState, isDirty } = useRagPanels();
   const [isSaving, setIsSaving] = useState(false);
   const updateMutation = useUpdateRagNotebookMutation();
@@ -110,6 +113,19 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
     >
       {/* Row 1: Title + Query Input + Run */}
       <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+        {/* Back button */}
+        {hasNotebook && (
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<ArrowBack />}
+            color="inherit"
+            onClick={() => navigate(`/tasks/${taskId}/rag-notebooks`)}
+            sx={{ color: "text.primary", whiteSpace: "nowrap" }}
+          >
+            Back to Notebooks
+          </Button>
+        )}
         {/* Title */}
         {hasNotebook && isRenaming ? (
           <TextField

--- a/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
+++ b/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
@@ -1,4 +1,4 @@
-import { Add, ArrowBack, Clear, Edit, PlayArrow, Settings, Science, History, Save } from "@mui/icons-material";
+import { Add, ArrowBack, Clear, PlayArrow, Settings, Science, History, Save } from "@mui/icons-material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -8,12 +8,13 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useRagPanels } from "./RagPanelsContext";
 import { MAX_PANELS } from "./ragPanelsReducer";
 
+import { EditableTitle } from "@/components/common";
 import { useUpdateRagNotebookMutation } from "@/hooks/useRagNotebooks";
 
 interface RagExperimentsHeaderProps {
@@ -42,34 +43,6 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
   const { state, setSharedQuery, addPanel, runAllPanels, canAddPanel, saveNotebookState, isDirty } = useRagPanels();
   const [isSaving, setIsSaving] = useState(false);
   const updateMutation = useUpdateRagNotebookMutation();
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [newNotebookName, setNewNotebookName] = useState(notebookName ?? "");
-
-  useEffect(() => {
-    if (notebookName) setNewNotebookName(notebookName);
-  }, [notebookName]);
-
-  const handleStartRename = () => {
-    setNewNotebookName(notebookName ?? "");
-    setIsRenaming(true);
-  };
-
-  const handleCancelRename = () => {
-    setIsRenaming(false);
-    setNewNotebookName(notebookName ?? "");
-  };
-
-  const handleSaveRename = async () => {
-    if (updateMutation.isPending) return;
-    const trimmed = newNotebookName.trim();
-    if (!trimmed || !notebookId || trimmed === notebookName) {
-      handleCancelRename();
-      return;
-    }
-    setIsRenaming(false);
-    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebookDescription } });
-  };
-
   const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSharedQuery(e.target.value);
   };
@@ -128,43 +101,19 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
       {/* Row 1: Title + Query Input + Run */}
       <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
         {/* Title */}
-        {hasNotebook && isRenaming ? (
-          <TextField
-            variant="filled"
-            size="small"
-            value={newNotebookName}
-            onChange={(e) => setNewNotebookName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleSaveRename();
-              else if (e.key === "Escape") handleCancelRename();
-            }}
-            onBlur={handleSaveRename}
-            autoFocus
-            sx={{
-              minWidth: 200,
-              "& .MuiInputBase-root": { fontSize: "1.25rem", fontWeight: 600 },
-            }}
-          />
-        ) : (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: "fit-content" }}>
-            <Typography variant="h6" sx={{ fontWeight: 600, whiteSpace: "nowrap", color: "text.primary" }}>
-              {notebookName || "RAG Playground"}
-            </Typography>
-            {hasNotebook && (
-              <IconButton
-                size="small"
-                onClick={handleStartRename}
-                sx={{
-                  padding: 0.5,
-                  color: "text.secondary",
-                  "&:hover": { color: "text.primary", backgroundColor: "action.hover" },
-                }}
-              >
-                <Edit sx={{ fontSize: "1rem" }} />
-              </IconButton>
-            )}
-          </Box>
-        )}
+        <EditableTitle
+          value={notebookName ?? ""}
+          onSave={async (newName) => {
+            if (notebookId) {
+              await updateMutation.mutateAsync({ notebookId, request: { name: newName, description: notebookDescription } });
+            }
+          }}
+          isPending={updateMutation.isPending}
+          fallbackText="RAG Playground"
+          showEditButton={hasNotebook}
+          typographySx={{ fontWeight: 600, whiteSpace: "nowrap", color: "text.primary" }}
+          textFieldSx={{ minWidth: 200 }}
+        />
 
         {/* Shared Query Input */}
         <TextField

--- a/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
+++ b/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
@@ -1,4 +1,4 @@
-import { Add, Clear, PlayArrow, Settings, Science, History, Save } from "@mui/icons-material";
+import { Add, Clear, Edit, PlayArrow, Settings, Science, History, Save } from "@mui/icons-material";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -8,16 +8,20 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { useRagPanels } from "./RagPanelsContext";
 import { MAX_PANELS } from "./ragPanelsReducer";
+
+import { useUpdateRagNotebookMutation } from "@/hooks/useRagNotebooks";
 
 interface RagExperimentsHeaderProps {
   onManageProviders: () => void;
   onRunExperiment: () => void;
   onToggleHistory: () => void;
   notebookName?: string;
+  notebookId?: string | null;
+  notebookDescription?: string | null;
   hasNotebook?: boolean;
   historyOpen?: boolean;
 }
@@ -27,11 +31,40 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
   onRunExperiment,
   onToggleHistory,
   notebookName,
+  notebookId,
+  notebookDescription,
   hasNotebook = false,
   historyOpen = false,
 }) => {
   const { state, setSharedQuery, addPanel, runAllPanels, canAddPanel, saveNotebookState, isDirty } = useRagPanels();
   const [isSaving, setIsSaving] = useState(false);
+  const updateMutation = useUpdateRagNotebookMutation();
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [newNotebookName, setNewNotebookName] = useState(notebookName ?? "");
+
+  useEffect(() => {
+    if (notebookName) setNewNotebookName(notebookName);
+  }, [notebookName]);
+
+  const handleStartRename = () => {
+    setNewNotebookName(notebookName ?? "");
+    setIsRenaming(true);
+  };
+
+  const handleCancelRename = () => {
+    setIsRenaming(false);
+    setNewNotebookName(notebookName ?? "");
+  };
+
+  const handleSaveRename = async () => {
+    const trimmed = newNotebookName.trim();
+    if (!trimmed || !notebookId || trimmed === notebookName) {
+      handleCancelRename();
+      return;
+    }
+    setIsRenaming(false);
+    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebookDescription } });
+  };
 
   const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSharedQuery(e.target.value);
@@ -78,9 +111,43 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
       {/* Row 1: Title + Query Input + Run */}
       <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
         {/* Title */}
-        <Typography variant="h6" sx={{ fontWeight: 600, whiteSpace: "nowrap", color: "text.primary", minWidth: "fit-content" }}>
-          {notebookName || "RAG Playground"}
-        </Typography>
+        {hasNotebook && isRenaming ? (
+          <TextField
+            variant="filled"
+            size="small"
+            value={newNotebookName}
+            onChange={(e) => setNewNotebookName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSaveRename();
+              else if (e.key === "Escape") handleCancelRename();
+            }}
+            onBlur={handleSaveRename}
+            autoFocus
+            sx={{
+              minWidth: 200,
+              "& .MuiInputBase-root": { fontSize: "1.25rem", fontWeight: 600 },
+            }}
+          />
+        ) : (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: "fit-content" }}>
+            <Typography variant="h6" sx={{ fontWeight: 600, whiteSpace: "nowrap", color: "text.primary" }}>
+              {notebookName || "RAG Playground"}
+            </Typography>
+            {hasNotebook && (
+              <IconButton
+                size="small"
+                onClick={handleStartRename}
+                sx={{
+                  padding: 0.5,
+                  color: "text.secondary",
+                  "&:hover": { color: "text.primary", backgroundColor: "action.hover" },
+                }}
+              >
+                <Edit sx={{ fontSize: "1rem" }} />
+              </IconButton>
+            )}
+          </Box>
+        )}
 
         {/* Shared Query Input */}
         <TextField

--- a/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
+++ b/genai-engine/ui/src/components/retrievals/RagExperimentsHeader.tsx
@@ -8,7 +8,7 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useRagPanels } from "./RagPanelsContext";
@@ -44,7 +44,6 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
   const updateMutation = useUpdateRagNotebookMutation();
   const [isRenaming, setIsRenaming] = useState(false);
   const [newNotebookName, setNewNotebookName] = useState(notebookName ?? "");
-  const isSavingRenameRef = useRef(false);
 
   useEffect(() => {
     if (notebookName) setNewNotebookName(notebookName);
@@ -61,19 +60,14 @@ export const RagExperimentsHeader: React.FC<RagExperimentsHeaderProps> = ({
   };
 
   const handleSaveRename = async () => {
-    if (isSavingRenameRef.current) return;
+    if (updateMutation.isPending) return;
     const trimmed = newNotebookName.trim();
     if (!trimmed || !notebookId || trimmed === notebookName) {
       handleCancelRename();
       return;
     }
-    isSavingRenameRef.current = true;
     setIsRenaming(false);
-    try {
-      await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebookDescription } });
-    } finally {
-      isSavingRenameRef.current = false;
-    }
+    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebookDescription } });
   };
 
   const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/genai-engine/ui/src/components/retrievals/RagExperimentsPage.tsx
+++ b/genai-engine/ui/src/components/retrievals/RagExperimentsPage.tsx
@@ -244,6 +244,8 @@ const RagExperimentsContent: React.FC = () => {
         onRunExperiment={handleOpenExperimentModal}
         onToggleHistory={() => setHistorySidebarOpen((prev) => !prev)}
         notebookName={notebook?.name}
+        notebookId={notebookId}
+        notebookDescription={notebook?.description}
         hasNotebook={!!notebookId}
         historyOpen={historySidebarOpen}
       />

--- a/genai-engine/ui/src/components/retrievals/notebooks/RagNotebookDetailModal.tsx
+++ b/genai-engine/ui/src/components/retrievals/notebooks/RagNotebookDetailModal.tsx
@@ -1,5 +1,4 @@
 import CloseIcon from "@mui/icons-material/Close";
-import EditIcon from "@mui/icons-material/Edit";
 import LaunchIcon from "@mui/icons-material/Launch";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -16,11 +15,11 @@ import TableCell from "@mui/material/TableCell";
 import TableContainer from "@mui/material/TableContainer";
 import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
-import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { EditableTitle } from "@/components/common";
 import { useRagNotebook, useRagNotebookHistoryWithPolling, useUpdateRagNotebookMutation } from "@/hooks/useRagNotebooks";
 import { getStatusChipSx } from "@/utils/statusChipStyles";
 
@@ -37,36 +36,6 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
   const { experiments, isLoading: isLoadingHistory } = useRagNotebookHistoryWithPolling(notebookId ?? undefined);
   const updateMutation = useUpdateRagNotebookMutation();
 
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [newNotebookName, setNewNotebookName] = useState("");
-
-  useEffect(() => {
-    if (notebook?.name) {
-      setNewNotebookName(notebook.name);
-    }
-  }, [notebook?.name]);
-
-  const handleStartRename = () => {
-    setNewNotebookName(notebook?.name ?? "");
-    setIsRenaming(true);
-  };
-
-  const handleCancelRename = () => {
-    setIsRenaming(false);
-    setNewNotebookName(notebook?.name ?? "");
-  };
-
-  const handleSaveRename = async () => {
-    if (updateMutation.isPending) return;
-    const trimmed = newNotebookName.trim();
-    if (!trimmed || !notebookId || trimmed === notebook?.name) {
-      handleCancelRename();
-      return;
-    }
-    setIsRenaming(false);
-    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
-  };
-
   const handleLaunchNotebook = () => {
     if (taskId && notebookId) {
       navigate(`/tasks/${taskId}/rag-notebooks/${notebookId}`);
@@ -79,50 +48,17 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth aria-labelledby="rag-notebook-detail-dialog-title">
       <DialogTitle id="rag-notebook-detail-dialog-title" sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          {isRenaming ? (
-            <TextField
-              variant="filled"
-              size="small"
-              value={newNotebookName}
-              onChange={(e) => setNewNotebookName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  handleSaveRename();
-                } else if (e.key === "Escape") {
-                  handleCancelRename();
-                }
-              }}
-              onBlur={handleSaveRename}
-              autoFocus
-              sx={{
-                "& .MuiInputBase-root": {
-                  fontSize: "1.25rem",
-                  fontWeight: 600,
-                },
-              }}
-            />
-          ) : (
-            <>
-              <Typography variant="h6" component="span">
-                {notebook?.name || "RAG Notebook Details"}
-              </Typography>
-              {notebook && (
-                <IconButton
-                  size="small"
-                  onClick={handleStartRename}
-                  sx={{
-                    padding: 0.5,
-                    color: "text.secondary",
-                    "&:hover": { color: "text.primary", backgroundColor: "action.hover" },
-                  }}
-                >
-                  <EditIcon sx={{ fontSize: "1rem" }} />
-                </IconButton>
-              )}
-            </>
-          )}
-        </Box>
+        <EditableTitle
+          value={notebook?.name ?? ""}
+          onSave={async (newName) => {
+            if (notebookId) {
+              await updateMutation.mutateAsync({ notebookId, request: { name: newName, description: notebook?.description } });
+            }
+          }}
+          isPending={updateMutation.isPending}
+          fallbackText="RAG Notebook Details"
+          showEditButton={!!notebook}
+        />
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           <Button variant="contained" size="small" startIcon={<LaunchIcon />} onClick={handleLaunchNotebook} disabled={!notebookId}>
             Launch

--- a/genai-engine/ui/src/components/retrievals/notebooks/RagNotebookDetailModal.tsx
+++ b/genai-engine/ui/src/components/retrievals/notebooks/RagNotebookDetailModal.tsx
@@ -18,7 +18,7 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useRagNotebook, useRagNotebookHistoryWithPolling, useUpdateRagNotebookMutation } from "@/hooks/useRagNotebooks";
@@ -39,7 +39,6 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
 
   const [isRenaming, setIsRenaming] = useState(false);
   const [newNotebookName, setNewNotebookName] = useState("");
-  const isSavingRenameRef = useRef(false);
 
   useEffect(() => {
     if (notebook?.name) {
@@ -58,19 +57,14 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
   };
 
   const handleSaveRename = async () => {
-    if (isSavingRenameRef.current) return;
+    if (updateMutation.isPending) return;
     const trimmed = newNotebookName.trim();
     if (!trimmed || !notebookId || trimmed === notebook?.name) {
       handleCancelRename();
       return;
     }
-    isSavingRenameRef.current = true;
     setIsRenaming(false);
-    try {
-      await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
-    } finally {
-      isSavingRenameRef.current = false;
-    }
+    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
   };
 
   const handleLaunchNotebook = () => {

--- a/genai-engine/ui/src/components/retrievals/notebooks/RagNotebookDetailModal.tsx
+++ b/genai-engine/ui/src/components/retrievals/notebooks/RagNotebookDetailModal.tsx
@@ -18,7 +18,7 @@ import TableHead from "@mui/material/TableHead";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useRagNotebook, useRagNotebookHistoryWithPolling, useUpdateRagNotebookMutation } from "@/hooks/useRagNotebooks";
@@ -39,6 +39,7 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
 
   const [isRenaming, setIsRenaming] = useState(false);
   const [newNotebookName, setNewNotebookName] = useState("");
+  const isSavingRenameRef = useRef(false);
 
   useEffect(() => {
     if (notebook?.name) {
@@ -57,13 +58,19 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
   };
 
   const handleSaveRename = async () => {
+    if (isSavingRenameRef.current) return;
     const trimmed = newNotebookName.trim();
     if (!trimmed || !notebookId || trimmed === notebook?.name) {
       handleCancelRename();
       return;
     }
+    isSavingRenameRef.current = true;
     setIsRenaming(false);
-    await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
+    try {
+      await updateMutation.mutateAsync({ notebookId, request: { name: trimmed, description: notebook?.description } });
+    } finally {
+      isSavingRenameRef.current = false;
+    }
   };
 
   const handleLaunchNotebook = () => {
@@ -123,7 +130,7 @@ const RagNotebookDetailModal: React.FC<RagNotebookDetailModalProps> = ({ open, n
           )}
         </Box>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <Button variant="outlined" size="small" startIcon={<LaunchIcon />} onClick={handleLaunchNotebook} disabled={!notebookId}>
+          <Button variant="contained" size="small" startIcon={<LaunchIcon />} onClick={handleLaunchNotebook} disabled={!notebookId}>
             Launch
           </Button>
           <IconButton onClick={onClose} size="small">

--- a/genai-engine/ui/src/components/retrievals/notebooks/RagNotebooks.tsx
+++ b/genai-engine/ui/src/components/retrievals/notebooks/RagNotebooks.tsx
@@ -90,6 +90,15 @@ const RagNotebooks: React.FC<RagNotebooksProps> = ({ onRegisterCreate }) => {
     [taskId, navigate]
   );
 
+  const handleViewLastRun = useCallback(
+    (experimentId: string) => {
+      if (taskId) {
+        navigate(`/tasks/${taskId}/rag-experiments/${experimentId}`);
+      }
+    },
+    [taskId, navigate]
+  );
+
   const handleSort = useCallback(
     (column: string) => {
       if (sortColumn === column) {
@@ -199,6 +208,7 @@ const RagNotebooks: React.FC<RagNotebooksProps> = ({ onRegisterCreate }) => {
             onSort={handleSort}
             onRowClick={handleRowClick}
             onLaunchNotebook={handleLaunchNotebook}
+            onViewLastRun={handleViewLastRun}
             onDelete={deleteMutation.mutateAsync}
           />
         )}

--- a/genai-engine/ui/src/components/retrievals/notebooks/RagNotebooksTable.tsx
+++ b/genai-engine/ui/src/components/retrievals/notebooks/RagNotebooksTable.tsx
@@ -115,7 +115,7 @@ const RagNotebooksTable: React.FC<RagNotebooksTableProps> = ({
                   </Typography>
                 </TableSortLabel>
               </TableCell>
-              <TableCell align="right">
+              <TableCell>
                 <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
                   Actions
                 </Typography>
@@ -152,8 +152,8 @@ const RagNotebooksTable: React.FC<RagNotebooksTableProps> = ({
                     {new Date(notebook.updated_at).toLocaleString()}
                   </Typography>
                 </TableCell>
-                <TableCell align="right">
-                  <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                <TableCell>
+                  <Box sx={{ display: "flex", gap: 1 }}>
                     <Tooltip title="Launch Notebook">
                       <Button
                         variant="outlined"

--- a/genai-engine/ui/src/components/retrievals/notebooks/RagNotebooksTable.tsx
+++ b/genai-engine/ui/src/components/retrievals/notebooks/RagNotebooksTable.tsx
@@ -154,6 +154,19 @@ const RagNotebooksTable: React.FC<RagNotebooksTableProps> = ({
                 </TableCell>
                 <TableCell align="right">
                   <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                    <Tooltip title="Launch Notebook">
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={<LaunchIcon />}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onLaunchNotebook(notebook.id);
+                        }}
+                      >
+                        Launch
+                      </Button>
+                    </Tooltip>
                     <Tooltip title={notebook.latest_run_id ? "View last run" : "No runs yet"}>
                       <span>
                         <IconButton
@@ -167,19 +180,6 @@ const RagNotebooksTable: React.FC<RagNotebooksTableProps> = ({
                           <HistoryIcon fontSize="small" />
                         </IconButton>
                       </span>
-                    </Tooltip>
-                    <Tooltip title="Launch Notebook">
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        startIcon={<LaunchIcon />}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onLaunchNotebook(notebook.id);
-                        }}
-                      >
-                        Launch
-                      </Button>
                     </Tooltip>
                     <Tooltip title="Delete Notebook">
                       <IconButton size="small" onClick={(e) => handleDeleteClick(notebook, e)} color="error">

--- a/genai-engine/ui/src/components/retrievals/notebooks/RagNotebooksTable.tsx
+++ b/genai-engine/ui/src/components/retrievals/notebooks/RagNotebooksTable.tsx
@@ -1,4 +1,5 @@
 import DeleteIcon from "@mui/icons-material/Delete";
+import HistoryIcon from "@mui/icons-material/History";
 import LaunchIcon from "@mui/icons-material/Launch";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -34,6 +35,7 @@ const RagNotebooksTable: React.FC<RagNotebooksTableProps> = ({
   onSort,
   onRowClick,
   onLaunchNotebook,
+  onViewLastRun,
   onDelete,
 }) => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -152,6 +154,20 @@ const RagNotebooksTable: React.FC<RagNotebooksTableProps> = ({
                 </TableCell>
                 <TableCell align="right">
                   <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-end" }}>
+                    <Tooltip title={notebook.latest_run_id ? "View last run" : "No runs yet"}>
+                      <span>
+                        <IconButton
+                          size="small"
+                          disabled={!notebook.latest_run_id}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (notebook.latest_run_id) onViewLastRun(notebook.latest_run_id);
+                          }}
+                        >
+                          <HistoryIcon fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
                     <Tooltip title="Launch Notebook">
                       <Button
                         variant="outlined"

--- a/genai-engine/ui/src/components/retrievals/notebooks/types.ts
+++ b/genai-engine/ui/src/components/retrievals/notebooks/types.ts
@@ -11,5 +11,6 @@ export interface RagNotebooksTableProps {
   onSort: (column: string) => void;
   onRowClick: (notebookId: string) => void;
   onLaunchNotebook: (notebookId: string) => void;
+  onViewLastRun: (experimentId: string) => void;
   onDelete: (notebookId: string) => Promise<void>;
 }

--- a/genai-engine/ui/src/components/test/TestView.tsx
+++ b/genai-engine/ui/src/components/test/TestView.tsx
@@ -20,7 +20,7 @@ export const TestView = () => {
 
   const [activeTab, setActiveTab] = useQueryState(
     "section",
-    parseAsStringEnum<TestTab>(["agent-experiments", "agentic-notebooks"]).withDefault("agent-experiments")
+    parseAsStringEnum<TestTab>(["agent-experiments", "agentic-notebooks"]).withDefault("agentic-notebooks")
   );
 
   return (
@@ -72,8 +72,8 @@ export const TestView = () => {
         onChange={(_, value) => setActiveTab(value)}
         sx={{ backgroundColor: "background.paper", borderBottom: 1, borderColor: "divider" }}
       >
-        <Tab label="Experiments" value="agent-experiments" />
         <Tab label="Notebooks" value="agentic-notebooks" />
+        <Tab label="Experiments" value="agent-experiments" />
       </Tabs>
 
       <Box sx={{ flex: 1, overflow: "hidden", display: "flex", flexDirection: "column" }}>


### PR DESCRIPTION
## Summary
Standardizes the user interface and interaction patterns across all three notebook types (Prompt, RAG, Agent) to provide a consistent experience regardless of which notebook type users are working with.

## Problem
Users faced different interfaces and interaction patterns when switching between Prompt, RAG, and Agent notebooks, creating cognitive overhead and inconsistent expectations. Some features like inline renaming were missing from certain notebook types, back navigation was broken in several areas, and table actions varied across notebook types.

## Solution
Created a unified interaction model by implementing consistent detail modals, inline rename functionality, standardized table actions, and proper back navigation across all notebook types. Extracted shared components like EditableTitle and applied consistent typography and button styling throughout.

## User Impact
Users now experience identical interaction patterns when working with any notebook type. They can rename notebooks inline from any view, access the same set of table actions (Launch, View last run, Delete) across all notebook tables, and rely on consistent back navigation. The interface eliminates previous inconsistencies that required users to learn different interaction patterns for each notebook type.

## Changed Areas
• **Notebook detail modals** - All three types now have consistent detail modals with rename and launch capabilities
• **Table actions** - Standardized Launch, View last run, and Delete actions across all notebook tables with proper tooltips and states
• **Navigation flow** - Fixed broken back navigation and added consistent "Back to Notebooks" buttons in launched notebook headers
• **Inline editing** - Added shared EditableTitle component with double-save protection for consistent rename experience
• **Typography system** - Unified notebook name display sizing and font weights across all launched views
• **Agent notebook infrastructure** - Added missing detail modal and table action components for feature parity

## Type
Feature

## Breaking Changes
None

<!-- enriched-by-louisa -->