### PR TITLE
Have the SDK set GenAI Engine task ID to OTLP spans

### DIFF
--- a/arthur-observability-sdk/docs/getting-started.md
+++ b/arthur-observability-sdk/docs/getting-started.md
@@ -48,7 +48,7 @@ arthur = Arthur(
 | `task_id` | `str \| None` | `None` | Arthur task UUID. Used for prompt fetching. |
 | `task_name` | `str \| None` | `None` | Task name — resolved lazily to a UUID via the API on the first prompt call. |
 | `service_name` | `str \| None` | `None` | OTel `service.name` resource attribute. Defaults to `task_name` or `task_id` when omitted. |
-| `resource_attributes` | `dict \| None` | `None` | Additional OTel resource attributes merged into the `TracerProvider`. |
+| `resource_attributes` | `dict \| None` | `None` | Additional OTel resource attributes merged into the `TracerProvider`. If `task_id` is provided and `arthur.task` is not explicitly set, it defaults to `task_id`. |
 | `enable_telemetry` | `bool` | `True` | When `False`, no `TracerProvider` is created (useful for prompt-only usage). |
 | `otlp_endpoint` | `str \| None` | `None` | OTLP HTTP traces endpoint. Defaults to `{base_url}/api/v1/traces`. |
 

--- a/arthur-observability-sdk/python/pyproject.toml
+++ b/arthur-observability-sdk/python/pyproject.toml
@@ -112,6 +112,10 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/arthur_observability_sdk", "src/arthur_genai_client"]
 
+[tool.isort]
+profile = "black"
+known_first_party = ["arthur_observability_sdk"]
+
 [tool.black]
 line-length = 100
 target-version = ["py310"]

--- a/arthur-observability-sdk/python/src/arthur_observability_sdk/arthur.py
+++ b/arthur-observability-sdk/python/src/arthur_observability_sdk/arthur.py
@@ -4,13 +4,14 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
-from arthur_observability_sdk._client import ArthurAPIClient
-from arthur_observability_sdk.telemetry import setup_telemetry
 from openinference.instrumentation import using_attributes, using_session, using_user
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 from opentelemetry import trace
 from opentelemetry.context import get_value
 from opentelemetry.sdk.trace import TracerProvider
+
+from arthur_observability_sdk._client import ArthurAPIClient
+from arthur_observability_sdk.telemetry import setup_telemetry
 
 logger = logging.getLogger(__name__)
 

--- a/arthur-observability-sdk/python/src/arthur_observability_sdk/arthur.py
+++ b/arthur-observability-sdk/python/src/arthur_observability_sdk/arthur.py
@@ -4,14 +4,13 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
+from arthur_observability_sdk._client import ArthurAPIClient
+from arthur_observability_sdk.telemetry import setup_telemetry
 from openinference.instrumentation import using_attributes, using_session, using_user
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 from opentelemetry import trace
 from opentelemetry.context import get_value
 from opentelemetry.sdk.trace import TracerProvider
-
-from arthur_observability_sdk._client import ArthurAPIClient
-from arthur_observability_sdk.telemetry import setup_telemetry
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +56,11 @@ class Arthur:
             base_url or os.environ.get("ARTHUR_BASE_URL") or "http://localhost:3030"
         ).rstrip("/")
         self._service_name: Optional[str] = service_name
-        self._resource_attributes: Dict[str, Any] = resource_attributes or {}
+        # Caller-supplied OTel resource attrs; `arthur.task` defaults from `task_id` unless set.
+        _attrs: Dict[str, Any] = dict(resource_attributes) if resource_attributes else {}
+        if task_id:
+            _attrs.setdefault("arthur.task", task_id)
+        self._resource_attributes = _attrs
         self._task_id: Optional[str] = task_id
         self._task_name: Optional[str] = task_name
         self._enable_telemetry: bool = enable_telemetry
