### PR TITLE
fix: restore native undo in playground message inputs (ae-caa)

### DIFF
--- a/genai-engine/ui/src/components/prompts-playground/messages/HighlightedInputComponent.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/messages/HighlightedInputComponent.tsx
@@ -20,6 +20,7 @@ export const HighlightedInputComponent = ({
       value={stringValue}
       onChange={(e) => onChange(e as React.ChangeEvent<HTMLInputElement>)}
       placeholder={placeholder}
+      variant="filled"
       multiline
       minRows={2}
       maxRows={20}

--- a/genai-engine/ui/src/components/prompts-playground/messages/HighlightedInputComponent.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/messages/HighlightedInputComponent.tsx
@@ -1,4 +1,4 @@
-import { MustacheHighlightedTextField } from "@arthur/shared-components";
+import TextField from "@mui/material/TextField";
 import React from "react";
 
 import { OpenAIMessageItem } from "@/lib/api-client/api-client";
@@ -15,23 +15,16 @@ export const HighlightedInputComponent = ({
   // Convert OpenAIMessageItem[] to string
   const stringValue = typeof value === "string" ? value : value.map((item) => item.text || "").join(" ");
 
-  // Adapter to handle the onChange type difference
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    onChange({
-      target: { value: e.target.value },
-    } as React.ChangeEvent<HTMLInputElement>);
-  };
-
   return (
-    <MustacheHighlightedTextField
+    <TextField
       value={stringValue}
-      onChange={handleChange}
+      onChange={(e) => onChange(e as React.ChangeEvent<HTMLInputElement>)}
       placeholder={placeholder}
       multiline
       minRows={2}
       maxRows={20}
       size="small"
-      hideTokens={true}
+      fullWidth
     />
   );
 };


### PR DESCRIPTION
Replace MustacheHighlightedTextField with standard MUI TextField in HighlightedInputComponent. The custom highlighted component likely uses a non-native input mechanism for its token-highlighting feature, which breaks the browser's native undo/redo (Ctrl+Z). Since hideTokens was always set to true in this component, the highlighting feature was never active — switching to a plain TextField restores native undo with no functional regression.