### PR TITLE
feat: add policy_alert_rule_check_count metric

### DIFF
--- a/ml-engine/src/ml_engine/job_executors/compliance_policy_check_executor.py
+++ b/ml-engine/src/ml_engine/job_executors/compliance_policy_check_executor.py
@@ -110,7 +110,12 @@ class CompliancePolicyCheckExecutor:
             str(assignment.id), status, alert_rule_results, attestation_results
         )
         self._write_compliance_metrics(
-            model_id, assignment, status, attestation_results, self._now
+            model_id,
+            assignment,
+            status,
+            attestation_results,
+            alert_rule_results,
+            self._now,
         )
 
     def _fetch_assignments(
@@ -329,6 +334,7 @@ class CompliancePolicyCheckExecutor:
         assignment: PolicyAssignment,
         status: ComplianceStatus,
         attestation_results: List[Tuple[PolicyAttestationRule, bool, str]],
+        alert_rule_results: List[Tuple[ClientAlertRule, bool, Optional[Alert]]],
         now: datetime,
     ) -> None:
         metric_ts = self._align_to_5min(now)
@@ -400,6 +406,51 @@ class CompliancePolicyCheckExecutor:
                                 ),
                                 Dimension(
                                     name="attestation_rule_name",
+                                    value=rule.name,
+                                ),
+                                Dimension(
+                                    name="status",
+                                    value="compliant" if passed else "non_compliant",
+                                ),
+                            ],
+                            values=[
+                                NumericPoint(timestamp=metric_ts, value=1.0),
+                            ],
+                        ),
+                    ],
+                )
+            )
+
+        # Per-alert-rule status metric (value=1 for counting, status in dimensions)
+        for rule, passed, _triggering_alert in alert_rule_results:
+            metrics.append(
+                NumericMetric(
+                    name="policy_alert_rule_check_count",
+                    numeric_series=[
+                        NumericTimeSeries(
+                            dimensions=[
+                                Dimension(
+                                    name="policy_id",
+                                    value=str(assignment.policy.id),
+                                ),
+                                Dimension(
+                                    name="policy_name",
+                                    value=assignment.policy.name,
+                                ),
+                                Dimension(
+                                    name="assignment_id",
+                                    value=str(assignment.id),
+                                ),
+                                Dimension(
+                                    name="model_name",
+                                    value=assignment.model.name,
+                                ),
+                                Dimension(
+                                    name="alert_rule_id",
+                                    value=str(rule.id),
+                                ),
+                                Dimension(
+                                    name="alert_rule_name",
                                     value=rule.name,
                                 ),
                                 Dimension(

--- a/ml-engine/tests/unit/job_executors/test_compliance_policy_check_executor.py
+++ b/ml-engine/tests/unit/job_executors/test_compliance_policy_check_executor.py
@@ -23,6 +23,7 @@ from arthur_client.api_bindings import (
     JobTrigger,
     ModelSummary,
     Policy,
+    PolicyAlertRule,
     PolicyAssignment,
     PolicyAttestationRule,
     PolicySummary,
@@ -597,3 +598,72 @@ def test_metrics_uploaded_with_correct_dimensions(mock_datetime):
     assert "attestation_rule_name" in att_dim_names
     assert "policy_name" in att_dim_names
     assert "model_name" in att_dim_names
+
+
+@patch("job_executors.compliance_policy_check_executor.datetime")
+def test_alert_rule_metrics_uploaded_with_correct_dimensions(mock_datetime):
+    """Verify alert rule metrics include alert_rule_id, alert_rule_name, and status dimensions."""
+    mock_datetime.now.return_value = NOW
+    mock_datetime.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+
+    executor, policies_client, alert_rules_client, alerts_client, metrics_client, _ = _make_executor()
+
+    model_id = str(uuid4())
+    policy_id = str(uuid4())
+    policy_summary = _make_policy_summary(policy_id)
+    model_summary = _make_model_summary(model_id)
+    assignment = _make_assignment(
+        policy_summary=policy_summary,
+        model_summary=model_summary,
+    )
+
+    alert_rule = _make_alert_rule(rule_id="failing-rule", model_id=model_id)
+    alert = _make_alert(alert_rule_id="failing-rule", model_id=model_id)
+    policy_alert_rule = PolicyAlertRule(
+        id="failing-rule",
+        policy_id=policy_id,
+        name=alert_rule.name,
+        threshold=alert_rule.threshold,
+        bound=alert_rule.bound,
+        query=alert_rule.query,
+        metric_name=alert_rule.metric_name,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    policy = _make_policy(policy_id, alert_rules=[policy_alert_rule])
+
+    job, job_spec = _make_job_and_spec(model_id)
+
+    policies_client.list_model_policy_assignments.return_value = _paginated_response([assignment])
+    policies_client.get_policy.return_value = policy
+    policies_client.list_model_attestations.return_value = _paginated_response([])
+    alert_rules_client.get_model_alert_rules.return_value = _paginated_response([alert_rule])
+    alerts_client.get_model_alerts.return_value = _paginated_response([alert])
+
+    executor.execute(job, job_spec)
+
+    upload_call = metrics_client.post_model_metrics_by_version.call_args
+    upload = upload_call.kwargs["metrics_upload"]
+
+    # Should have 2 metrics: 1 compliance check + 1 alert rule check (no attestation rules)
+    assert len(upload.metrics) == 2
+
+    # First metric is the overall compliance check
+    compliance_metric = upload.metrics[0].actual_instance
+    assert compliance_metric.name == "policy_compliance_check_count"
+
+    # Second metric is the alert rule check
+    alert_metric = upload.metrics[1].actual_instance
+    assert alert_metric.name == "policy_alert_rule_check_count"
+    alert_dim_names = {d.name for d in alert_metric.numeric_series[0].dimensions}
+    assert "policy_id" in alert_dim_names
+    assert "policy_name" in alert_dim_names
+    assert "assignment_id" in alert_dim_names
+    assert "model_name" in alert_dim_names
+    assert "alert_rule_id" in alert_dim_names
+    assert "alert_rule_name" in alert_dim_names
+    assert "status" in alert_dim_names
+
+    # Verify status is non_compliant since the alert fired
+    alert_dims = {d.name: d.value for d in alert_metric.numeric_series[0].dimensions}
+    assert alert_dims["status"] == "non_compliant"


### PR DESCRIPTION
## Summary

- Adds `policy_alert_rule_check_count` metric to the compliance policy check executor, emitted per alert rule with dimensions for policy, assignment, model, rule, and compliance status
- Enables a historic line graph of rule violations over time, segmented by rule across policies
- Includes test coverage verifying metric name, all dimensions, and status value

## Test plan

- [x] `test_alert_rule_metrics_uploaded_with_correct_dimensions` — verifies metric structure and non_compliant status when an alert fires
- [x] All 11 existing compliance executor tests pass
- [x] Lint clean (`scripts/lint.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)