### PR TITLE
feat(multitenancy): scope API keys to organizations (UP-4423)

### DIFF
--- a/genai-engine/src/auth/multi_validator.py
+++ b/genai-engine/src/auth/multi_validator.py
@@ -55,6 +55,7 @@ class MultiMethodValidator:
                 db_session,
             ):
                 request.state.user_id = user.id
+                request.state.org_scope = user.org_scope
                 return user
         except Exception as e:
             logger.warning(
@@ -63,10 +64,12 @@ class MultiMethodValidator:
         finally:
             db_session.close()
 
-        # If API key validation fails, try oauth validation
+        # If API key validation fails, try oauth validation. JWT users are always
+        # cross-org admins in v1 — org_scope stays None.
         try:
             if jwk_client and (user := jwk_client.validate(token)):
                 request.state.user_id = user.id
+                request.state.org_scope = user.org_scope
                 return user
         except Exception as oauth_error:
             raise oauth_error

--- a/genai-engine/src/dependencies.py
+++ b/genai-engine/src/dependencies.py
@@ -14,7 +14,7 @@ from arthur_common.models.enums import MetricType, RuleType
 from authlib.integrations.starlette_client import OAuth
 from cachetools import TTLCache
 from dotenv import load_dotenv
-from fastapi import Depends, HTTPException, Query
+from fastapi import Depends, HTTPException, Query, Request
 from psycopg2 import OperationalError as Psycopg2OperationalError
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
@@ -326,6 +326,16 @@ def get_task_repository(
         MetricRepository(db_session),
         application_config,
     )
+
+
+def get_org_scope(request: Request) -> Optional[UUID]:
+    """Return the caller's org scope, or None for admins/JWT users.
+
+    Set by MultiMethodValidator from api_key.org_id. Used by handlers that need
+    to make admin-vs-tenant decisions (e.g., routing newly-created tasks to the
+    default org for admins and to the caller's org for tenants).
+    """
+    return getattr(request.state, "org_scope", None)
 
 
 def get_validated_task(

--- a/genai-engine/src/dependencies.py
+++ b/genai-engine/src/dependencies.py
@@ -329,11 +329,20 @@ def get_task_repository(
 
 
 def get_org_scope(request: Request) -> Optional[UUID]:
-    """Return the caller's org scope, or None for admins/JWT users.
+    """Return the caller's org scope when authenticated, else None.
 
-    Set by MultiMethodValidator from api_key.org_id. Used by handlers that need
-    to make admin-vs-tenant decisions (e.g., routing newly-created tasks to the
-    default org for admins and to the caller's org for tenants).
+    None has two meanings and callers must distinguish them by pairing this
+    dependency with the auth dependency:
+
+    1. Authenticated admin / JWT user (cross-org access). org_scope was
+       explicitly set to None by MultiMethodValidator from api_key.org_id.
+    2. Unauthenticated request. MultiMethodValidator never ran, so
+       request.state.org_scope was never set.
+
+    To distinguish case 2 from case 1, always combine this dependency with
+    `Depends(multi_validator.validate_api_multi_auth)` on the same handler.
+    Do NOT use this on a public route without an auth gate — None will be
+    indistinguishable from "admin" and may grant cross-org access.
     """
     return getattr(request.state, "org_scope", None)
 

--- a/genai-engine/src/repositories/api_key_repository.py
+++ b/genai-engine/src/repositories/api_key_repository.py
@@ -25,6 +25,7 @@ class ApiKeyRepository:
         self,
         description: Optional[str],
         roles: list[APIKeysRolesEnum],
+        org_id: Optional[uuid.UUID] = None,
     ) -> ApiKey:
         # Check the number of active keys
         active_keys_count = (
@@ -47,6 +48,7 @@ class ApiKeyRepository:
             key_hash=key_hash,
             description=description,
             roles=[role.value for role in roles],
+            org_id=org_id,
         )
         self.db_session.add(db_api_key)
         self.db_session.commit()

--- a/genai-engine/src/schemas/internal_schemas.py
+++ b/genai-engine/src/schemas/internal_schemas.py
@@ -170,6 +170,7 @@ from schemas.rag_experiment_schemas import (
     RagConfig,
     RagConfigResponse,
     RagExperimentSummary,
+    SavedRagConfig,
     UnsavedRagConfigResponse,
 )
 from schemas.rag_notebook_schemas import (
@@ -3982,8 +3983,6 @@ class InternalSavedRagConfig(BaseModel):
         This method handles the conversion between request and response schemas
         for RAG configurations, converting request settings types to response settings types.
         """
-        from schemas.rag_experiment_schemas import SavedRagConfig
-
         if config.type == "saved":
             # Saved configs don't need conversion - they're the same in both request and response
             return SavedRagConfig(

--- a/genai-engine/src/schemas/internal_schemas.py
+++ b/genai-engine/src/schemas/internal_schemas.py
@@ -1807,6 +1807,9 @@ class User(BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     roles: list[AuthUserRole]
+    # Set from api_key.org_id on the API-key auth path. None for JWT users
+    # and for admin API keys (org_id IS NULL). Drives request.state.org_scope.
+    org_scope: Optional[uuid.UUID] = None
 
     @staticmethod
     def _from_database_model(user: DatabaseUser) -> "User":
@@ -1969,6 +1972,8 @@ class ApiKey(BaseModel):
     created_at: datetime
     deactivated_at: Optional[datetime] = None
     roles: list[str] = [constants.TASK_ADMIN]
+    # NULL = admin (cross-org). Non-null = tenant scoped to that org.
+    org_id: Optional[uuid.UUID] = None
 
     @staticmethod
     def _from_database_model(api_key: DatabaseApiKey) -> "ApiKey":
@@ -1980,6 +1985,7 @@ class ApiKey(BaseModel):
             created_at=api_key.created_at,
             deactivated_at=api_key.deactivated_at,
             roles=api_key.roles,
+            org_id=api_key.org_id,
         )
 
     def _to_response_model(self, message: str = "") -> ApiKeyResponse:
@@ -2005,6 +2011,7 @@ class ApiKey(BaseModel):
                 AuthUserRole(name=role, description="API Key user", composite=True)
                 for role in self.roles
             ],
+            org_scope=self.org_id,
         )
 
 

--- a/genai-engine/tests/unit/auth/test_multi_validator.py
+++ b/genai-engine/tests/unit/auth/test_multi_validator.py
@@ -9,6 +9,7 @@ suite asserts it is set correctly on all three auth paths:
   - JWT request (admin) → org_scope = None
 """
 
+import asyncio
 import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -33,8 +34,6 @@ def _run(validator: MultiMethodValidator, request, *, api_key_user, jwt_user):
     matches (see api_key_validator_client.py). multi_validator catches it,
     logs, then falls through to the JWT path.
     """
-    import asyncio
-
     api_key_client = MagicMock()
     if api_key_user is None:
         api_key_client.validate.side_effect = BadCredentialsException()

--- a/genai-engine/tests/unit/auth/test_multi_validator.py
+++ b/genai-engine/tests/unit/auth/test_multi_validator.py
@@ -1,0 +1,102 @@
+"""Tests for MultiMethodValidator.
+
+The single test that distinguishes admin (cross-org) from tenant (single-org)
+callers throughout the rest of multi-tenancy is request.state.org_scope. This
+suite asserts it is set correctly on all three auth paths:
+
+  - API key with org_id = NULL (admin) → org_scope = None
+  - API key with org_id = <uuid> (tenant) → org_scope = <uuid>
+  - JWT request (admin) → org_scope = None
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from arthur_common.models.common_schemas import AuthUserRole
+
+from auth.multi_validator import MultiMethodValidator
+from schemas.internal_schemas import User
+
+
+def _make_request() -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace())
+
+
+def _run(validator: MultiMethodValidator, request, *, api_key_user, jwt_user):
+    import asyncio
+
+    api_key_client = MagicMock()
+    api_key_client.validate.return_value = api_key_user
+    jwk_client = MagicMock()
+    jwk_client.validate.return_value = jwt_user
+
+    return asyncio.run(
+        validator.validate_api_multi_auth(
+            request=request,
+            jwk_client=jwk_client,
+            token="test-token",
+            api_key_validator_client=api_key_client,
+            db_session=MagicMock(),
+            creds=None,
+        ),
+    )
+
+
+@pytest.mark.unit_tests
+def test_api_key_admin_sets_org_scope_none():
+    """Admin API key (org_id=NULL) → request.state.org_scope is None."""
+    user = User(
+        id="admin-key-id",
+        email="",
+        roles=[AuthUserRole(name="ORG_ADMIN", description="", composite=True)],
+        org_scope=None,
+    )
+    request = _make_request()
+    validator = MultiMethodValidator(api_key_validator_creators=[])
+
+    result = _run(validator, request, api_key_user=user, jwt_user=None)
+
+    assert result is user
+    assert request.state.user_id == "admin-key-id"
+    assert request.state.org_scope is None
+
+
+@pytest.mark.unit_tests
+def test_api_key_tenant_sets_org_scope_to_org_id():
+    """Tenant API key (org_id=X) → request.state.org_scope = X."""
+    org_id = uuid.uuid4()
+    user = User(
+        id="tenant-key-id",
+        email="",
+        roles=[AuthUserRole(name="TENANT-USER", description="", composite=True)],
+        org_scope=org_id,
+    )
+    request = _make_request()
+    validator = MultiMethodValidator(api_key_validator_creators=[])
+
+    result = _run(validator, request, api_key_user=user, jwt_user=None)
+
+    assert result is user
+    assert request.state.user_id == "tenant-key-id"
+    assert request.state.org_scope == org_id
+
+
+@pytest.mark.unit_tests
+def test_jwt_path_sets_org_scope_none():
+    """JWT user → request.state.org_scope = None (v1 design)."""
+    user = User(
+        id="jwt-sub",
+        email="user@example.com",
+        roles=[AuthUserRole(name="ORG_ADMIN", description="", composite=True)],
+    )
+    request = _make_request()
+    validator = MultiMethodValidator(api_key_validator_creators=[])
+
+    # API key validation returns None so we fall through to JWT path.
+    result = _run(validator, request, api_key_user=None, jwt_user=user)
+
+    assert result is user
+    assert request.state.user_id == "jwt-sub"
+    assert request.state.org_scope is None

--- a/genai-engine/tests/unit/auth/test_multi_validator.py
+++ b/genai-engine/tests/unit/auth/test_multi_validator.py
@@ -17,6 +17,7 @@ import pytest
 from arthur_common.models.common_schemas import AuthUserRole
 
 from auth.multi_validator import MultiMethodValidator
+from schemas.custom_exceptions import BadCredentialsException
 from schemas.internal_schemas import User
 
 
@@ -25,10 +26,20 @@ def _make_request() -> SimpleNamespace:
 
 
 def _run(validator: MultiMethodValidator, request, *, api_key_user, jwt_user):
+    """Drive validate_api_multi_auth with mocked clients.
+
+    When api_key_user is None we model the production failure path: the
+    APIKeyValidatorClient raises BadCredentialsException when no validator
+    matches (see api_key_validator_client.py). multi_validator catches it,
+    logs, then falls through to the JWT path.
+    """
     import asyncio
 
     api_key_client = MagicMock()
-    api_key_client.validate.return_value = api_key_user
+    if api_key_user is None:
+        api_key_client.validate.side_effect = BadCredentialsException()
+    else:
+        api_key_client.validate.return_value = api_key_user
     jwk_client = MagicMock()
     jwk_client.validate.return_value = jwt_user
 
@@ -94,7 +105,8 @@ def test_jwt_path_sets_org_scope_none():
     request = _make_request()
     validator = MultiMethodValidator(api_key_validator_creators=[])
 
-    # API key validation returns None so we fall through to JWT path.
+    # API key validation raises BadCredentialsException (production behavior
+    # when no validator matches the token) so we fall through to JWT.
     result = _run(validator, request, api_key_user=None, jwt_user=user)
 
     assert result is user

--- a/genai-engine/tests/unit/repositories/test_auth_repository.py
+++ b/genai-engine/tests/unit/repositories/test_auth_repository.py
@@ -3,7 +3,9 @@ import datetime
 import uuid
 from unittest.mock import MagicMock
 
+import bcrypt
 import pytest
+from arthur_common.models.enums import APIKeysRolesEnum
 
 from db_models import DatabaseApiKey
 from repositories.api_key_repository import ApiKeyRepository
@@ -52,8 +54,6 @@ def test_validate_key_with_mocked_db_result():
 
 @pytest.mark.unit_tests
 def test_validate_key_with_real_hash():
-    import bcrypt
-
     # Create a real bcrypt hash for testing
     test_key_value = "test_key_value"
     real_hash = bcrypt.hashpw(
@@ -173,8 +173,6 @@ def test_get_user_representation_org_scope_none_for_admin_key():
 @pytest.mark.unit_tests
 def test_create_api_key_persists_org_id(monkeypatch):
     """create_api_key(org_id=X) passes org_id through to the DatabaseApiKey row."""
-    from arthur_common.models.enums import APIKeysRolesEnum
-
     db_session = MagicMock()
     # Zero existing keys so we pass the max_api_key_limit gate.
     db_session.query.return_value.filter.return_value.count.return_value = 0
@@ -208,8 +206,6 @@ def test_create_api_key_persists_org_id(monkeypatch):
 @pytest.mark.unit_tests
 def test_create_api_key_defaults_to_none_org_id_for_admin(monkeypatch):
     """create_api_key() without org_id (admin path) leaves the column NULL."""
-    from arthur_common.models.enums import APIKeysRolesEnum
-
     db_session = MagicMock()
     db_session.query.return_value.filter.return_value.count.return_value = 0
 

--- a/genai-engine/tests/unit/repositories/test_auth_repository.py
+++ b/genai-engine/tests/unit/repositories/test_auth_repository.py
@@ -1,10 +1,13 @@
 import base64
+import datetime
+import uuid
 from unittest.mock import MagicMock
 
 import pytest
 
 from db_models import DatabaseApiKey
 from repositories.api_key_repository import ApiKeyRepository
+from schemas.internal_schemas import ApiKey
 
 
 @pytest.mark.unit_tests
@@ -65,6 +68,9 @@ def test_validate_key_with_real_hash():
     mock_db_api_key.description = "Test API Key"
     mock_db_api_key.roles = ["admin"]
     mock_db_api_key.is_active = True
+    mock_db_api_key.created_at = datetime.datetime(2026, 1, 1)
+    mock_db_api_key.deactivated_at = None
+    mock_db_api_key.org_id = None
 
     # Mock the database session and query chain
     db_session = MagicMock()
@@ -92,3 +98,137 @@ def test_validate_key_with_real_hash():
     assert result.id == "test_api_key_id"
     assert result.description == "Test API Key"
     assert result.roles == ["admin"]
+
+
+@pytest.mark.unit_tests
+def test_api_key_from_database_model_propagates_org_id_when_set():
+    """Tenant key (api_keys.org_id non-null) surfaces org_id on the ApiKey schema."""
+    org_id = uuid.uuid4()
+    db_api_key = MagicMock(spec=DatabaseApiKey)
+    db_api_key.id = "tenant-key-id"
+    db_api_key.key_hash = "hash"
+    db_api_key.description = "tenant key"
+    db_api_key.is_active = True
+    db_api_key.created_at = datetime.datetime(2026, 1, 1)
+    db_api_key.deactivated_at = None
+    db_api_key.roles = ["TENANT-USER"]
+    db_api_key.org_id = org_id
+
+    api_key = ApiKey._from_database_model(db_api_key)
+
+    assert api_key.org_id == org_id
+
+
+@pytest.mark.unit_tests
+def test_api_key_from_database_model_org_id_none_for_admin_keys():
+    """Admin key (api_keys.org_id IS NULL) yields org_id=None — existing behavior."""
+    db_api_key = MagicMock(spec=DatabaseApiKey)
+    db_api_key.id = "admin-key-id"
+    db_api_key.key_hash = "hash"
+    db_api_key.description = "admin key"
+    db_api_key.is_active = True
+    db_api_key.created_at = datetime.datetime(2026, 1, 1)
+    db_api_key.deactivated_at = None
+    db_api_key.roles = ["ORG_ADMIN"]
+    db_api_key.org_id = None
+
+    api_key = ApiKey._from_database_model(db_api_key)
+
+    assert api_key.org_id is None
+
+
+@pytest.mark.unit_tests
+def test_get_user_representation_propagates_org_id_as_org_scope():
+    """ApiKey.org_id flows into User.org_scope so multi_validator can pick it up."""
+    org_id = uuid.uuid4()
+    api_key = ApiKey(
+        id="tenant-key-id",
+        is_active=True,
+        created_at=datetime.datetime(2026, 1, 1),
+        roles=["TENANT-USER"],
+        org_id=org_id,
+    )
+
+    user = api_key.get_user_representation()
+
+    assert user.org_scope == org_id
+
+
+@pytest.mark.unit_tests
+def test_get_user_representation_org_scope_none_for_admin_key():
+    """Admin ApiKey (org_id=None) yields User.org_scope=None — cross-org access."""
+    api_key = ApiKey(
+        id="admin-key-id",
+        is_active=True,
+        created_at=datetime.datetime(2026, 1, 1),
+        roles=["ORG_ADMIN"],
+        org_id=None,
+    )
+
+    user = api_key.get_user_representation()
+
+    assert user.org_scope is None
+
+
+@pytest.mark.unit_tests
+def test_create_api_key_persists_org_id(monkeypatch):
+    """create_api_key(org_id=X) passes org_id through to the DatabaseApiKey row."""
+    from arthur_common.models.enums import APIKeysRolesEnum
+
+    db_session = MagicMock()
+    # Zero existing keys so we pass the max_api_key_limit gate.
+    db_session.query.return_value.filter.return_value.count.return_value = 0
+
+    # Bypass pydantic validation — create_api_key constructs DatabaseApiKey but
+    # doesn't commit, so SQLAlchemy defaults aren't applied yet. Return a thin
+    # stand-in that exposes the underlying ORM row for inspection.
+    class _Stub:
+        def __init__(self, db_api_key):
+            self.db = db_api_key
+
+        def set_key(self, key):
+            pass
+
+    monkeypatch.setattr(
+        ApiKey, "_from_database_model", staticmethod(lambda db: _Stub(db))
+    )
+    repo = ApiKeyRepository(db_session=db_session)
+    org_id = uuid.uuid4()
+    repo.create_api_key(
+        description="tenant key",
+        roles=[APIKeysRolesEnum.TASK_ADMIN],
+        org_id=org_id,
+    )
+
+    added = db_session.add.call_args[0][0]
+    assert isinstance(added, DatabaseApiKey)
+    assert added.org_id == org_id
+
+
+@pytest.mark.unit_tests
+def test_create_api_key_defaults_to_none_org_id_for_admin(monkeypatch):
+    """create_api_key() without org_id (admin path) leaves the column NULL."""
+    from arthur_common.models.enums import APIKeysRolesEnum
+
+    db_session = MagicMock()
+    db_session.query.return_value.filter.return_value.count.return_value = 0
+
+    class _Stub:
+        def __init__(self, db_api_key):
+            self.db = db_api_key
+
+        def set_key(self, key):
+            pass
+
+    monkeypatch.setattr(
+        ApiKey, "_from_database_model", staticmethod(lambda db: _Stub(db))
+    )
+    repo = ApiKeyRepository(db_session=db_session)
+    repo.create_api_key(
+        description="admin key",
+        roles=[APIKeysRolesEnum.ORG_ADMIN],
+    )
+
+    added = db_session.add.call_args[0][0]
+    assert isinstance(added, DatabaseApiKey)
+    assert added.org_id is None


### PR DESCRIPTION
## Summary

Implements [UP-4423](https://arthurai.atlassian.net/browse/UP-4423) — wires `api_keys.org_id` (added in UP-4422 / `feat/multitenancy_migrations`) through the auth path so `request.state.org_scope` is set on every authenticated request.

This is the single test that distinguishes admin (cross-org) from tenant (single-org) callers throughout the rest of multi-tenancy. See [§6 Authentication & Authorization](https://github.com/arthur-ai/arthur-engine/blob/UP-4387-multitenancy/genai-engine/docs/MULTI_TENANCY_DESIGN.md#6-authentication--authorization) of the design doc.

This PR stacks on top of `feat/multitenancy_migrations` — the prior 3 commits are the migration + ORM work from UP-4422. The new commit (`1aeaff0a`) is the only delta this PR adds on top of that.

## What changed

**Pydantic schemas (`src/schemas/internal_schemas.py`)**
- `ApiKey` gains `org_id: UUID | None`
- `User` gains `org_scope: UUID | None`
- `ApiKey._from_database_model` propagates `org_id`
- `ApiKey.get_user_representation()` maps `org_id` → `User.org_scope`

**Auth wiring (`src/auth/multi_validator.py`)**
- Sets `request.state.org_scope = user.org_scope` on both API-key and JWT paths
- JWT users default to `org_scope=None` per v1 design

**Dependency (`src/dependencies.py`)**
- New `get_org_scope(request) -> UUID | None` — used by handlers that need admin-vs-tenant decisions

**Repository (`src/repositories/api_key_repository.py`)**
- `create_api_key()` accepts optional `org_id` for the tenant signup flow (separate ticket). `None` preserves admin behavior.

## Test plan

- [x] `_from_database_model` propagates `org_id` for tenant keys
- [x] `_from_database_model` returns `org_id=None` for admin keys
- [x] `get_user_representation()` maps `org_id` → `User.org_scope`
- [x] `get_user_representation()` returns `org_scope=None` for admin
- [x] `create_api_key(org_id=X)` persists `org_id` on the DatabaseApiKey row
- [x] `create_api_key()` without `org_id` (admin) leaves the column `NULL`
- [x] `MultiMethodValidator` sets `request.state.org_scope=None` for admin API key
- [x] `MultiMethodValidator` sets `request.state.org_scope=<uuid>` for tenant API key
- [x] `MultiMethodValidator` sets `request.state.org_scope=None` for JWT users

All 12 tests in `tests/unit/repositories/test_auth_repository.py` and `tests/unit/auth/test_multi_validator.py` pass locally.

## Out of scope

Per the ticket:
- `TENANT-USER` role + permission frozenset additions ([UP-4428](https://arthurai.atlassian.net/browse/UP-4428))
- Endpoint-level enforcement of `org_scope` (decorators + Pattern C repository changes — [UP-4429](https://arthurai.atlassian.net/browse/UP-4429))
- Public tenant signup endpoint that mints tenant-scoped keys (separate ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)