@@ -66,7 +69,7 @@ class Arthur:
         if task_id is None and task_name is None and service_name is None:
             raise ValueError(
                 "Arthur requires at least one of: task_id, task_name, or service_name. "
-                "Provide a task context for prompt fetching or a service_name for telemetry."
+                "Provide a task context for prompt fetching or a service_name for telemetry.",
             )
 
         self._tracer_provider: Optional[TracerProvider] = None
@@ -119,7 +122,7 @@ class Arthur:
             self._resolved_task_id = self._api_client.resolve_task_id(self._task_name)
             return self._resolved_task_id
         raise ValueError(
-            "No task_id available. Provide task_id or task_name when initialising Arthur."
+            "No task_id available. Provide task_id or task_name when initialising Arthur.",
         )
 
     def _apply_openinference_context(self, span: Any) -> None:
@@ -148,7 +151,7 @@ class Arthur:
         except ImportError:
             raise ImportError(
                 f"Missing optional dependency '{package}'. "
-                f"Install it with: pip install arthur-observability-sdk[{extra_name}]"
+                f"Install it with: pip install arthur-observability-sdk[{extra_name}]",
             )
         try:
             instrumentor_cls = getattr(mod, class_name)
@@ -156,7 +159,7 @@ class Arthur:
             raise ImportError(
                 f"Module '{module_path}' does not export '{class_name}'. "
                 f"You may have an incompatible version of '{package}'. "
-                f"Try: pip install --upgrade arthur-observability-sdk[{extra_name}]"
+                f"Try: pip install --upgrade arthur-observability-sdk[{extra_name}]",
             )
         instrumentor = instrumentor_cls()
         kwargs: Dict[str, Any] = {}
@@ -208,11 +211,15 @@ class Arthur:
             try:
                 if tag:
                     prompt_data = self._api_client.get_prompt_by_tag(
-                        task_id=resolved_task_id, name=name, tag=tag
+                        task_id=resolved_task_id,
+                        name=name,
+                        tag=tag,
                     )
                 else:
                     prompt_data = self._api_client.get_prompt_by_version(
-                        task_id=resolved_task_id, name=name, version=version
+                        task_id=resolved_task_id,
+                        name=name,
+                        version=version,
                     )
             except Exception as exc:
                 span.record_exception(exc)
