### PR TITLE
pass the AuditLogEnabled param to the substack

### DIFF
--- a/deployment/cloudformation/genai-engine/arthur-genai-engine-ecs-task-definition-gpu.yml
+++ b/deployment/cloudformation/genai-engine/arthur-genai-engine-ecs-task-definition-gpu.yml
@@ -199,6 +199,22 @@ Parameters:
     Type: String
     Description: '(Optional) URL for internal model repository (S3 bucket). When set, GenAI Engine will download models from this location instead of the internet.'
     Default: ''
+  AuditLogRetentionPeriod:
+    Type: Number
+    Description: 'Number of days to retain audit logs in CloudWatch'
+    Default: "365"
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 365]
+  AuditLogEnabled:
+    Type: String
+    Description: 'Enable audit logging'
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+  AuditLogOverridePath:
+    Type: String
+    Description: 'Override path for audit log directory'
+    Default: '/home/nonroot/audit_logs'
 
 Conditions:
   EnableAuthService: !Equals [ !Ref GenaiEngineAPIOnlyModeEnabled, 'disabled' ]
@@ -207,6 +223,7 @@ Conditions:
   ImportAuthServiceCertificate: !Not [ !Equals [ !Ref AuthLoadBalancerCertificateURL, '' ] ]
   ImportGenaiEngineSecretOpenAIEmbeddingModelNamesEndpointsKeysARN: !Not [ !Equals [ !Ref GenaiEngineSecretOpenAIEmbeddingModelNamesEndpointsKeysARN, '' ] ]
   UseInternalModelRepository: !Not [ !Equals [ !Ref GenaiEngineModelRepositoryURL, '' ] ]
+  IsAuditLogEnabled: !Equals [ !Ref AuditLogEnabled, 'true' ]
 
 Resources:
   GenaiEngineECSLogGroup:
@@ -215,6 +232,15 @@ Resources:
     Properties:
       LogGroupName: !Sub "/arthur/ecs/${ArthurResourceNamespace}-genai-engine-gpu${ArthurResourceNameSuffix}"
       RetentionInDays: 365
+
+  GenaiEngineAuditLogECSLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: IsAuditLogEnabled
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      LogGroupName: !Sub "/arthur/ecs/${ArthurResourceNamespace}-genai-engine-gpu-audit-logs${ArthurResourceNameSuffix}"
+      RetentionInDays: !Ref AuditLogRetentionPeriod
 
   GenaiEngineECSGPUTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
@@ -228,7 +254,17 @@ Resources:
       Memory: !Ref GenaiEngineEC2TaskMemoryValue
       TaskRoleArn: !Ref GenaiEngineECSTaskRoleARN
       ExecutionRoleArn: !Ref GenaiEngineECSTaskExecutionRoleARN
+      Volumes:
+        - Name: 'audit-logs'
       ContainerDefinitions:
+        - Name: 'init-audit-logs'
+          Image: 'public.ecr.aws/docker/library/busybox:latest'
+          Command: [ "sh", "-c", "chmod 777 /audit_logs" ]
+          Essential: false
+          MountPoints:
+            - SourceVolume: 'audit-logs'
+              ContainerPath: '/audit_logs'
+              ReadOnly: false
         - Name: 'arthur-genai-engine-gpu'
           Image: !Sub "${GenaiEngineContainerImageLocation}:${GenaiEngineVersion}"
           RepositoryCredentials: !If
@@ -236,6 +272,13 @@ Resources:
             - CredentialsParameter: !Ref ContainerRepositoryCredentialsSecretARN
             - !Ref AWS::NoValue
           Essential: true
+          DependsOn:
+            - ContainerName: 'init-audit-logs'
+              Condition: 'SUCCESS'
+          MountPoints:
+            - SourceVolume: 'audit-logs'
+              ContainerPath: '/home/nonroot/audit_logs'
+              ReadOnly: false
           PortMappings:
             - ContainerPort: 3030
               HostPort: 3030
