### PR TITLE
[no-ref] support user_id filtering by substring instead of exact match

### DIFF
--- a/genai-engine/src/routers/v1/legacy_span_routes.py
+++ b/genai-engine/src/routers/v1/legacy_span_routes.py
@@ -170,7 +170,7 @@ def trace_query_parameters(
     ),
     user_ids: list[str] = Query(
         None,
-        description="User IDs to filter on. Optional.",
+        description="User ID substrings to filter on (case-insensitive). Returns results where user_id contains any of the provided values. Optional.",
     ),
     span_name: str = Query(
         None,

--- a/genai-engine/src/schemas/internal_schemas.py
+++ b/genai-engine/src/schemas/internal_schemas.py
@@ -2375,7 +2375,7 @@ class TraceQuerySchema(BaseModel):
     span_count_filters: Optional[list[FloatRangeFilter]] = None
     user_ids: Optional[list[str]] = Field(
         None,
-        description="User IDs to filter on. Optional.",
+        description="User ID substrings to filter on (case-insensitive). Returns results where user_id contains any of the provided values. Optional.",
     )
     annotation_score: Optional[int] = Field(
         None,

--- a/genai-engine/src/services/trace/span_query_service.py
+++ b/genai-engine/src/services/trace/span_query_service.py
@@ -81,6 +81,11 @@ class SpanQueryService:
     SpanQueryService with single-query strategy. This implements the proposed optimizations for comparison.
     """
 
+    @staticmethod
+    def _escape_like(value: str) -> str:
+        """Escape special SQL LIKE/ILIKE wildcard characters in user input."""
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
     def __init__(self, db_session: Session):
         self.db_session = db_session
         self.filter_service = FilterService(db_session)
@@ -247,7 +252,10 @@ class SpanQueryService:
             conditions.append(
                 or_(
                     *[
-                        DatabaseTraceMetadata.user_id.ilike(f"%{uid}%")
+                        DatabaseTraceMetadata.user_id.ilike(
+                            f"%{self._escape_like(uid)}%",
+                            escape="\\",
+                        )
                         for uid in filters.user_ids
                     ]
                 ),
@@ -808,7 +816,10 @@ class SpanQueryService:
             conditions.append(
                 or_(
                     *[
-                        DatabaseTraceMetadata.user_id.ilike(f"%{uid}%")
+                        DatabaseTraceMetadata.user_id.ilike(
+                            f"%{self._escape_like(uid)}%",
+                            escape="\\",
+                        )
                         for uid in filters.user_ids
                     ]
                 ),
@@ -1172,7 +1183,10 @@ class SpanQueryService:
             query = query.where(
                 or_(
                     *[
-                        DatabaseTraceMetadata.user_id.ilike(f"%{uid}%")
+                        DatabaseTraceMetadata.user_id.ilike(
+                            f"%{self._escape_like(uid)}%",
+                            escape="\\",
+                        )
                         for uid in user_ids
                     ]
                 ),

--- a/genai-engine/src/services/trace/span_query_service.py
+++ b/genai-engine/src/services/trace/span_query_service.py
@@ -244,7 +244,14 @@ class SpanQueryService:
         if filters.end_time:
             conditions.append(DatabaseTraceMetadata.end_time <= filters.end_time)
         if filters.user_ids:
-            conditions.append(DatabaseTraceMetadata.user_id.in_(filters.user_ids))
+            conditions.append(
+                or_(
+                    *[
+                        DatabaseTraceMetadata.user_id.ilike(f"%{uid}%")
+                        for uid in filters.user_ids
+                    ]
+                ),
+            )
         if filters.session_ids:
             conditions.append(DatabaseTraceMetadata.session_id.in_(filters.session_ids))
         if not filters.include_experiment_traces:
@@ -798,7 +805,14 @@ class SpanQueryService:
         if filters.end_time:
             conditions.append(DatabaseTraceMetadata.end_time <= filters.end_time)
         if filters.user_ids:
-            conditions.append(DatabaseTraceMetadata.user_id.in_(filters.user_ids))
+            conditions.append(
+                or_(
+                    *[
+                        DatabaseTraceMetadata.user_id.ilike(f"%{uid}%")
+                        for uid in filters.user_ids
+                    ]
+                ),
+            )
         if filters.session_ids:
             conditions.append(DatabaseTraceMetadata.session_id.in_(filters.session_ids))
 
@@ -1153,9 +1167,16 @@ class SpanQueryService:
                 ),
             )
 
-        # Apply user filtering
+        # Apply user filtering (case-insensitive substring match)
         if user_ids:
-            query = query.where(DatabaseTraceMetadata.user_id.in_(user_ids))
+            query = query.where(
+                or_(
+                    *[
+                        DatabaseTraceMetadata.user_id.ilike(f"%{uid}%")
+                        for uid in user_ids
+                    ]
+                ),
+            )
 
         # Group by session_id, task_id, and user_id to ensure proper session boundaries
         query = query.group_by(

--- a/genai-engine/src/utils/model_load.py
+++ b/genai-engine/src/utils/model_load.py
@@ -292,7 +292,9 @@ def get_claim_classifier_embedding_model() -> SentenceTransformer | None:
     global CLAIM_CLASSIFIER_EMBEDDING_MODEL
     if not CLAIM_CLASSIFIER_EMBEDDING_MODEL:
         model_path = get_local_model_path("sentence-transformers/all-MiniLM-L12-v2")
-        CLAIM_CLASSIFIER_EMBEDDING_MODEL = SentenceTransformer(model_path)
+        CLAIM_CLASSIFIER_EMBEDDING_MODEL = SentenceTransformer(
+            model_path, device=get_device()
+        )
     return CLAIM_CLASSIFIER_EMBEDDING_MODEL
 
 

--- a/genai-engine/tests/routes/trace_api/test_session_endpoints.py
+++ b/genai-engine/tests/routes/trace_api/test_session_endpoints.py
@@ -122,7 +122,7 @@ def test_list_sessions_metadata_filtering_by_user_ids(
     client: GenaiEngineTestClientBase,
     comprehensive_test_data,
 ):
-    """Test filtering sessions by user IDs."""
+    """Test filtering sessions by user IDs with substring matching."""
 
     # Filter sessions by user1
     status_code, data = client.trace_api_list_sessions_metadata(
@@ -151,6 +151,25 @@ def test_list_sessions_metadata_filtering_by_user_ids(
     # Verify we have sessions from both users
     user_ids = {session.user_id for session in data.sessions}
     assert user_ids == {"user1", "user2"}
+
+    # Substring match: "user" matches both "user1" and "user2"
+    status_code, data = client.trace_api_list_sessions_metadata(
+        task_ids=["api_task1", "api_task2"],
+        user_ids=["user"],
+    )
+    assert status_code == 200
+    assert data.count == 2
+    matched_user_ids = {session.user_id for session in data.sessions}
+    assert matched_user_ids == {"user1", "user2"}
+
+    # Case-insensitive match: "USER1" should match "user1"
+    status_code, data = client.trace_api_list_sessions_metadata(
+        task_ids=["api_task1"],
+        user_ids=["USER1"],
+    )
+    assert status_code == 200
+    assert data.count == 1
+    assert data.sessions[0].user_id == "user1"
 
     # Filter by non-existent user
     status_code, data = client.trace_api_list_sessions_metadata(

--- a/genai-engine/tests/routes/trace_api/test_trace_endpoints.py
+++ b/genai-engine/tests/routes/trace_api/test_trace_endpoints.py
@@ -182,9 +182,9 @@ def test_list_traces_metadata_filtering_by_user_ids(
     client: GenaiEngineTestClientBase,
     comprehensive_test_data,
 ):
-    """Test filtering traces by user IDs."""
+    """Test filtering traces by user IDs with substring matching."""
 
-    # Filter traces by user1
+    # Exact user_id still works as a substring match
     status_code, data = client.trace_api_list_traces_metadata(
         task_ids=["api_task1"],
         user_ids=["user1"],
@@ -210,6 +210,27 @@ def test_list_traces_metadata_filtering_by_user_ids(
     # Verify we have traces from both users
     user_ids = {trace.user_id for trace in data.traces}
     assert user_ids == {"user1", "user2"}
+
+    # Substring match: "user" is a substring of both "user1" and "user2"
+    status_code, data = client.trace_api_list_traces_metadata(
+        task_ids=["api_task1", "api_task2"],
+        user_ids=["user"],
+    )
+    assert status_code == 200
+    assert data.count == 4  # matches both user1 (3 traces) and user2 (1 trace)
+    assert len(data.traces) == 4
+    matched_user_ids = {trace.user_id for trace in data.traces}
+    assert matched_user_ids == {"user1", "user2"}
+
+    # Case-insensitive match: "USER1" should match "user1"
+    status_code, data = client.trace_api_list_traces_metadata(
+        task_ids=["api_task1"],
+        user_ids=["USER1"],
+    )
+    assert status_code == 200
+    assert data.count == 3
+    for trace in data.traces:
+        assert trace.user_id == "user1"
 
     # Filter by non-existent user
     status_code, data = client.trace_api_list_traces_metadata(

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-07T18:15:17.270513899Z"
+exclude-newer = "2026-04-11T18:47:09.072586Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "arthur-genai-engine"
-version = "2.1.508"
+version = "2.1.518"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Also, fixes an issue running the service locally on m5 Macs with the MPS device being used to run the SentenceTransformer