@@ -283,11 +290,15 @@ class Arthur:
                 # not the already-substituted result.
                 if tag:
                     template_data = self._api_client.get_prompt_by_tag(
-                        task_id=resolved_task_id, name=name, tag=tag
+                        task_id=resolved_task_id,
+                        name=name,
+                        tag=tag,
                     )
                 else:
                     template_data = self._api_client.get_prompt_by_version(
-                        task_id=resolved_task_id, name=name, version=version
+                        task_id=resolved_task_id,
+                        name=name,
+                        version=version,
                     )
 
                 prompt_data = self._api_client.render_prompt(

--- a/arthur-observability-sdk/python/tests/test_client.py
+++ b/arthur-observability-sdk/python/tests/test_client.py
@@ -2,8 +2,9 @@
 
 from unittest.mock import MagicMock
 
-import arthur_genai_client.models as _genai_models
 import pytest
+
+import arthur_genai_client.models as _genai_models
 from arthur_observability_sdk._client import ArthurAPIClient
 from arthur_observability_sdk.arthur import Arthur
 

--- a/arthur-observability-sdk/python/tests/test_client.py
+++ b/arthur-observability-sdk/python/tests/test_client.py
@@ -2,9 +2,8 @@
 
 from unittest.mock import MagicMock
 
-import pytest
-
 import arthur_genai_client.models as _genai_models
+import pytest
 from arthur_observability_sdk._client import ArthurAPIClient
 from arthur_observability_sdk.arthur import Arthur
 
@@ -55,6 +54,51 @@ def test_arthur_requires_task_or_service_name():
 def test_arthur_accepts_task_id_only():
     arthur = Arthur(task_id="uuid-1234", api_key="test-key", enable_telemetry=False)
     assert arthur._task_id == "uuid-1234"
+    arthur.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# arthur.task resource attribute auto-injection
+# ---------------------------------------------------------------------------
+
+
+def test_task_id_auto_added_to_resource_attributes():
+    """task_id is automatically included as 'arthur.task' in resource_attributes."""
+    arthur = Arthur(task_id="uuid-1234", api_key="test-key", enable_telemetry=False)
+    assert arthur._resource_attributes["arthur.task"] == "uuid-1234"
+    arthur.shutdown()
+
+
+def test_task_id_not_added_when_arthur_task_already_present():
+    """Explicit 'arthur.task' in resource_attributes is not overwritten by task_id."""
+    arthur = Arthur(
+        task_id="uuid-1234",
+        api_key="test-key",
+        enable_telemetry=False,
+        resource_attributes={"arthur.task": "explicit-task-id"},
+    )
+    assert arthur._resource_attributes["arthur.task"] == "explicit-task-id"
+    arthur.shutdown()
+
+
+def test_task_id_not_added_to_resource_attributes_when_absent():
+    """When no task_id is given, 'arthur.task' is not added to resource_attributes."""
+    arthur = Arthur(service_name="my-service", api_key="test-key", enable_telemetry=False)
+    assert "arthur.task" not in arthur._resource_attributes
+    arthur.shutdown()
+
+
+def test_existing_resource_attributes_preserved_with_task_id():
+    """Custom resource_attributes are preserved alongside the injected 'arthur.task'."""
+    arthur = Arthur(
+        task_id="uuid-1234",
+        api_key="test-key",
+        enable_telemetry=False,
+        resource_attributes={"deployment.environment": "staging", "team": "ml"},
+    )
+    assert arthur._resource_attributes["arthur.task"] == "uuid-1234"
+    assert arthur._resource_attributes["deployment.environment"] == "staging"
+    assert arthur._resource_attributes["team"] == "ml"
     arthur.shutdown()
 
 
@@ -176,7 +220,8 @@ def _make_api_client() -> ArthurAPIClient:
 def test_resolve_task_id_found_on_first_page():
     client = _make_api_client()
     client._tasks_api.search_tasks_api_v2_tasks_search_post.return_value = _make_search_result(
-        [_make_task("my-task", "uuid-1")], count=1
+        [_make_task("my-task", "uuid-1")],
+        count=1,
     )
     assert client.resolve_task_id("my-task") == "uuid-1"
     client._tasks_api.search_tasks_api_v2_tasks_search_post.assert_called_once()
@@ -199,7 +244,8 @@ def test_resolve_task_id_skips_substring_matches_on_first_page():
 def test_resolve_task_id_raises_when_not_found():
     client = _make_api_client()
     client._tasks_api.search_tasks_api_v2_tasks_search_post.return_value = _make_search_result(
-        [_make_task("my-task-v2", "uuid-1")], count=1
+        [_make_task("my-task-v2", "uuid-1")],
+        count=1,
     )
     with pytest.raises(ValueError, match="No task with an exact name match"):
         client.resolve_task_id("my-task")
@@ -208,7 +254,8 @@ def test_resolve_task_id_raises_when_not_found():
 def test_resolve_task_id_raises_includes_substring_count():
     client = _make_api_client()
     client._tasks_api.search_tasks_api_v2_tasks_search_post.return_value = _make_search_result(
-        [_make_task("my-task-v2", "uuid-1")], count=3
+        [_make_task("my-task-v2", "uuid-1")],
+        count=3,
     )
     with pytest.raises(ValueError, match="3 task"):
         client.resolve_task_id("my-task")

--- a/arthur-observability-sdk/python/uv.lock
+++ b/arthur-observability-sdk/python/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-04-10T15:23:41.523006Z"
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "aiofiles"
 version = "24.1.0"
@@ -156,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "arthur-observability-sdk"
-version = "2.1.501"
+version = "2.1.511"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Arthur.__init__ accepts task_id but never adds it to OTel resource attributes — it only uses task_id for prompt fetch API calls.