@@ -337,6 +380,12 @@ Resources:
               - Name: 'MODEL_REPOSITORY_URL'
                 Value: !Ref GenaiEngineModelRepositoryURL
               - !Ref AWS::NoValue
+            - Name: 'AUDIT_LOG_ENABLED'
+              Value: !Ref AuditLogEnabled
+            - Name: 'AUDIT_LOG_OVERRIDE_PATH'
+              Value: !Ref AuditLogOverridePath
+            - Name: 'AUDIT_LOG_RETENTION_DAYS'
+              Value: !Ref AuditLogRetentionPeriod
           Secrets:
             - Name: 'GENAI_ENGINE_ADMIN_KEY'
               ValueFrom: !Ref GenaiEngineSecretAPIKeyARN
@@ -379,6 +428,26 @@ Resources:
             Timeout: 5
             Retries: 3
             StartPeriod: 300
+        - !If
+          - IsAuditLogEnabled
+          - Name: 'audit-log-forwarder'
+            Image: 'public.ecr.aws/docker/library/busybox:latest'
+            Command: [ "sh", "-c", "tail -F /audit_logs/audit.log" ]
+            Essential: false
+            DependsOn:
+              - ContainerName: 'init-audit-logs'
+                Condition: 'SUCCESS'
+            MountPoints:
+              - SourceVolume: 'audit-logs'
+                ContainerPath: '/audit_logs'
+                ReadOnly: true
+            LogConfiguration:
+              LogDriver: 'awslogs'
+              Options:
+                awslogs-group: !Sub "/arthur/ecs/${ArthurResourceNamespace}-genai-engine-gpu-audit-logs${ArthurResourceNameSuffix}"
+                awslogs-region: !Sub "${AWS::Region}"
+                awslogs-stream-prefix: 'ecs'
+          - !Ref AWS::NoValue
 Outputs:
   GenaiEngineECSGPUTaskDefinitionOutput:
     Description: 'The task definition for Arthur GenAI Engine with GPUs'

--- a/deployment/cloudformation/root-arthur-engine-cpu.yml
+++ b/deployment/cloudformation/root-arthur-engine-cpu.yml
@@ -354,6 +354,21 @@ Parameters:
     Type: Number
     Default: 1500
     Description: 'Max page size for fetching data from the GenAI Engine'
+  AuditLogEnabled:
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description: 'Enable audit logging'
+  AuditLogRetentionPeriod:
+    Type: Number
+    Default: 365
+    Description: 'Number of days to retain audit logs in CloudWatch'
+  AuditLogOverridePath:
+    Type: String
+    Default: '/home/nonroot/audit_logs'
+    Description: 'Override path for audit log directory'
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -814,6 +829,9 @@ Resources:
           - UseInternalModelRepository
           - !GetAtt [ GenaiEngineModelUploadStack, Outputs.GenaiEngineModelRepositoryURL ]
           - ''
+        AuditLogEnabled: !Ref AuditLogEnabled
+        AuditLogRetentionPeriod: !Ref AuditLogRetentionPeriod
+        AuditLogOverridePath: !Ref AuditLogOverridePath
       TemplateURL:  "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-ecs-task-definition.yml"
   MLEngineECSTaskDefinitionStack:
     Type: AWS::CloudFormation::Stack

--- a/deployment/cloudformation/root-arthur-engine-gpu.yml
+++ b/deployment/cloudformation/root-arthur-engine-gpu.yml
@@ -468,6 +468,21 @@ Parameters:
     Type: Number
     Default: 1500
     Description: 'Max page size for fetching data from the GenAI Engine'
+  AuditLogEnabled:
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description: 'Enable audit logging'
+  AuditLogRetentionPeriod:
+    Type: Number
+    Default: 365
+    Description: 'Number of days to retain audit logs in CloudWatch'
+  AuditLogOverridePath:
+    Type: String
+    Default: '/home/nonroot/audit_logs'
+    Description: 'Override path for audit log directory'
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -997,6 +1012,9 @@ Resources:
           - UseInternalModelRepository
           - !GetAtt [ GenaiEngineModelUploadStack, Outputs.GenaiEngineModelRepositoryURL ]
           - ''
