### PR TITLE
Automate release PR creation and main→dev sync (#release-process)

### DIFF
--- a/.github/workflows/arthur-observability-sdk-release.yml
+++ b/.github/workflows/arthur-observability-sdk-release.yml
@@ -22,7 +22,7 @@ jobs:
   generate-client:
     if: |
       (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') &&
-      startsWith(github.event.head_commit.message, 'Increment arthur-engine version to')
+      startsWith(github.event.head_commit.message, 'Increment arthur-engine version')
     runs-on: ubuntu-latest
     env:
       GIT_DEPTH: 100
@@ -115,7 +115,7 @@ jobs:
   # ── create git tag (stable releases only) ─────────────────────────────────
   create-git-tag:
     needs: publish-pypi
-    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'Increment arthur-engine version to')
+    if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'Increment arthur-engine version')
     runs-on: ubuntu-latest
     environment: shared-protected-branch-secrets
     steps:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,55 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-release-pr:
+    environment: shared-protected-branch-secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Arthur GitHub Automator App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ARTHUR_GH_AUTOMATOR_APP_ID }}
+          private-key: ${{ secrets.ARTHUR_GH_AUTOMATOR_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Check versions and create PR
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -e
+
+          git fetch origin dev main
+
+          DEV_VERSION=$(git show origin/dev:version)
+          MAIN_VERSION=$(git show origin/main:version)
+
+          echo "Dev version:  ${DEV_VERSION}"
+          echo "Main version: ${MAIN_VERSION}"
+
+          if [ "$DEV_VERSION" = "$MAIN_VERSION" ]; then
+            echo "Error: dev and main are already at the same version (${DEV_VERSION}). Nothing to release."
+            exit 1
+          fi
+
+          EXISTING_PR=$(gh pr list --base main --head dev --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Error: a dev→main PR already exists: #${EXISTING_PR}"
+            echo "$(gh pr view $EXISTING_PR --json url --jq '.url')"
+            exit 1
+          fi
+
+          gh pr create \
+            --base main \
+            --head dev \
+            --title "Increment arthur-engine version" \
+            --body "Production release PR. Dev is at \`${DEV_VERSION}\`, main is at \`${MAIN_VERSION}\`.
+
+Merging this PR will trigger the production build and deployment pipeline."

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -46,10 +46,10 @@ jobs:
             exit 1
           fi
 
+          BODY="Production release PR. Merging this PR will trigger the production build and deployment pipeline."
+
           gh pr create \
             --base main \
             --head dev \
             --title "Increment arthur-engine version" \
-            --body "Production release PR. Dev is at \`${DEV_VERSION}\`, main is at \`${MAIN_VERSION}\`.
-
-Merging this PR will trigger the production build and deployment pipeline."
+            --body "$BODY"

--- a/.github/workflows/version-workflow.yml
+++ b/.github/workflows/version-workflow.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Sync main into dev
         run: |
           git fetch origin main
-          git merge origin/main -X ours --no-edit
+          git merge origin/main --no-edit
       - name: Bump Arthur Engine Version
         env:
           ARTHUR_ENGINE_CFT_CPU_HTML_PATH: "deployment/cloudformation/start-cpu-stack.html"

--- a/.github/workflows/version-workflow.yml
+++ b/.github/workflows/version-workflow.yml
@@ -47,6 +47,10 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - uses: ./.github/workflows/composite-actions/setup-git
+      - name: Sync main into dev
+        run: |
+          git fetch origin main
+          git merge origin/main -X ours --no-edit
       - name: Bump Arthur Engine Version
         env:
           ARTHUR_ENGINE_CFT_CPU_HTML_PATH: "deployment/cloudformation/start-cpu-stack.html"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,34 @@
+# Releasing to Production
+
+## 1. Merge your feature branch to `dev`
+
+Open a PR from your feature branch into `dev` and merge it.
+
+## 2. Wait for the Version Management workflow
+
+After the merge lands, the [Version Management](https://github.com/arthur-ai/arthur-engine/actions/workflows/version-workflow.yml) workflow runs automatically. It syncs any divergence from `main` and commits a version bump (`"Increment arthur-engine version to X.Y.Z"`) directly to `dev`. This also triggers a dev build (Docker images, Helm charts, etc.). After the dev resources are created, it will trigger a workflow in the arthur-scope GitLab repository to release the engine to the sts-arthur-dev account.
+
+## 3. Create the release PR
+
+Once the version bump has landed on `dev`, trigger the [Create Release PR](https://github.com/arthur-ai/arthur-engine/actions/workflows/create-release-pr.yml) workflow via **Run workflow**.
+
+This creates a PR from `dev` → `main` with the correct title to trigger the production pipeline. Review and merge it — all production artifacts are built and published automatically when it lands on `main`.
+
+## What gets published and from where
+
+All production publishing is triggered by the version bump commit landing on `main`. Two workflows fire in parallel:
+
+**[Arthur Engine CI](https://github.com/arthur-ai/arthur-engine/actions/workflows/arthur-engine-workflow.yml)**
+- GenAI Engine Docker images (CPU + GPU) → Docker Hub
+- ML Engine Docker images → Docker Hub + Artifactory
+- Models Docker images → Docker Hub
+- CloudFormation templates → S3
+- Helm charts → GHCR + Docker Hub
+- Git tag for the release
+- Triggers the GitLab deployment pipeline
+
+**[Arthur Observability SDK Release](https://github.com/arthur-ai/arthur-engine/actions/workflows/arthur-observability-sdk-release.yml)**
+- Python observability SDK → PyPI (stable release)
+- SDK git tag (`sdk-vX.Y.Z`)
+
+No extra release steps are needed for the SDK — it picks up the same trigger automatically.


### PR DESCRIPTION
- Add create-release-pr.yml: workflow_dispatch to create dev→main PR with the correct trigger title; guards against same-version and duplicate PRs
- Add sync step to version-workflow.yml: merges origin/main before each version bump so dev stays in sync after production squash merges