### PR TITLE
fix(tracer): fix token counting and intermediate LLM spans in Claude Code tracer

### DIFF
--- a/integrations/claude-code/claude_code_tracer.py
+++ b/integrations/claude-code/claude_code_tracer.py
@@ -151,6 +151,75 @@ def _new_span_id() -> str:
     return secrets.token_hex(8)
 
 
+# ---------------------------------------------------------------------------
+# Subagent trace-context propagation
+# ---------------------------------------------------------------------------
+
+# How long to wait for a subagent to claim the context file before giving up.
+_PENDING_AGENT_TIMEOUT_S = 30
+_PENDING_AGENT_DIR = STATE_DIR / "pending_agent"
+
+
+def _write_pending_agent_context(
+    parent_session_id: str,
+    parent_trace_id: str,
+    parent_span_id: str,
+) -> None:
+    """Write a side-channel file so the next subagent can inherit this trace.
+
+    Called from handle_pre_tool when an Agent tool invocation is detected.
+    The file is keyed by session+span so parallel agent invocations in the
+    same session each get their own file.
+    """
+    _PENDING_AGENT_DIR.mkdir(parents=True, exist_ok=True)
+    path = _PENDING_AGENT_DIR / f"{parent_session_id}_{parent_span_id}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "parent_session_id": parent_session_id,
+                "parent_trace_id": parent_trace_id,
+                "parent_span_id": parent_span_id,
+                "created_ns": time.time_ns(),
+            }
+        )
+    )
+
+
+def _claim_pending_agent_context() -> Optional[dict]:
+    """Claim the most recent unclaimed subagent context, if any.
+
+    Called from handle_user_prompt_submit when a new session is initialised.
+    Returns the context dict (with ``parent_trace_id`` and ``parent_span_id``)
+    or None.  Claiming removes the file so no other session can use it.
+    """
+    if not _PENDING_AGENT_DIR.exists():
+        return None
+
+    deadline_ns = time.time_ns() - _PENDING_AGENT_TIMEOUT_S * 1_000_000_000
+    candidates: list[tuple[int, Path, dict]] = []
+    for p in _PENDING_AGENT_DIR.glob("*.json"):
+        try:
+            ctx = json.loads(p.read_text())
+            if ctx.get("created_ns", 0) >= deadline_ns:
+                candidates.append((ctx["created_ns"], p, ctx))
+        except Exception:
+            continue
+
+    if not candidates:
+        return None
+
+    # Newest first — grab the most recently written unclaimed context.
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    for _, path, ctx in candidates:
+        try:
+            path.unlink()
+            return ctx
+        except FileNotFoundError:
+            # Another process claimed it first; try the next one.
+            continue
+    return None
+
+
 @contextlib.contextmanager
 def _session_lock(session_id: str):
     """Exclusive per-session file lock.
@@ -871,6 +940,9 @@ def _complete_turn(
     turn_number = current_trace.get("turn_number", 1)
     prompt_preview = current_trace.get("prompt_preview", "")
     final_output = current_trace.get("last_llm_output", "")
+    # For the first turn of a subagent the CHAIN span is a child of the parent's
+    # Agent tool span, making all subagent work visible inside the parent trace.
+    parent_agent_span_id = current_trace.get("parent_agent_span_id")
 
     # Root CHAIN span
     username = state.get("username", "unknown")
@@ -895,7 +967,7 @@ def _complete_turn(
             {
                 "trace_id_hex": trace_id,
                 "span_id_hex": root_span_id,
-                "parent_span_id_hex": None,
+                "parent_span_id_hex": parent_agent_span_id,
                 "name": "claude-code-turn",
                 "kind": SpanKind.INTERNAL,
                 "start_ns": turn_start_ns,
@@ -922,6 +994,7 @@ def _build_tool_span_record(
     root_span_id: str,
     is_failure: bool = False,
     error_msg: str = "",
+    span_id: Optional[str] = None,
 ) -> dict:
     """Build a span record dict for a tool call (success or failure).
 
@@ -983,14 +1056,14 @@ def _build_tool_span_record(
 
     rec: dict[str, Any] = {
         "trace_id_hex": trace_id,
-        "span_id_hex": _new_span_id(),
+        "span_id_hex": span_id or _new_span_id(),
         "parent_span_id_hex": root_span_id,
         "name": tool_name,
         "kind": None,  # defaults to SpanKind.CLIENT in _build_and_export_spans
         "start_ns": start_ns,
         "end_ns": end_ns,
         "attributes": attrs,
-        "force_span_id": False,
+        "force_span_id": span_id is not None,
     }
 
     if is_failure:
@@ -1028,6 +1101,13 @@ def handle_user_prompt_submit(data: dict, config: dict) -> None:
         state["human_msg_count"] = 0
         state["turn_number"] = 0
 
+        # If a parent session pre-registered an Agent invocation, inherit its
+        # trace context so this subagent's spans are nested inside the parent trace.
+        parent_ctx = _claim_pending_agent_context()
+        if parent_ctx:
+            state["inherited_trace_id"] = parent_ctx["parent_trace_id"]
+            state["parent_agent_span_id"] = parent_ctx["parent_span_id"]
+
     # Complete the previous turn's trace if one is in progress.
     # Use the cached transcript path from state so that any mid-session
     # project-dir changes (e.g. gh pr create writing to a worktree dir) do
@@ -1052,13 +1132,23 @@ def handle_user_prompt_submit(data: dict, config: dict) -> None:
     turn_number = state.get("turn_number", 0) + 1
     state["turn_number"] = turn_number
     state["human_msg_count"] = current_human_count
+
+    # Use the inherited trace ID if this session was spawned as a subagent, so
+    # all spans land in the parent's trace.  Also consume the parent agent span
+    # ID (used only for the first CHAIN span so it becomes a child of the Agent
+    # tool span in the parent trace).
+    trace_id = state.pop("inherited_trace_id", None) or _new_trace_id()
+    parent_agent_span_id = state.pop("parent_agent_span_id", None)
+
     state["current_trace"] = {
-        "trace_id": _new_trace_id(),
+        "trace_id": trace_id,
         "root_span_id": _new_span_id(),
         "turn_start_ns": now_ns,
         "turn_number": turn_number,
         "human_count_at_start": current_human_count,
         "prompt_preview": _truncate(prompt) if prompt else "",
+        # Non-None only for the first turn of a subagent; cleared after _complete_turn
+        "parent_agent_span_id": parent_agent_span_id,
     }
 
     _save_state(session_id, state)
@@ -1111,11 +1201,25 @@ def handle_pre_tool(data: dict, config: dict) -> None:
             "prompt_preview": _truncate(prompt_preview) if prompt_preview else "",
         }
 
