### PR TITLE
Fix LLM prompt token count to include cached tokens

### DIFF
--- a/integrations/claude-code/claude_code_tracer.py
+++ b/integrations/claude-code/claude_code_tracer.py
@@ -395,7 +395,7 @@ def _extract_llm_spans_for_turn(
                 "openinference.span.kind": "LLM",
                 "llm.system": "anthropic",
                 "llm.model_name": model,
-                "llm.token_count.prompt": input_tokens,
+                "llm.token_count.prompt": input_tokens + cache_read + cache_create,
                 "llm.token_count.completion": output_tokens,
                 "llm.token_count.total": input_tokens
                 + cache_read

--- a/integrations/claude-code/test_tracer.py
+++ b/integrations/claude-code/test_tracer.py
@@ -636,7 +636,8 @@ class TestExtractLlmSpansForTurn:
         )
         spans = self._extract(p)
         attrs = spans[0]["attributes"]
-        assert attrs["llm.token_count.prompt"] == 5
+        # prompt = input_tokens + cache_read + cache_create = 5+100+5 = 110
+        assert attrs["llm.token_count.prompt"] == 110
         assert attrs["llm.token_count.completion"] == 10
         # total = input + cache_read + cache_create + output = 5+100+5+10 = 120
         assert attrs["llm.token_count.total"] == 120


### PR DESCRIPTION
## Summary

- `llm.token_count.prompt` was only reporting `input_tokens` (the uncached portion of the prompt), ignoring `cache_read_input_tokens` and `cache_creation_input_tokens`
- For heavily cached requests this caused wildly wrong prompt counts (e.g. **1 token** displayed instead of **31,720**), while the total remained correct
- Fix: `prompt = input_tokens + cache_read + cache_create` so prompt + completion = total

## Test plan

- [ ] Existing unit test `test_token_counts` updated to reflect correct expected value (5+100+5=110 instead of 5)
- [ ] All 114 tests pass (`python3 -m pytest test_tracer.py -q`)
- [ ] Verify in Arthur Engine UI: prompt token count in span badge/tooltip now matches (prompt + completion = total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)