+        AuditLogEnabled: !Ref AuditLogEnabled
+        AuditLogRetentionPeriod: !Ref AuditLogRetentionPeriod
+        AuditLogOverridePath: !Ref AuditLogOverridePath
       TemplateURL:  "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-ecs-task-definition-gpu.yml"
   MLEngineECSTaskDefinitionStack:
     Type: AWS::CloudFormation::Stack

--- a/deployment/cloudformation/root-arthur-genai-engine-cpu.yml
+++ b/deployment/cloudformation/root-arthur-genai-engine-cpu.yml
@@ -264,6 +264,13 @@ Parameters:
     Type: Number
     Default: 4096
     Description: 'Memory value for AWS Fargate for the Model Upload ECS task'
+  AuditLogEnabled:
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description: 'Enable audit logging'
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -619,6 +626,7 @@ Resources:
           - UseInternalModelRepository
           - !GetAtt [ GenaiEngineModelUploadStack, Outputs.GenaiEngineModelRepositoryURL ]
           - ''
+        AuditLogEnabled: !Ref AuditLogEnabled
       TemplateURL: !Sub "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-ecs-task-definition.yml"
   GenaiEngineLBStack:
     Type: AWS::CloudFormation::Stack

--- a/deployment/cloudformation/root-arthur-genai-engine-cpu.yml
+++ b/deployment/cloudformation/root-arthur-genai-engine-cpu.yml
@@ -271,6 +271,14 @@ Parameters:
       - 'false'
     Default: 'false'
     Description: 'Enable audit logging'
+  AuditLogRetentionPeriod:
+    Type: Number
+    Default: 365
+    Description: 'Number of days to retain audit logs in CloudWatch'
+  AuditLogOverridePath:
+    Type: String
+    Default: '/home/nonroot/audit_logs'
+    Description: 'Override path for audit log directory'
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -627,6 +635,8 @@ Resources:
           - !GetAtt [ GenaiEngineModelUploadStack, Outputs.GenaiEngineModelRepositoryURL ]
           - ''
         AuditLogEnabled: !Ref AuditLogEnabled
+        AuditLogRetentionPeriod: !Ref AuditLogRetentionPeriod
+        AuditLogOverridePath: !Ref AuditLogOverridePath
       TemplateURL: !Sub "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-ecs-task-definition.yml"
   GenaiEngineLBStack:
     Type: AWS::CloudFormation::Stack

--- a/deployment/cloudformation/root-arthur-genai-engine-gpu.yml
+++ b/deployment/cloudformation/root-arthur-genai-engine-gpu.yml
@@ -378,6 +378,21 @@ Parameters:
     Type: Number
     Default: 4096
     Description: 'Memory value for AWS Fargate for the Model Upload ECS task'
+  AuditLogEnabled:
+    Type: String
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
+    Description: 'Enable audit logging'
+  AuditLogRetentionPeriod:
+    Type: Number
+    Default: 365
+    Description: 'Number of days to retain audit logs in CloudWatch'
+  AuditLogOverridePath:
+    Type: String
+    Default: '/home/nonroot/audit_logs'
+    Description: 'Override path for audit log directory'
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -804,6 +819,9 @@ Resources:
           - UseInternalModelRepository
           - !GetAtt [ GenaiEngineModelUploadStack, Outputs.GenaiEngineModelRepositoryURL ]
           - ''
+        AuditLogEnabled: !Ref AuditLogEnabled
+        AuditLogRetentionPeriod: !Ref AuditLogRetentionPeriod
+        AuditLogOverridePath: !Ref AuditLogOverridePath
       TemplateURL: !Sub "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-ecs-task-definition-gpu.yml"
   GenaiEngineLBStack:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
## Description 

adds the AuditLogEnabled param to the arthur-genai-engine stack so we can pass the param down to the GenaiEngineECSTaskDefinitionStack through scope's dev-sts-platform/.gitlab-ci.yml