-    state.setdefault("pending_tools", {})[tool_name] = {
+    pending_entry: dict[str, Any] = {
         "tool_name": tool_name,
         "tool_input": tool_input,
         "start_ns": now_ns,
     }
+
+    # For Agent tool calls, pre-allocate the span ID and write a side-channel
+    # file so the spawned subagent can inherit this trace.
+    current_trace = state.get("current_trace")
+    if tool_name == "Agent" and current_trace:
+        agent_span_id = _new_span_id()
+        pending_entry["pre_allocated_span_id"] = agent_span_id
+        _write_pending_agent_context(
+            parent_session_id=session_id,
+            parent_trace_id=current_trace["trace_id"],
+            parent_span_id=agent_span_id,
+        )
+
+    state.setdefault("pending_tools", {})[tool_name] = pending_entry
     _save_state(session_id, state)
 
 
@@ -1159,6 +1263,9 @@ def handle_post_tool(data: dict, config: dict) -> None:
     tool_input = data.get("tool_input") or current_tool.get("tool_input", {})
     tool_response = data.get("tool_response", {})
     start_ns = current_tool.get("start_ns", end_ns - 1_000_000)
+    # For Agent tool calls the span ID was pre-allocated at PreToolUse time so
+    # the subagent could reference it as its parent span.
+    pre_allocated_span_id = current_tool.get("pre_allocated_span_id")
 
     span_record = _build_tool_span_record(
         tool_name=tool_name,
@@ -1168,6 +1275,7 @@ def handle_post_tool(data: dict, config: dict) -> None:
         end_ns=end_ns,
         trace_id=current_trace["trace_id"],
         root_span_id=current_trace["root_span_id"],
+        span_id=pre_allocated_span_id,
     )
 
     # Export the tool span before acquiring the lock — this is the slow network

--- a/integrations/claude-code/claude_code_tracer.py
+++ b/integrations/claude-code/claude_code_tracer.py
@@ -180,7 +180,16 @@ def _session_lock(session_id: str):
 
 
 def _find_transcript_path(data: dict, session_id: str) -> Optional[str]:
-    """Locate the session's transcript JSONL file."""
+    """Locate the session's transcript JSONL file.
+
+    Searches three locations in priority order and returns the first match.
+    Callers that need a stable path across the lifetime of a session should
+    cache the result in session state via ``_get_cached_transcript_path``
+    rather than calling this function repeatedly — the ``transcript_path``
+    value in hook ``data`` can change mid-session when Claude Code writes
+    entries to a *different* project directory (e.g. after ``gh pr create``
+    in a worktree context).
+    """
     # 1. Provided directly in hook data
     tp = data.get("transcript_path", "")
     if tp and Path(tp).exists():
@@ -202,6 +211,29 @@ def _find_transcript_path(data: dict, session_id: str) -> Optional[str]:
             return str(matches[0])
 
     return None
+
+
+def _get_cached_transcript_path(
+    data: dict,
+    state: dict,
+    session_id: str,
+) -> Optional[str]:
+    """Return the transcript path for this session, caching it in *state*.
+
+    Once resolved, the path is stored under ``state["transcript_path"]`` so
+    that all subsequent hook calls use the same file even if Claude Code later
+    writes a new entry to a different project directory (e.g. a worktree dir
+    after ``gh pr create``).  The cache is only accepted when the file still
+    exists; if it has been deleted the function re-resolves.
+    """
+    cached = state.get("transcript_path", "")
+    if cached and Path(cached).exists():
+        return cached
+
+    resolved = _find_transcript_path(data, session_id)
+    if resolved:
+        state["transcript_path"] = resolved
+    return resolved
 
 
 def _is_human_message(entry: dict) -> bool:
@@ -996,17 +1028,23 @@ def handle_user_prompt_submit(data: dict, config: dict) -> None:
         state["human_msg_count"] = 0
         state["turn_number"] = 0
 
-    # Complete the previous turn's trace if one is in progress
+    # Complete the previous turn's trace if one is in progress.
+    # Use the cached transcript path from state so that any mid-session
+    # project-dir changes (e.g. gh pr create writing to a worktree dir) do
+    # not silently redirect us to a shadow transcript file.
     if state.get("current_trace"):
-        transcript_path = _find_transcript_path(data, session_id)
+        transcript_path = _get_cached_transcript_path(data, state, session_id)
         _emit_pending_llm_spans(state, transcript_path, config)
         _complete_turn(state, config, transcript_path, now_ns)
+        # Clear the cached path so the new turn resolves it fresh below
+        state.pop("transcript_path", None)
 
     # Count human messages for LLM span extraction.
     # UserPromptSubmit fires before Claude processes the prompt, so the new
     # message is not yet in the transcript — human_count_at_start equals the
     # current count (the new prompt will become count+1 in the transcript).
-    transcript_path = _find_transcript_path(data, session_id)
+    # Resolve and immediately cache the transcript path for this new turn.
+    transcript_path = _get_cached_transcript_path(data, state, session_id)
     current_human_count = (
         _count_human_messages(transcript_path) if transcript_path else 0
     )
@@ -1049,7 +1087,7 @@ def handle_pre_tool(data: dict, config: dict) -> None:
     # This handles cases where the hook isn't registered or fires before the
     # UserPromptSubmit event is available.
     if not state.get("current_trace"):
-        transcript_path = _find_transcript_path(data, session_id)
+        transcript_path = _get_cached_transcript_path(data, state, session_id)
         current_human_count = (
             _count_human_messages(transcript_path) if transcript_path else 0
         )
@@ -1144,10 +1182,13 @@ def handle_post_tool(data: dict, config: dict) -> None:
     # Acquire an exclusive per-session lock before emitting LLM spans.
     # Parallel PostToolUse processes race on emitted_llm_span_count; the lock
     # ensures each process re-reads the latest count and never double-emits.
-    transcript_path = _find_transcript_path(data, session_id)
+    # Resolve the transcript path *inside* the lock so we always use the path
+    # that was cached in state at UserPromptSubmit time — not the (potentially
+    # stale or redirected) path carried in the current hook payload.
     with _session_lock(session_id):
         state = _load_state(session_id)
         state.get("pending_tools", {}).pop(tool_name, None)
+        transcript_path = _get_cached_transcript_path(data, state, session_id)
         _emit_pending_llm_spans(state, transcript_path, config)
         _save_state(session_id, state)
 
@@ -1201,10 +1242,10 @@ def handle_post_tool_failure(data: dict, config: dict) -> None:
         span_records=[span_record],
     )
 
