### PR TITLE
RFC 7230 - a server MUST NOT send Transfer-Encoding in 1xx or 204 response

### DIFF
--- a/genai-engine/src/server.py
+++ b/genai-engine/src/server.py
@@ -284,6 +284,10 @@ class TransferEncodingMiddleware(BaseHTTPMiddleware):
         call_next: RequestResponseEndpoint,
     ) -> Response:
         response = await call_next(request)
+        # RFC 7230 §3.3.1 / RFC 9112 §6.1: must not send Transfer-Encoding
+        # in 1xx or 204 responses
+        if 100 <= response.status_code < 200 or response.status_code == 204:
+            return response
         response.headers["Transfer-Encoding"] = "chunked"
         if "content-length" in response.headers:
             del response.headers["content-length"]

--- a/genai-engine/tests/unit/routes/test_transfer_encoding_middleware.py
+++ b/genai-engine/tests/unit/routes/test_transfer_encoding_middleware.py
@@ -1,15 +1,29 @@
 from unittest.mock import patch
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from server import get_test_app
+from server import TransferEncodingMiddleware, get_test_app
 from tests.clients.base_test_client import app
+
+_minimal_app = FastAPI()
+_minimal_app.add_middleware(TransferEncodingMiddleware)
+
+
+@_minimal_app.delete("/resource", status_code=204)
+async def delete_resource() -> None:
+    return None
 
 
 @pytest.fixture(scope="module")
 def test_client() -> TestClient:
     return TestClient(app)
+
+
+@pytest.fixture(scope="module")
+def minimal_client() -> TestClient:
+    return TestClient(_minimal_app)
 
 
 @pytest.mark.unit_tests
@@ -26,6 +40,13 @@ def test_transfer_encoding_middleware_on_error_response(test_client: TestClient)
     assert resp.status_code in (401, 403)
     assert resp.headers.get("transfer-encoding") == "chunked"
     assert "content-length" not in resp.headers
+
+
+@pytest.mark.unit_tests
+def test_transfer_encoding_middleware_skipped_on_204(minimal_client: TestClient):
+    resp = minimal_client.delete("/resource")
+    assert resp.status_code == 204
+    assert "transfer-encoding" not in resp.headers
 
 
 @pytest.mark.unit_tests

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-14T04:08:43.972748Z"
+exclude-newer = "2026-04-14T14:03:06.638339Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -158,7 +158,7 @@ wheels = [
 
 [[package]]
 name = "arthur-genai-engine"
-version = "2.1.525"
+version = "2.1.526"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Per RFC 7230
 §3.3.1 / RFC 9112 §6.1 (verified against the actual RFC text), a server MUST NOT send Transfer-Encoding in:
 - 1xx (informational) responses
 - 204 No Content responses