### PR TITLE
fix(tracer): skip shadow transcripts created by gh pr create in worktrees

### DIFF
--- a/integrations/claude-code/claude_code_tracer.py
+++ b/integrations/claude-code/claude_code_tracer.py
@@ -179,29 +179,69 @@ def _session_lock(session_id: str):
 # ---------------------------------------------------------------------------
 
 
+def _transcript_has_conversation(path: Path) -> bool:
+    """Return True if the transcript contains at least one user or assistant message.
+
+    Shadow transcripts (e.g. files created by ``gh pr create`` in a worktree
+    context) contain only ``pr-link`` entries and must be skipped.
+    """
+    try:
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                if json.loads(line).get("type") in ("user", "assistant"):
+                    return True
+            except (json.JSONDecodeError, ValueError):
+                continue
+    except Exception:
+        pass
+    return False
+
+
 def _find_transcript_path(data: dict, session_id: str) -> Optional[str]:
-    """Locate the session's transcript JSONL file."""
+    """Locate the session's transcript JSONL file.
+
+    Collects all candidate paths, then prefers the one(s) that contain actual
+    conversation content (user/assistant messages).  Among those, the largest
+    file wins — this reliably selects the real transcript over shadow files
+    created by ``gh pr create`` inside git worktrees.
+    """
+    seen: set = set()
+    candidates: list = []
+
+    def _add(p: Path) -> None:
+        resolved = p.resolve()
+        if resolved not in seen and p.exists():
+            seen.add(resolved)
+            candidates.append(p)
+
     # 1. Provided directly in hook data
     tp = data.get("transcript_path", "")
-    if tp and Path(tp).exists():
-        return tp
+    if tp:
+        _add(Path(tp))
 
     # 2. Construct from CLAUDE_PROJECT_DIR (path with / → -)
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
     if project_dir:
         sanitized = project_dir.replace("/", "-")
-        path = Path.home() / ".claude" / "projects" / sanitized / f"{session_id}.jsonl"
-        if path.exists():
-            return str(path)
+        _add(Path.home() / ".claude" / "projects" / sanitized / f"{session_id}.jsonl")
 
     # 3. Glob fallback across all project dirs
     projects_dir = Path.home() / ".claude" / "projects"
     if projects_dir.exists():
-        matches = list(projects_dir.glob(f"*/{session_id}.jsonl"))
-        if matches:
-            return str(matches[0])
+        for match in projects_dir.glob(f"*/{session_id}.jsonl"):
+            _add(match)
 
-    return None
+    if not candidates:
+        return None
+
+    # Prefer candidates that contain real conversation content; if several do,
+    # pick the largest (the real transcript is always the biggest).
+    content_candidates = [p for p in candidates if _transcript_has_conversation(p)]
+    pool = content_candidates if content_candidates else candidates
+    return str(max(pool, key=lambda p: p.stat().st_size))
 
 
 def _is_human_message(entry: dict) -> bool:

--- a/integrations/claude-code/test_tracer.py
+++ b/integrations/claude-code/test_tracer.py
@@ -1668,6 +1668,78 @@ class TestFindTranscriptPath:
         result = tracer._find_transcript_path({}, "nosuchsession")
         assert result is None
 
+    def test_skips_shadow_transcript_in_favour_of_real_one(
+        self, tmp_path, monkeypatch
+    ):
+        """When gh pr create writes a pr-link shadow file in a worktree dir,
+        _find_transcript_path must skip it and return the real transcript."""
+        session_id = "shadow-test-sess"
+
+        # Shadow file: only a pr-link entry (written by gh pr create in worktree)
+        shadow_dir = tmp_path / ".claude" / "projects" / "-worktree-shadow"
+        shadow_dir.mkdir(parents=True)
+        shadow = shadow_dir / f"{session_id}.jsonl"
+        shadow.write_text(
+            json.dumps({"type": "pr-link", "prNumber": 1234, "prUrl": "https://x"})
+            + "\n"
+        )
+
+        # Real transcript: has user + assistant messages
+        real_dir = tmp_path / ".claude" / "projects" / "-real-project"
+        real_dir.mkdir(parents=True)
+        real = real_dir / f"{session_id}.jsonl"
+        real.write_text(
+            "\n".join(
+                [
+                    json.dumps({"type": "user", "message": {"role": "user", "content": "hello"}}),
+                    json.dumps({"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]}}),
+                ]
+            )
+            + "\n"
+        )
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        # Provide the shadow as the explicit transcript_path (as hooks do after gh pr create)
+        result = tracer._find_transcript_path(
+            {"transcript_path": str(shadow)}, session_id
+        )
+        assert result == str(real)
+
+    def test_prefers_larger_content_transcript_among_multiple(
+        self, tmp_path, monkeypatch
+    ):
+        """When two transcripts both have conversation content, prefer the larger one."""
+        session_id = "multi-content-sess"
+
+        projects_dir = tmp_path / ".claude" / "projects"
+
+        small_dir = projects_dir / "small-project"
+        small_dir.mkdir(parents=True)
+        small = small_dir / f"{session_id}.jsonl"
+        small.write_text(
+            json.dumps({"type": "user", "message": {"role": "user", "content": "hi"}}) + "\n"
+        )
+
+        large_dir = projects_dir / "large-project"
+        large_dir.mkdir(parents=True)
+        large = large_dir / f"{session_id}.jsonl"
+        # Write many entries so it's definitively larger
+        large.write_text(
+            "\n".join(
+                json.dumps({"type": "user", "message": {"role": "user", "content": f"turn {i}"}})
+                for i in range(50)
+            )
+            + "\n"
+        )
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        result = tracer._find_transcript_path({}, session_id)
+        assert result == str(large)
+
 
 # ---------------------------------------------------------------------------
 # discover_config — global config fallback


### PR DESCRIPTION
## Summary

- **Root cause**: When `gh pr create` runs inside a git worktree, Claude Code writes a `{"type": "pr-link"}` entry to the *worktree* project directory, creating a nearly-empty shadow transcript file with the same session ID as the real transcript.
- `_find_transcript_path` was returning this file immediately (no content validation), causing `_count_human_messages` to return 0 and `_extract_llm_spans_for_turn` to emit no LLM spans for every subsequent turn after the PR was created.
- **Fix**: collect all candidate paths, filter to those containing actual `user`/`assistant` entries via a new `_transcript_has_conversation` helper, then pick the largest — which is always the real transcript. Falls back to the largest file if no content-bearing candidate is found.
- Adds 2 regression tests: shadow-file skipping and multi-transcript largest-wins behavior.

## Test plan
- [ ] All 116 unit tests pass: `python3 -m pytest integrations/claude-code/test_tracer.py`
- [ ] New regression tests `test_skips_shadow_transcript_in_favour_of_real_one` and `test_prefers_larger_content_transcript_among_multiple` pass
- [ ] On a live session: after `gh pr create` in a worktree, subsequent turns emit LLM spans with correct token counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)