-    transcript_path = _find_transcript_path(data, session_id)
     with _session_lock(session_id):
         state = _load_state(session_id)
         state.get("pending_tools", {}).pop(tool_name, None)
+        transcript_path = _get_cached_transcript_path(data, state, session_id)
         _emit_pending_llm_spans(state, transcript_path, config)
         _save_state(session_id, state)
 
@@ -1212,13 +1253,14 @@ def handle_post_tool_failure(data: dict, config: dict) -> None:
 def handle_stop(data: dict, config: dict) -> None:
     session_id = data.get("session_id", "unknown")
     end_ns = time.time_ns()
-    transcript_path = _find_transcript_path(data, session_id)
 
     with _session_lock(session_id):
         state = _load_state(session_id)
         if not state.get("current_trace"):
             log.debug("No active trace for session %s at stop", session_id)
             return
+
+        transcript_path = _get_cached_transcript_path(data, state, session_id)
 
         # Emit the final LLM span(s) — the last response has no tool call after it,
         # so handle_post_tool never got the chance to emit it.

--- a/integrations/claude-code/claude_code_tracer.py
+++ b/integrations/claude-code/claude_code_tracer.py
@@ -378,6 +378,29 @@ def _extract_llm_spans_for_turn(
 
     Output is the assistant's text response when present; otherwise the
     tool_use blocks serialised as JSON so the span always has an output value.
+
+    **Grouping by message.id**
+
+    Claude Code (with extended thinking enabled) splits a single API response
+    across multiple consecutive transcript entries that share the same
+    ``message.id`` — one entry per block type (thinking / text / tool_use).
+    Each entry duplicates the input-side token counts.  We MUST group these
+    entries and emit exactly one LLM span per API response, otherwise:
+
+      * Prompt tokens are reported N× too high (once per entry).
+      * "Thinking-only" entries produce empty, noisy spans.
+      * Intermediate text (the entry with ``type=text`` that precedes a tool
+        call) becomes its own orphaned 8-token span instead of being part of
+        the single span for that API call.
+
+    Grouping strategy:
+      - Input tokens  → first entry in the group (avoids duplication).
+      - Output tokens → sum across all entries (each entry captures the tokens
+                        for its own block).
+      - Text output   → concatenate all ``text`` blocks from any entry.
+      - Tool output   → JSON of tool_use blocks from the last entry (fall-back
+                        when no text is present).
+      - Timestamp     → first entry.
     """
     spans = []
     try:
@@ -391,6 +414,91 @@ def _extract_llm_spans_for_turn(
         last_input_role = "user"
         last_input_content = ""
 
+        # Accumulator for the current message.id group
+        current_group_id: Optional[str] = None
+        group_first_usage: dict = {}
+        group_total_output_tokens: int = 0
+        group_text_parts: list = []
+        group_tool_use_parts: list = []
+        group_model: str = "claude"
+        group_ts: str = ""
+        group_input_snapshot: dict = {}  # last_input* captured at group start
+
+        def _flush_group() -> None:
+            """Emit one LLM span for the accumulated group, if non-empty."""
+            nonlocal current_group_id, group_first_usage, group_total_output_tokens
+            nonlocal group_text_parts, group_tool_use_parts, group_model, group_ts
+            nonlocal group_input_snapshot
+
+            if not current_group_id:
+                return
+
+            usage = group_first_usage
+            input_tokens = usage.get("input_tokens", 0)
+            cache_read = usage.get("cache_read_input_tokens", 0)
+            cache_create = usage.get("cache_creation_input_tokens", 0)
+            output_tokens = group_total_output_tokens
+
+            if group_text_parts:
+                output_value = _truncate("".join(group_text_parts))
+                output_mime = "text/plain"
+            elif group_tool_use_parts:
+                output_value = _truncate(json.dumps(group_tool_use_parts))
+                output_mime = "application/json"
+            else:
+                output_value = ""
+                output_mime = "text/plain"
+
+            start_ns = _iso_to_ns(group_ts)
+            end_ns = start_ns + max(output_tokens * 10_000_000, 1_000_000)
+
+            snap = group_input_snapshot
+            attrs: dict[str, Any] = {
+                "openinference.span.kind": "LLM",
+                "llm.system": "anthropic",
+                "llm.model_name": group_model,
+                "llm.token_count.prompt": input_tokens + cache_read + cache_create,
+                "llm.token_count.completion": output_tokens,
+                "llm.token_count.total": input_tokens
+                + cache_read
+                + cache_create
+                + output_tokens,
+                "llm.token_count.prompt_details.cache_read": cache_read,
+                "llm.token_count.prompt_details.cache_write": cache_create,
+                "llm.input_messages.0.message.role": snap.get("role", "user"),
+                "llm.input_messages.0.message.content": snap.get("content", ""),
+                "input.value": snap.get("value", ""),
+                "input.mime_type": snap.get("mime", "text/plain"),
+                "llm.output_messages.0.message.role": "assistant",
+                "llm.output_messages.0.message.content": output_value,
+                "output.value": output_value,
+                "output.mime_type": output_mime,
+            }
+
+            spans.append(
+                {
+                    "trace_id_hex": trace_id_hex,
+                    "span_id_hex": _new_span_id(),
+                    "parent_span_id_hex": root_span_id_hex,
+                    "name": f"claude/{group_model}",
+                    "kind": None,
+                    "start_ns": start_ns,
+                    "end_ns": end_ns,
+                    "attributes": attrs,
+                    "force_span_id": False,
+                },
+            )
+
+            # Reset accumulator
+            current_group_id = None
+            group_first_usage = {}
+            group_total_output_tokens = 0
+            group_text_parts = []
+            group_tool_use_parts = []
+            group_model = "claude"
+            group_ts = ""
+            group_input_snapshot = {}
+
         for line in lines:
             if not line.strip():
                 continue
@@ -403,12 +511,9 @@ def _extract_llm_spans_for_turn(
 
             # ── Human message: marks the start of this turn ──────────────────
             if _is_human_message(entry):
+                _flush_group()
                 human_count += 1
                 if in_turn:
-                    # A second human message within the same trace can happen when
-                    # the Claude Code context is compressed and the session continues
-                    # without firing a new UserPromptSubmit hook.  Keep scanning so
-                    # the LLM spans from the continuation are also captured.
                     human_text = entry.get("message", {}).get("content", "")
                     last_input_value = json.dumps(
                         {"role": "user", "content": human_text[:500]},
@@ -433,6 +538,7 @@ def _extract_llm_spans_for_turn(
 
             # ── Tool result (user message with list content) ──────────────────
             if entry_type == "user":
+                _flush_group()
                 content = entry.get("message", {}).get("content", "")
                 if isinstance(content, list):
                     text = _tool_result_text(content)
@@ -445,7 +551,7 @@ def _extract_llm_spans_for_turn(
                     last_input_content = _truncate(payload)
                 continue
 
-            # ── Assistant LLM response ────────────────────────────────────────
+            # ── Non-assistant entries (progress, system, …) ───────────────────
             if entry_type != "assistant":
                 continue
 
@@ -454,86 +560,45 @@ def _extract_llm_spans_for_turn(
             if not usage:
                 continue
 
+            msg_id = msg.get("id", "") or id(entry)  # fall back to object id
             model = msg.get("model", "claude")
             content_blocks = msg.get("content", [])
             ts = entry.get("timestamp", "")
 
-            # Output: prefer text; fall back to serialised tool_use blocks
-            text_parts = []
-            tool_use_parts = []
+            # ── Start a new group or extend the current one ───────────────────
+            if msg_id != current_group_id:
+                _flush_group()
+                current_group_id = msg_id
+                group_first_usage = usage
+                group_total_output_tokens = 0
+                group_text_parts = []
+                group_tool_use_parts = []
+                group_model = model
+                group_ts = ts
+                # Snapshot the input context at the start of this API call
+                group_input_snapshot = {
+                    "role": last_input_role,
+                    "content": last_input_content,
+                    "value": last_input_value,
+                    "mime": last_input_mime,
+                }
+
+            # Accumulate output tokens and content blocks for this group
+            group_total_output_tokens += usage.get("output_tokens", 0)
             for block in content_blocks:
                 if not isinstance(block, dict):
                     continue
                 if block.get("type") == "text":
-                    text_parts.append(block.get("text", ""))
+                    group_text_parts.append(block.get("text", ""))
                 elif block.get("type") == "tool_use":
-                    tool_use_parts.append(
+                    group_tool_use_parts.append(
                         {
                             "name": block.get("name", ""),
                             "input": block.get("input", {}),
                         },
                     )
 
-            if text_parts:
-                output_value = _truncate("".join(text_parts))
-                output_mime = "text/plain"
-            elif tool_use_parts:
-                output_value = _truncate(json.dumps(tool_use_parts))
-                output_mime = "application/json"
-            else:
-                output_value = ""
-                output_mime = "text/plain"
-
-            input_tokens = usage.get("input_tokens", 0)
-            cache_read = usage.get("cache_read_input_tokens", 0)
-            cache_create = usage.get("cache_creation_input_tokens", 0)
-            output_tokens = usage.get("output_tokens", 0)
-
-            start_ns = _iso_to_ns(ts)
-            end_ns = start_ns + max(output_tokens * 10_000_000, 1_000_000)
-
-            attrs: dict[str, Any] = {
-                "openinference.span.kind": "LLM",
-                "llm.system": "anthropic",
-                "llm.model_name": model,
-                "llm.token_count.prompt": input_tokens + cache_read + cache_create,
-                "llm.token_count.completion": output_tokens,
-                "llm.token_count.total": input_tokens
-                + cache_read
-                + cache_create
-                + output_tokens,
-                "llm.token_count.prompt_details.cache_read": cache_read,
-                "llm.token_count.prompt_details.cache_write": cache_create,
-                # Input: the message that immediately preceded this LLM call
-                "llm.input_messages.0.message.role": last_input_role,
-                "llm.input_messages.0.message.content": last_input_content,
-                "input.value": last_input_value,
-                "input.mime_type": last_input_mime,
-                # Output: text response or serialised tool_use blocks
-                "llm.output_messages.0.message.role": "assistant",
-                "llm.output_messages.0.message.content": output_value,
-                "output.value": output_value,
-                "output.mime_type": output_mime,
-            }
-
-            spans.append(
-                {
-                    "trace_id_hex": trace_id_hex,
-                    "span_id_hex": _new_span_id(),
-                    "parent_span_id_hex": root_span_id_hex,
-                    "name": f"claude/{model}",
-                    "kind": None,  # Caller sets SpanKind
-                    "start_ns": start_ns,
-                    "end_ns": end_ns,
-                    "attributes": attrs,
-                    "force_span_id": False,
-                },
-            )
-
-            # Update last_input for the next LLM call: the assistant's output
-            # becomes part of what the model was shown next (via tool results).
-            # We leave last_input* unchanged here — the tool result user message
-            # that follows will overwrite it when we see that entry.
+        _flush_group()
 
     except Exception as e:
         log.warning("Failed to extract LLM spans: %s", e)

--- a/integrations/claude-code/claude_code_tracer.py
+++ b/integrations/claude-code/claude_code_tracer.py
@@ -248,10 +248,36 @@ def _session_lock(session_id: str):
 # ---------------------------------------------------------------------------
 
 
+def _is_real_transcript(path: str) -> bool:
+    """Return True if the transcript has at least one human or assistant entry.
+
+    Shadow transcripts created by ``gh pr create`` in a worktree contain only
+    ``pr-link`` metadata entries and no actual conversation content.  Accepting
+    one of these as the authoritative transcript would leave the tracer with
+    nothing to extract LLM spans from.
+    """
+    try:
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("type") in ("user", "assistant"):
+                    return True
+        return False
+    except OSError:
+        return False
+
+
 def _find_transcript_path(data: dict, session_id: str) -> Optional[str]:
     """Locate the session's transcript JSONL file.
 
-    Searches three locations in priority order and returns the first match.
+    Searches three locations in priority order and returns the first match
+    that contains real conversation content (at least one user/assistant entry).
     Callers that need a stable path across the lifetime of a session should
     cache the result in session state via ``_get_cached_transcript_path``
     rather than calling this function repeatedly — the ``transcript_path``
@@ -259,10 +285,12 @@ def _find_transcript_path(data: dict, session_id: str) -> Optional[str]:
     entries to a *different* project directory (e.g. after ``gh pr create``
     in a worktree context).
     """
+    candidates: list[str] = []
+
     # 1. Provided directly in hook data
     tp = data.get("transcript_path", "")
     if tp and Path(tp).exists():
-        return tp
+        candidates.append(tp)
 
     # 2. Construct from CLAUDE_PROJECT_DIR (path with / → -)
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "")
@@ -270,14 +298,24 @@ def _find_transcript_path(data: dict, session_id: str) -> Optional[str]:
         sanitized = project_dir.replace("/", "-")
         path = Path.home() / ".claude" / "projects" / sanitized / f"{session_id}.jsonl"
         if path.exists():
-            return str(path)
+            candidates.append(str(path))
 
-    # 3. Glob fallback across all project dirs
+    # 3. Glob fallback across all project dirs (sorted largest-first so the
+    #    real transcript wins over tiny shadow files)
     projects_dir = Path.home() / ".claude" / "projects"
     if projects_dir.exists():
         matches = list(projects_dir.glob(f"*/{session_id}.jsonl"))
-        if matches:
-            return str(matches[0])
+        matches.sort(key=lambda p: p.stat().st_size, reverse=True)
+        candidates.extend(str(m) for m in matches)
+
+    # Return the first candidate that contains actual conversation entries
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if _is_real_transcript(candidate):
+            return candidate
 
     return None
 

--- a/integrations/claude-code/test_tracer.py
+++ b/integrations/claude-code/test_tracer.py
@@ -1626,10 +1626,20 @@ class TestStateHelperErrorPaths:
 # ---------------------------------------------------------------------------
 
 
+def _real_transcript_content() -> str:
+    """Minimal transcript content with one human message — passes _is_real_transcript."""
+    return json.dumps({"type": "user", "message": {"role": "user", "content": "hi"}}) + "\n"
+
+
+def _shadow_transcript_content() -> str:
+    """Shadow transcript with only pr-link entries — rejected by _is_real_transcript."""
+    return json.dumps({"type": "pr-link", "sessionId": "s", "prNumber": 1}) + "\n"
+
+
 class TestFindTranscriptPath:
     def test_uses_transcript_path_from_data(self, tmp_path):
         p = tmp_path / "t.jsonl"
-        p.write_text("")
+        p.write_text(_real_transcript_content())
         result = tracer._find_transcript_path({"transcript_path": str(p)}, "any")
         assert result == str(p)
 
@@ -1640,13 +1650,55 @@ class TestFindTranscriptPath:
         )
         assert result is None
 
+    def test_skips_shadow_transcript_in_data(self, tmp_path):
+        """A transcript with only pr-link entries should be rejected."""
+        shadow = tmp_path / "shadow.jsonl"
+        shadow.write_text(_shadow_transcript_content())
+        result = tracer._find_transcript_path({"transcript_path": str(shadow)}, "any")
+        assert result is None
+
+    def test_shadow_in_data_falls_back_to_real_glob(self, tmp_path, monkeypatch):
+        """When hook data points to a shadow transcript, glob fallback finds the real one."""
+        session_id = "sess-fallback"
+        shadow = tmp_path / "shadow.jsonl"
+        shadow.write_text(_shadow_transcript_content())
+
+        real_dir = tmp_path / ".claude" / "projects" / "real-project"
+        real_dir.mkdir(parents=True)
+        real = real_dir / f"{session_id}.jsonl"
+        real.write_text(_real_transcript_content())
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = tracer._find_transcript_path({"transcript_path": str(shadow)}, session_id)
+        assert result == str(real)
+
+    def test_glob_prefers_largest_file(self, tmp_path, monkeypatch):
+        """When multiple candidates exist, the largest (most content) is preferred."""
+        session_id = "sess-multi"
+        small_dir = tmp_path / ".claude" / "projects" / "small-proj"
+        small_dir.mkdir(parents=True)
+        small = small_dir / f"{session_id}.jsonl"
+        small.write_text(_real_transcript_content())
+
+        big_dir = tmp_path / ".claude" / "projects" / "big-proj"
+        big_dir.mkdir(parents=True)
+        big = big_dir / f"{session_id}.jsonl"
+        # Make it larger with more entries
+        big.write_text(_real_transcript_content() * 10)
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = tracer._find_transcript_path({}, session_id)
+        assert result == str(big)
+
     def test_env_var_path(self, tmp_path, monkeypatch):
         # Create <home>/.claude/projects/<sanitized>/sess.jsonl via CLAUDE_PROJECT_DIR
         project_dir = "/my/project"
         sanitized = project_dir.replace("/", "-")
         transcript = tmp_path / ".claude" / "projects" / sanitized / "myses.jsonl"
         transcript.parent.mkdir(parents=True)
-        transcript.write_text("")
+        transcript.write_text(_real_transcript_content())
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", project_dir)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         result = tracer._find_transcript_path({}, "myses")
@@ -1656,7 +1708,7 @@ class TestFindTranscriptPath:
         # No env var, but transcript exists somewhere under projects/
         transcript = tmp_path / ".claude" / "projects" / "some-dir" / "globsess.jsonl"
         transcript.parent.mkdir(parents=True)
-        transcript.write_text("")
+        transcript.write_text(_real_transcript_content())
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         result = tracer._find_transcript_path({}, "globsess")
@@ -1692,7 +1744,7 @@ class TestGetCachedTranscriptPath:
     def test_resolves_and_caches_when_state_has_no_path(self, tmp_path):
         """When state has no cached path, resolve via hook data and cache it."""
         p = tmp_path / "t.jsonl"
-        p.write_text("")
+        p.write_text(_real_transcript_content())
         state = {}
         result = tracer._get_cached_transcript_path(
             {"transcript_path": str(p)}, state, "any"
@@ -1703,12 +1755,12 @@ class TestGetCachedTranscriptPath:
     def test_re_resolves_if_cached_path_deleted(self, tmp_path):
         """If the cached file no longer exists, fall through to _find_transcript_path."""
         gone = tmp_path / "gone.jsonl"
-        gone.write_text("")
+        gone.write_text(_real_transcript_content())
         state = {"transcript_path": str(gone)}
         gone.unlink()  # delete it
 
         new = tmp_path / "new.jsonl"
-        new.write_text("")
+        new.write_text(_real_transcript_content())
         result = tracer._get_cached_transcript_path(
             {"transcript_path": str(new)}, state, "any"
         )

--- a/integrations/claude-code/test_tracer.py
+++ b/integrations/claude-code/test_tracer.py
@@ -2303,3 +2303,152 @@ class TestMain:
         with pytest.raises(SystemExit) as exc:
             tracer.main()
         assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# _extract_llm_spans_for_turn — message.id grouping
+# ---------------------------------------------------------------------------
+
+
+def llm_entry_with_id(
+    msg_id: str,
+    text: str = "",
+    tool_use_blocks: list | None = None,
+    model: str = "claude-sonnet-4-6",
+    input_tokens: int = 10,
+    output_tokens: int = 20,
+    cache_read: int = 0,
+    cache_create: int = 0,
+    ts: str = "2026-01-01T00:00:02.000000+00:00",
+) -> dict:
+    """LLM transcript entry with an explicit message.id (for grouping tests)."""
+    content = []
+    if text:
+        content.append({"type": "text", "text": text})
+    for b in tool_use_blocks or []:
+        content.append(b)
+    return {
+        "type": "assistant",
+        "message": {
+            "id": msg_id,
+            "role": "assistant",
+            "model": model,
+            "content": content,
+            "usage": {
+                "input_tokens": input_tokens,
+                "cache_read_input_tokens": cache_read,
+                "cache_creation_input_tokens": cache_create,
+                "output_tokens": output_tokens,
+            },
+        },
+        "timestamp": ts,
+    }
+
+
+class TestExtractLlmSpansMessageIdGrouping:
+    """
+    Verify that consecutive assistant entries sharing a message.id are collapsed
+    into a single LLM span (Fix 3: multi-entry API response grouping).
+    """
+
+    TRACE_ID = "e" * 32
+    ROOT_ID = "f" * 16
+
+    def _extract(self, p, human_count_at_start=0):
+        return tracer._extract_llm_spans_for_turn(
+            str(p),
+            human_count_at_start,
+            self.TRACE_ID,
+            self.ROOT_ID,
+        )
+
+    def test_two_entries_same_id_produce_one_span(self, tmp_transcript):
+        # Extended-thinking: first entry = thinking block (no text/tool_use),
+        # second entry = text block. Both share message id "msg_abc".
+        p = tmp_transcript(
+            [
+                human_entry("Hello"),
+                llm_entry_with_id("msg_abc", text="", output_tokens=5),
+                llm_entry_with_id("msg_abc", text="Hi there", output_tokens=15),
+            ]
+        )
+        spans = self._extract(p)
+        assert len(spans) == 1
+        attrs = spans[0]["attributes"]
+        assert attrs["output.value"] == "Hi there"
+        assert attrs["output.mime_type"] == "text/plain"
+
+    def test_output_tokens_summed_across_entries(self, tmp_transcript):
+        # The thinking entry contributes 5 tokens, text entry contributes 15.
+        # Total completion must be 20, not 15 (last entry only) or 5 (first only).
+        p = tmp_transcript(
+            [
+                human_entry("Hello"),
+                llm_entry_with_id("msg_abc", text="", output_tokens=5),
+                llm_entry_with_id("msg_abc", text="Answer", output_tokens=15),
+            ]
+        )
+        spans = self._extract(p)
+        assert len(spans) == 1
+        assert spans[0]["attributes"]["llm.token_count.completion"] == 20
+
+    def test_prompt_tokens_taken_from_first_entry_only(self, tmp_transcript):
+        # input_tokens=100 appears on both entries (duplicated by Claude Code).
+        # The span must report 100, not 200.
+        p = tmp_transcript(
+            [
+                human_entry("Hello"),
+                llm_entry_with_id("msg_abc", text="", input_tokens=100, output_tokens=5),
+                llm_entry_with_id("msg_abc", text="Answer", input_tokens=100, output_tokens=15),
+            ]
+        )
+        spans = self._extract(p)
+        assert len(spans) == 1
+        assert spans[0]["attributes"]["llm.token_count.prompt"] == 100
+
+    def test_different_ids_produce_separate_spans(self, tmp_transcript):
+        # Two API calls, each with a distinct message.id → two spans.
+        p = tmp_transcript(
+            [
+                human_entry("Hello"),
+                llm_entry_with_id("msg_aaa", text="First response"),
+                tool_result_entry("t1", "tool output"),
+                llm_entry_with_id("msg_bbb", text="Second response"),
+            ]
+        )
+        spans = self._extract(p)
+        assert len(spans) == 2
+        assert spans[0]["attributes"]["output.value"] == "First response"
+        assert spans[1]["attributes"]["output.value"] == "Second response"
+
+    def test_three_entries_same_id_text_concatenated(self, tmp_transcript):
+        # Three entries with same id: thinking + text_part_1 + text_part_2
+        p = tmp_transcript(
+            [
+                human_entry("Hello"),
+                llm_entry_with_id("msg_xyz", text="", output_tokens=3),
+                llm_entry_with_id("msg_xyz", text="Hello ", output_tokens=4),
+                llm_entry_with_id("msg_xyz", text="world", output_tokens=5),
+            ]
+        )
+        spans = self._extract(p)
+        assert len(spans) == 1
+        assert spans[0]["attributes"]["output.value"] == "Hello world"
+        assert spans[0]["attributes"]["llm.token_count.completion"] == 12
+
+    def test_tool_use_entry_followed_by_text_entry_same_id(self, tmp_transcript):
+        # text entry takes precedence over tool_use when both present in group
+        tb = tool_use_block("Read", "/tmp/foo")
+        p = tmp_transcript(
+            [
+                human_entry("Hello"),
+                llm_entry_with_id("msg_mix", tool_use_blocks=[tb], output_tokens=8),
+                llm_entry_with_id("msg_mix", text="Here is the file", output_tokens=10),
+            ]
+        )
+        spans = self._extract(p)
+        assert len(spans) == 1
+        attrs = spans[0]["attributes"]
+        assert attrs["output.mime_type"] == "text/plain"
+        assert attrs["output.value"] == "Here is the file"
+        assert attrs["llm.token_count.completion"] == 18

--- a/integrations/claude-code/test_tracer.py
+++ b/integrations/claude-code/test_tracer.py
@@ -1670,6 +1670,86 @@ class TestFindTranscriptPath:
 
 
 # ---------------------------------------------------------------------------
+# _get_cached_transcript_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetCachedTranscriptPath:
+    def test_uses_cached_path_from_state(self, tmp_path):
+        """If state already has a transcript_path that exists, return it without
+        calling _find_transcript_path again — even if the hook data points elsewhere."""
+        real = tmp_path / "real.jsonl"
+        real.write_text("")
+        decoy = tmp_path / "decoy.jsonl"
+        decoy.write_text("")
+
+        state = {"transcript_path": str(real)}
+        result = tracer._get_cached_transcript_path(
+            {"transcript_path": str(decoy)}, state, "any"
+        )
+        assert result == str(real)
+
+    def test_resolves_and_caches_when_state_has_no_path(self, tmp_path):
+        """When state has no cached path, resolve via hook data and cache it."""
+        p = tmp_path / "t.jsonl"
+        p.write_text("")
+        state = {}
+        result = tracer._get_cached_transcript_path(
+            {"transcript_path": str(p)}, state, "any"
+        )
+        assert result == str(p)
+        assert state["transcript_path"] == str(p)
+
+    def test_re_resolves_if_cached_path_deleted(self, tmp_path):
+        """If the cached file no longer exists, fall through to _find_transcript_path."""
+        gone = tmp_path / "gone.jsonl"
+        gone.write_text("")
+        state = {"transcript_path": str(gone)}
+        gone.unlink()  # delete it
+
+        new = tmp_path / "new.jsonl"
+        new.write_text("")
+        result = tracer._get_cached_transcript_path(
+            {"transcript_path": str(new)}, state, "any"
+        )
+        assert result == str(new)
+        assert state["transcript_path"] == str(new)
+
+    def test_cached_path_survives_shadow_file_creation(self, tmp_path, monkeypatch):
+        """Simulate gh pr create writing a shadow file mid-session.
+
+        The cached path from UserPromptSubmit should be used even after
+        the hook payload starts pointing to the shadow file.
+        """
+        session_id = "stable-sess"
+        real_dir = tmp_path / ".claude" / "projects" / "real-project"
+        real_dir.mkdir(parents=True)
+        real = real_dir / f"{session_id}.jsonl"
+        real.write_text(
+            "\n".join([
+                json.dumps({"type": "user", "message": {"role": "user", "content": "hi"}}),
+                json.dumps({"type": "assistant", "message": {"role": "assistant", "content": []}}),
+            ]) + "\n"
+        )
+
+        # State cached at UserPromptSubmit time, pointing to the real transcript
+        state = {"transcript_path": str(real)}
+
+        # Mid-session, gh pr create writes a shadow file; hook data now points there
+        shadow_dir = tmp_path / ".claude" / "projects" / "worktree-dir"
+        shadow_dir.mkdir(parents=True)
+        shadow = shadow_dir / f"{session_id}.jsonl"
+        shadow.write_text(json.dumps({"type": "pr-link", "prNumber": 99}) + "\n")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = tracer._get_cached_transcript_path(
+            {"transcript_path": str(shadow)}, state, session_id
+        )
+        # Must return the cached real transcript, not the shadow
+        assert result == str(real)
+
+
+# ---------------------------------------------------------------------------
 # discover_config — global config fallback
 # ---------------------------------------------------------------------------
 

--- a/integrations/claude-code/test_tracer.py
+++ b/integrations/claude-code/test_tracer.py
@@ -1750,6 +1750,106 @@ class TestGetCachedTranscriptPath:
 
 
 # ---------------------------------------------------------------------------
+# Subagent trace context propagation
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentContextPropagation:
+    """Tests for _write_pending_agent_context / _claim_pending_agent_context."""
+
+    def test_write_and_claim_round_trip(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tracer, "STATE_DIR", tmp_path / "tracer")
+        monkeypatch.setattr(tracer, "_PENDING_AGENT_DIR", tmp_path / "tracer" / "pending_agent")
+        tracer._write_pending_agent_context("parent-sess", "traceid-abc", "spanid-xyz")
+        ctx = tracer._claim_pending_agent_context()
+        assert ctx is not None
+        assert ctx["parent_trace_id"] == "traceid-abc"
+        assert ctx["parent_span_id"] == "spanid-xyz"
+        assert ctx["parent_session_id"] == "parent-sess"
+        # File is deleted after claiming
+        assert not any((tmp_path / "tracer" / "pending_agent").iterdir())
+
+    def test_claim_returns_none_when_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tracer, "_PENDING_AGENT_DIR", tmp_path / "pending_agent")
+        assert tracer._claim_pending_agent_context() is None
+
+    def test_claim_ignores_stale_context(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tracer, "_PENDING_AGENT_DIR", tmp_path / "pending_agent")
+        monkeypatch.setattr(tracer, "_PENDING_AGENT_TIMEOUT_S", 0)
+        tracer._write_pending_agent_context("s", "t", "p")
+        # With 0s timeout, the file is immediately considered stale
+        assert tracer._claim_pending_agent_context() is None
+
+    def test_subagent_inherits_trace_id(self, tmp_path, monkeypatch):
+        """UserPromptSubmit for a new session should inherit the parent trace ID."""
+        monkeypatch.setattr(tracer, "STATE_DIR", tmp_path / "tracer")
+        monkeypatch.setattr(tracer, "_PENDING_AGENT_DIR", tmp_path / "tracer" / "pending_agent")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
+        parent_trace_id = "aabbccddeeff00112233445566778899"
+        parent_span_id = "0011223344556677"
+        tracer._write_pending_agent_context("parent-sess", parent_trace_id, parent_span_id)
+
+        exported: list[dict] = []
+
+        def fake_export(config, session_id, username, span_records):
+            exported.extend(span_records)
+
+        monkeypatch.setattr(tracer, "_build_and_export_spans", fake_export)
+        monkeypatch.setattr(tracer, "discover_config", lambda: {"api_key": "k", "task_id": "t", "endpoint": "https://x"})
+
+        data = {"session_id": "child-sess", "prompt": "do the task"}
+        state = {}
+        monkeypatch.setattr(tracer, "_load_state", lambda sid: state)
+        monkeypatch.setattr(tracer, "_save_state", lambda sid, s: state.update(s))
+
+        tracer.handle_user_prompt_submit(data, {"api_key": "k", "task_id": "t", "endpoint": "https://x"})
+
+        # The new trace should use the parent's trace ID
+        assert state["current_trace"]["trace_id"] == parent_trace_id
+        # And record the parent agent span for use in _complete_turn
+        assert state["current_trace"]["parent_agent_span_id"] == parent_span_id
+
+    def test_handle_pre_tool_writes_context_for_agent(self, tmp_path, monkeypatch):
+        """PreToolUse for the Agent tool should write a pending context file."""
+        monkeypatch.setattr(tracer, "STATE_DIR", tmp_path / "tracer")
+        monkeypatch.setattr(tracer, "_PENDING_AGENT_DIR", tmp_path / "tracer" / "pending_agent")
+
+        trace_id = "deadbeef" * 4
+        root_span_id = "cafebabe" * 2
+        state = {
+            "session_id": "parent-sess",
+            "current_trace": {
+                "trace_id": trace_id,
+                "root_span_id": root_span_id,
+                "turn_start_ns": 0,
+                "turn_number": 1,
+                "human_count_at_start": 0,
+            },
+            "pending_tools": {},
+        }
+        monkeypatch.setattr(tracer, "_load_state", lambda sid: state)
+        monkeypatch.setattr(tracer, "_save_state", lambda sid, s: state.update(s))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
+        data = {
+            "session_id": "parent-sess",
+            "tool_name": "Agent",
+            "tool_input": {"prompt": "go do stuff"},
+        }
+        tracer.handle_pre_tool(data, {"api_key": "k", "task_id": "t", "endpoint": "https://x"})
+
+        # A pending context file should now exist
+        ctx = tracer._claim_pending_agent_context()
+        assert ctx is not None
+        assert ctx["parent_trace_id"] == trace_id
+        # The pre-allocated span ID should be stored in pending_tools
+        assert "pre_allocated_span_id" in state["pending_tools"]["Agent"]
+
+
+# ---------------------------------------------------------------------------
 # discover_config — global config fallback
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Three fixes to the Claude Code OpenInference tracer:

- **Fix 1: Shadow transcript path caching** — cached transcript path in session state to prevent mid-session redirect to shadow transcript created by gh pr create in worktrees
- **Fix 2: Subagent context propagation** — skills/agents spawned by the Agent tool now nest all telemetry under the parent trace instead of creating separate traces
- **Fix 3: Group multi-entry API responses by message.id** — fixes prompt token duplication and missing intermediate LLM spans caused by extended-thinking splitting one API response across multiple transcript entries

## Test plan

- [x] 129 unit tests pass
- [x] TestGetCachedTranscriptPath (4 tests) - Fix 1 regression
- [x] TestSubagentContextPropagation (5 tests) - Fix 2 regression
- [x] TestExtractLlmSpansMessageIdGrouping (6 tests) - Fix 3 regression

Generated with Claude Code