### PR TITLE
fix(UP-4072): handle stale chunk load failure when opening span drawer

### DIFF
--- a/genai-engine/ui/src/components/traces/components/CommonDrawer.tsx
+++ b/genai-engine/ui/src/components/traces/components/CommonDrawer.tsx
@@ -12,23 +12,44 @@ import { createTitle } from "@/utils/title";
 
 type DrawerTarget = "trace" | "span" | "session" | "user";
 
+/**
+ * Wraps a lazy import factory to handle stale chunk load failures.
+ *
+ * When the app is redeployed, Vite generates new content-hashed chunk filenames.
+ * Users with the old page still open will try to fetch stale chunk URLs that no
+ * longer exist, causing "Failed to fetch dynamically imported module" errors.
+ * Reloading the page fetches the updated index.html and the new chunk URLs.
+ */
+const lazyWithChunkReload = <T extends React.ComponentType<{ id: string }>>(
+  factory: () => Promise<{ default: T }>
+): React.LazyExoticComponent<T> => {
+  return lazy(() =>
+    factory().catch((err: unknown) => {
+      if (err instanceof TypeError && err.message.toLowerCase().includes("failed to fetch")) {
+        window.location.reload();
+      }
+      throw err;
+    })
+  );
+};
+
 const CONTENT_MAP: Record<DrawerTarget, React.LazyExoticComponent<React.ComponentType<{ id: string }>>> = {
-  trace: lazy(() =>
+  trace: lazyWithChunkReload(() =>
     import("./TraceDrawerContent").then((module) => ({
       default: module.TraceDrawerContent,
     }))
   ),
-  span: lazy(() =>
+  span: lazyWithChunkReload(() =>
     import("./SpanDrawerContent").then((module) => ({
       default: module.SpanDrawerContent,
     }))
   ),
-  session: lazy(() =>
+  session: lazyWithChunkReload(() =>
     import("./SessionDrawerContent").then((module) => ({
       default: module.SessionDrawerContent,
     }))
   ),
-  user: lazy(() =>
+  user: lazyWithChunkReload(() =>
     import("./UserDrawerContent").then((module) => ({
       default: module.UserDrawerContent,
     }))

--- a/genai-engine/ui/src/components/traces/components/CommonDrawer.tsx
+++ b/genai-engine/ui/src/components/traces/components/CommonDrawer.tsx
@@ -20,9 +20,7 @@ type DrawerTarget = "trace" | "span" | "session" | "user";
  * longer exist, causing "Failed to fetch dynamically imported module" errors.
  * Reloading the page fetches the updated index.html and the new chunk URLs.
  */
-const lazyWithChunkReload = <T extends React.ComponentType<{ id: string }>>(
-  factory: () => Promise<{ default: T }>
-): React.LazyExoticComponent<T> => {
+const lazyWithChunkReload = <T extends React.ComponentType<{ id: string }>>(factory: () => Promise<{ default: T }>): React.LazyExoticComponent<T> => {
   return lazy(() =>
     factory().catch((err: unknown) => {
       if (err instanceof TypeError && err.message.toLowerCase().includes("failed to fetch")) {


### PR DESCRIPTION
## Summary
- Adds `lazyWithChunkReload()` wrapper around all lazy drawer content imports in `CommonDrawer.tsx`
- When a dynamically imported chunk fails to load with a `TypeError: Failed to fetch` error (stale deployment), the page reloads automatically to pick up fresh assets
- Covers trace, span, session, and user drawer content components

## Root Cause
Vite splits `SpanDrawerContent` (and other drawer components) into content-hashed chunks. When the app is redeployed, new chunk hashes are generated. Users who still have the old page open will attempt to load the old chunk URL (e.g. `SpanDrawerContent-Dx2k1xpB.js`) which no longer exists on the server — causing `TypeError: Failed to fetch dynamically imported module`.

## Test plan
- [ ] Open the traces page
- [ ] Open a trace, then click on a span title to open the span drawer — verifies happy path still works
- [ ] Simulate stale deployment by opening the app, then manually clearing the built assets from the server and redeploying — the page should auto-reload rather than showing a rendering failure

Jira: UP-4072

🤖 Generated with [Claude Code](https://claude.com/claude-code)