### PR TITLE
add engine audit logging to cloudwatch

### DIFF
--- a/deployment/cloudformation/genai-engine/arthur-genai-engine-ecs-task-definition.yml
+++ b/deployment/cloudformation/genai-engine/arthur-genai-engine-ecs-task-definition.yml
@@ -195,6 +195,21 @@ Parameters:
     Type: String
     Description: '(Optional) URL for internal model repository (S3 bucket). When set, GenAI Engine will download models from this location instead of the internet.'
     Default: ''
+  AuditLogRetentionPeriod:
+    Type: Number
+    Description: 'Number of days to retain audit logs in CloudWatch'
+    Default: "365"
+  AuditLogEnabled:
+    Type: String
+    Description: 'Enable audit logging'
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  AuditLogOverridePath:
+    Type: String
+    Description: 'Override path for audit log directory'
+    Default: 'null'
 
 Conditions:
   EnableAuthService: !Equals [ !Ref GenaiEngineAPIOnlyModeEnabled, 'disabled' ]
@@ -203,6 +218,7 @@ Conditions:
   ImportAuthServiceCertificate: !Not [ !Equals [ !Ref AuthLoadBalancerCertificateURL, '' ] ]
   ImportGenaiEngineSecretOpenAIEmbeddingModelNamesEndpointsKeysARN: !Not [ !Equals [ !Ref GenaiEngineSecretOpenAIEmbeddingModelNamesEndpointsKeysARN, '' ] ]
   UseInternalModelRepository: !Not [ !Equals [ !Ref GenaiEngineModelRepositoryURL, '' ] ]
+  IsAuditLogEnabled: !Equals [ !Ref AuditLogEnabled, 'true' ]
 
 Resources:
   GenaiEngineECSLogGroup:
@@ -211,6 +227,15 @@ Resources:
     Properties:
       LogGroupName: !Sub "/arthur/ecs/${ArthurResourceNamespace}-genai-engine${ArthurResourceNameSuffix}"
       RetentionInDays: 365
+
+  GenaiEngineAuditLogECSLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: IsAuditLogEnabled
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      LogGroupName: !Sub "/arthur/ecs/${ArthurResourceNamespace}-genai-engine-audit-logs${ArthurResourceNameSuffix}"
+      RetentionInDays: !Ref AuditLogRetentionPeriod
 
   GenaiEngineECSTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
@@ -224,7 +249,17 @@ Resources:
       Memory: !Ref GenaiEngineFargateTaskMemoryValue
       TaskRoleArn: !Ref GenaiEngineECSTaskRoleARN
       ExecutionRoleArn: !Ref GenaiEngineECSTaskExecutionRoleARN
+      Volumes:
+        - Name: 'audit-logs'
       ContainerDefinitions:
+        - Name: 'init-audit-logs'
+          Image: 'public.ecr.aws/docker/library/busybox:latest'
+          Command: [ "sh", "-c", "chmod 777 /audit_logs" ]
+          Essential: false
+          MountPoints:
+            - SourceVolume: 'audit-logs'
+              ContainerPath: '/audit_logs'
+              ReadOnly: false
         - Name: 'arthur-genai-engine'
           Image: !Sub "${GenaiEngineContainerImageLocation}:${GenaiEngineVersion}"
           RepositoryCredentials: !If
@@ -232,6 +267,13 @@ Resources:
             - CredentialsParameter: !Ref ContainerRepositoryCredentialsSecretARN
             - !Ref AWS::NoValue
           Essential: true
+          DependsOn:
+            - ContainerName: 'init-audit-logs'
+              Condition: 'SUCCESS'
+          MountPoints:
+            - SourceVolume: 'audit-logs'
+              ContainerPath: '/home/nonroot/audit_logs'
+              ReadOnly: false
           PortMappings:
             - ContainerPort: 3030
               HostPort: 3030
@@ -327,6 +369,12 @@ Resources:
               - Name: 'MODEL_REPOSITORY_URL'
                 Value: !Ref GenaiEngineModelRepositoryURL
               - !Ref AWS::NoValue
+            - Name: 'AUDIT_LOG_ENABLED'
+              Value: !Ref AuditLogEnabled
+            - Name: 'AUDIT_LOG_OVERRIDE_PATH'
+              Value: !Ref AuditLogOverridePath
+            - Name: 'AUDIT_LOG_RETENTION_DAYS'
+              Value: !Ref AuditLogRetentionPeriod
           Secrets:
             - Name: 'GENAI_ENGINE_ADMIN_KEY'
               ValueFrom: !Ref GenaiEngineSecretAPIKeyARN
@@ -369,6 +417,23 @@ Resources:
             Timeout: 5
             Retries: 3
             StartPeriod: 300
