### PR TITLE
[no-ref] fix eval pagination

### DIFF
--- a/genai-engine/src/repositories/continuous_evals_repository.py
+++ b/genai-engine/src/repositories/continuous_evals_repository.py
@@ -242,7 +242,7 @@ class ContinuousEvalsRepository:
         task_id: str,
         pagination_parameters: Optional[PaginationParameters] = None,
         filter_request: Optional[ContinuousEvalListFilterRequest] = None,
-    ) -> List[ContinuousEval]:
+    ) -> tuple[List[ContinuousEval], int]:
         base_query = self.db_session.query(DatabaseContinuousEval).filter(
             DatabaseContinuousEval.task_id == task_id,
         )
@@ -294,6 +294,8 @@ class ContinuousEvalsRepository:
                     DatabaseContinuousEval.id.in_(filter_request.continuous_eval_ids),
                 )
 
+        total_count = base_query.count()
+
         if pagination_parameters:
             base_query = self._apply_sorting_and_pagination(
                 base_query,
@@ -306,14 +308,14 @@ class ContinuousEvalsRepository:
         return [
             ContinuousEval.from_db_model(db_continuous_eval)
             for db_continuous_eval in db_continuous_evals
-        ]
+        ], total_count
 
     def list_continuous_eval_run_results(
         self,
         task_id: str,
         pagination_parameters: Optional[PaginationParameters] = None,
         filter_request: Optional[ContinuousEvalRunResultsListFilterRequest] = None,
-    ) -> List[AgenticAnnotation]:
+    ) -> tuple[List[AgenticAnnotation], int]:
         base_query = (
             self.db_session.query(DatabaseAgenticAnnotation)
             .join(
@@ -384,6 +386,8 @@ class ContinuousEvalsRepository:
                     == filter_request.continuous_eval_enabled,
                 )
 
+        total_count = base_query.count()
+
         if pagination_parameters:
             base_query = self._apply_sorting_and_pagination(
                 base_query,
@@ -396,7 +400,7 @@ class ContinuousEvalsRepository:
         return [
             AgenticAnnotation.from_db_model(db_agentic_annotation)
             for db_agentic_annotation in db_agentic_annotations
-        ]
+        ], total_count
 
     def delete_continuous_eval(
         self,

--- a/genai-engine/src/routers/v1/continuous_eval_routes.py
+++ b/genai-engine/src/routers/v1/continuous_eval_routes.py
@@ -104,7 +104,7 @@ def list_continuous_evals(
 ) -> ListContinuousEvalsResponse:
     try:
         continuous_eval_repo = ContinuousEvalsRepository(db_session)
-        continuous_evals = continuous_eval_repo.list_continuous_evals(
+        continuous_evals, total_count = continuous_eval_repo.list_continuous_evals(
             task.id,
             pagination_parameters,
             filter_request,
@@ -114,7 +114,7 @@ def list_continuous_evals(
                 continuous_eval.to_response_model()
                 for continuous_eval in continuous_evals
             ],
-            count=len(continuous_evals),
+            count=total_count,
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -144,7 +144,7 @@ def list_continuous_eval_run_results(
 ) -> ListAgenticAnnotationsResponse:
     try:
         continuous_eval_repo = ContinuousEvalsRepository(db_session)
-        agentic_annotations = continuous_eval_repo.list_continuous_eval_run_results(
+        agentic_annotations, total_count = continuous_eval_repo.list_continuous_eval_run_results(
             task.id,
             pagination_parameters,
             filter_request,
@@ -153,7 +153,7 @@ def list_continuous_eval_run_results(
             annotations=[
                 annotation.to_response_model() for annotation in agentic_annotations
             ],
-            count=len(agentic_annotations),
+            count=total_count,
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/genai-engine/src/routers/v1/continuous_eval_routes.py
+++ b/genai-engine/src/routers/v1/continuous_eval_routes.py
@@ -144,10 +144,12 @@ def list_continuous_eval_run_results(
 ) -> ListAgenticAnnotationsResponse:
     try:
         continuous_eval_repo = ContinuousEvalsRepository(db_session)
-        agentic_annotations, total_count = continuous_eval_repo.list_continuous_eval_run_results(
-            task.id,
-            pagination_parameters,
-            filter_request,
+        agentic_annotations, total_count = (
+            continuous_eval_repo.list_continuous_eval_run_results(
+                task.id,
+                pagination_parameters,
+                filter_request,
+            )
         )
         return ListAgenticAnnotationsResponse(
             annotations=[

--- a/genai-engine/tests/unit/routes/tasks/test_continuous_eval_crud_routes.py
+++ b/genai-engine/tests/unit/routes/tasks/test_continuous_eval_crud_routes.py
@@ -870,7 +870,7 @@ def test_list_continuous_evals_pagination(client: GenaiEngineTestClientBase):
         )
         assert status_code == 200
         assert len(received_continuous_evals.evals) == len(transforms) // 2
-        assert received_continuous_evals.count == len(transforms) // 2
+        assert received_continuous_evals.count == len(transforms)
         for i in range(len(received_continuous_evals.evals) // 2):
             assert received_continuous_evals.evals[i].id == continuous_evals[i].id
             assert (
@@ -901,7 +901,7 @@ def test_list_continuous_evals_pagination(client: GenaiEngineTestClientBase):
         )
         assert status_code == 200
         assert len(received_continuous_evals.evals) == 0
-        assert received_continuous_evals.count == 0
+        assert received_continuous_evals.count == len(transforms)
     finally:
         client.delete_task(agentic_task.id)
 
@@ -1370,7 +1370,7 @@ def test_list_continuous_eval_run_results_pagination(client: GenaiEngineTestClie
             len(received_run_results.annotations)
             == len(continuous_eval_annotations) // 2
         )
-        assert received_run_results.count == len(continuous_eval_annotations) // 2
+        assert received_run_results.count == len(continuous_eval_annotations)
         for i in range(len(received_run_results.annotations) // 2):
             assert received_run_results.annotations[i].id == str(
                 continuous_eval_annotations[i].id,
@@ -1397,7 +1397,7 @@ def test_list_continuous_eval_run_results_pagination(client: GenaiEngineTestClie
         )
         assert status_code == 200
         assert len(received_run_results.annotations) == 0
-        assert received_run_results.count == 0
+        assert received_run_results.count == len(continuous_eval_annotations)
     finally:
         client.delete_transform(transform.id)
         client.delete_llm_eval(task_id, llm_eval.name)

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-11T18:47:09.072586Z"
+exclude-newer = "2026-04-12T00:26:42.935559Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "arthur-genai-engine"
-version = "2.1.518"
+version = "2.1.519"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
**Root cause**: Both `list_continuous_evals` and `list_continuous_eval_run_results` in `ContinuousEvalsRepository` returned only the paginated results. The route handlers then used `count=len(results)` — which is the page size, not the total. The frontend's Material React Table uses `rowCount` (from the `count` field) to determine total pages, so it always thought there was only one page.

**Changes made:**

1. **`src/repositories/continuous_evals_repository.py`** — Both methods now call `base_query.count()` *before* applying pagination, and return `tuple[List[...], int]` instead of just `List[...]`.

2. **`src/routers/v1/continuous_eval_routes.py`** — Both route handlers unpack the tuple and pass `total_count` as the `count` field in the response.

3. **`tests/.../test_continuous_eval_crud_routes.py`** — Fixed 4 test assertions that were asserting the buggy behavior (count == page size) to assert the correct behavior (count == total matching records regardless of pagination).