+        - !If
+          - IsAuditLogEnabled
+          - Name: 'audit-log-forwarder'
+            Image: 'public.ecr.aws/docker/library/busybox:latest'
+            Command: [ "sh", "-c", "tail -F /audit_logs/audit.log" ]
+            Essential: true
+            MountPoints:
+              - SourceVolume: 'audit-logs'
+                ContainerPath: '/audit_logs'
+                ReadOnly: true
+            LogConfiguration:
+              LogDriver: 'awslogs'
+              Options:
+                awslogs-group: !Sub "/arthur/ecs/${ArthurResourceNamespace}-genai-engine-audit-logs${ArthurResourceNameSuffix}"
+                awslogs-region: !Sub "${AWS::Region}"
+                awslogs-stream-prefix: 'ecs'
+          - !Ref AWS::NoValue
 Outputs:
   GenaiEngineECSTaskDefinitionOutput:
     Description: 'The task definition for Arthur GenAI Engine'

--- a/deployment/cloudformation/genai-engine/arthur-genai-engine-ecs-task-definition.yml
+++ b/deployment/cloudformation/genai-engine/arthur-genai-engine-ecs-task-definition.yml
@@ -199,6 +199,7 @@ Parameters:
     Type: Number
     Description: 'Number of days to retain audit logs in CloudWatch'
     Default: "365"
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 365]
   AuditLogEnabled:
     Type: String
     Description: 'Enable audit logging'
@@ -209,7 +210,7 @@ Parameters:
   AuditLogOverridePath:
     Type: String
     Description: 'Override path for audit log directory'
-    Default: 'null'
+    Default: '/home/nonroot/audit_logs'
 
 Conditions:
   EnableAuthService: !Equals [ !Ref GenaiEngineAPIOnlyModeEnabled, 'disabled' ]
@@ -422,7 +423,10 @@ Resources:
           - Name: 'audit-log-forwarder'
             Image: 'public.ecr.aws/docker/library/busybox:latest'
             Command: [ "sh", "-c", "tail -F /audit_logs/audit.log" ]
-            Essential: true
+            Essential: false
+            DependsOn:
+              - ContainerName: 'init-audit-logs'
+                Condition: 'SUCCESS'
             MountPoints:
               - SourceVolume: 'audit-logs'
                 ContainerPath: '/audit_logs'

--- a/genai-engine/src/config/config.py
+++ b/genai-engine/src/config/config.py
@@ -75,7 +75,7 @@ class Config:
             none_on_missing=True,
         )
 
-        if override is not None and override.lower() != "null":
-            return str(override)
+        if override is not None and override.strip().lower() != "null":
+            return override.strip()
 
         return os.path.join(os.path.dirname(__file__), "..", "..", "audit_logs")

--- a/genai-engine/src/config/config.py
+++ b/genai-engine/src/config/config.py
@@ -75,7 +75,7 @@ class Config:
             none_on_missing=True,
         )
 
-        if override is not None and override.strip().lower() != "null":
+        if override and override.strip().lower() != "null":
             return override.strip()
 
         return os.path.join(os.path.dirname(__file__), "..", "..", "audit_logs")

--- a/genai-engine/src/config/config.py
+++ b/genai-engine/src/config/config.py
@@ -55,24 +55,27 @@ class Config:
     @classmethod
     def audit_log_enabled(cls) -> bool:
         audit_log_enabled = get_env_var(
-            constants.AUDIT_LOG_ENABLED_ENV_VAR, default="true"
+            constants.AUDIT_LOG_ENABLED_ENV_VAR,
+            default="true",
         )
         return audit_log_enabled.lower() == "true"
 
     @classmethod
     def audit_log_retention_days(cls) -> int:
         audit_log_retention_days = get_env_var(
-            constants.AUDIT_LOG_RETENTION_DAYS_ENV_VAR, default="365"
+            constants.AUDIT_LOG_RETENTION_DAYS_ENV_VAR,
+            default="365",
         )
         return int(audit_log_retention_days)
 
     @classmethod
     def audit_log_dir(cls) -> str:
         override = get_env_var(
-            constants.AUDIT_LOG_OVERRIDE_PATH_ENV_VAR, none_on_missing=True
+            constants.AUDIT_LOG_OVERRIDE_PATH_ENV_VAR,
+            none_on_missing=True,
         )
 
-        if override is not None:
+        if override is not None and override.lower() != "null":
             return str(override)
 
         return os.path.join(os.path.dirname(__file__), "..", "..", "audit_logs")

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-14T19:49:37.742291Z"
+exclude-newer = "2026-04-17T20:19:55.200988Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -159,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "arthur-genai-engine"
-version = "2.1.530"
+version = "2.1.534"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Description

Mimics the creation of the audit trail log group in cloudwatch that exists in scope for the genai-engine

## Jira Ticket

- https://arthurai.atlassian.net/browse/UP-4208