### PR TITLE
feat(multitenancy): GET /users/me identity introspection (UP-4426)

### DIFF
--- a/genai-engine/src/api_changelog.md
+++ b/genai-engine/src/api_changelog.md
@@ -2,6 +2,10 @@ The intention of this changelog is to document API changes as they happen to eff
 
 ---
 
+# 05/20/2026
+- **CHANGE** for **URL**: /auth/api_keys/  added the new 'TENANT-USER' enum value to the request property 'roles/anyOf[subschema #1]/items/'
+- **CHANGE** for **URL**: /users/me  endpoint added
+
 # 05/15/2026
 - **CHANGE** for **URL**: /api/v2/validate endpoint added
 

--- a/genai-engine/src/repositories/organizations_repository.py
+++ b/genai-engine/src/repositories/organizations_repository.py
@@ -1,0 +1,21 @@
+import uuid
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from db_models import DatabaseOrganization
+
+
+class OrganizationsRepository:
+    def __init__(self, db_session: Session) -> None:
+        self.db_session = db_session
+
+    def get_organization_by_id(
+        self,
+        organization_id: uuid.UUID,
+    ) -> Optional[DatabaseOrganization]:
+        return (
+            self.db_session.query(DatabaseOrganization)
+            .filter(DatabaseOrganization.id == organization_id)
+            .one_or_none()
+        )

--- a/genai-engine/src/routers/user_routes.py
+++ b/genai-engine/src/routers/user_routes.py
@@ -9,6 +9,7 @@ from arthur_common.models.enums import (
 from arthur_common.models.request_schemas import CreateUserRequest, PasswordResetRequest
 from arthur_common.models.response_schemas import UserResponse
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response
+from sqlalchemy.orm import Session
 from starlette import status
 
 from auth.ApiKeyValidator.APIKeyvalidatorCreator import APIKeyValidatorCreator
@@ -16,10 +17,12 @@ from auth.ApiKeyValidator.enums import APIKeyValidatorType
 from auth.multi_validator import MultiMethodValidator
 from auth.oauth_validator import validate_token
 from clients.auth.abc_keycloak_client import ABCAuthClient
-from dependencies import get_keycloak_client
+from dependencies import get_db_session, get_keycloak_client
+from repositories.organizations_repository import OrganizationsRepository
 from routers.route_handler import GenaiEngineRoute
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import User
+from schemas.response_schemas import MeResponse, OrganizationResponse
 from utils.users import permission_checker
 from utils.utils import common_pagination_parameters, constants, public_endpoint
 
@@ -77,6 +80,44 @@ def search_users(
         page_size=pagination_parameters.page_size,
     )
     return [user._to_response_model() for user in users]
+
+
+@user_management_routes.get(
+    "/me",
+    description=(
+        "Returns the current caller's identity, roles, org_scope, and (when "
+        "scoped) the organization record. Used by the UI on login to decide "
+        "between admin and tenant render branches. Admin callers and JWT "
+        "callers receive org_scope=null and org=null."
+    ),
+    response_model=MeResponse,
+)
+@public_endpoint
+def get_me(
+    current_user: User | None = Depends(multi_validator.validate_api_multi_auth),
+    db_session: Session = Depends(get_db_session),
+) -> MeResponse:
+    if not current_user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=constants.ERROR_AUTHENTICATION_REQUIRED,
+            headers={"full_stacktrace": "false"},
+        )
+
+    org: OrganizationResponse | None = None
+    if current_user.org_scope is not None:
+        db_org = OrganizationsRepository(db_session).get_organization_by_id(
+            current_user.org_scope,
+        )
+        if db_org is not None:
+            org = OrganizationResponse(id=db_org.id, name=db_org.name)
+
+    return MeResponse(
+        user_id=current_user.id,
+        roles=[role.name for role in current_user.roles],
+        org_scope=current_user.org_scope,
+        org=org,
+    )
 
 
 @user_management_routes.get(

--- a/genai-engine/src/schemas/response_schemas.py
+++ b/genai-engine/src/schemas/response_schemas.py
@@ -33,6 +33,18 @@ from schemas.enums import (
 )
 
 
+class OrganizationResponse(BaseModel):
+    id: UUID
+    name: str
+
+
+class MeResponse(BaseModel):
+    user_id: str
+    roles: list[str]
+    org_scope: Optional[UUID] = None
+    org: Optional[OrganizationResponse] = None
+
+
 class DocumentStorageConfigurationResponse(BaseModel):
     storage_environment: Optional[str] = None
     bucket_name: Optional[str] = None

--- a/genai-engine/staging.openapi.json
+++ b/genai-engine/staging.openapi.json
@@ -2,7 +2,7 @@
     "openapi": "3.1.0",
     "info": {
         "title": "Arthur GenAI Engine",
-        "version": "2.1.568"
+        "version": "2.1.503"
     },
     "paths": {
         "/api/v2/engine-config": {
@@ -16726,6 +16726,33 @@
                 }
             }
         },
+        "/users/me": {
+            "get": {
+                "tags": [
+                    "User Management"
+                ],
+                "summary": "Get Me",
+                "description": "Returns the current caller's identity, roles, org_scope, and (when scoped) the organization record. Used by the UI on login to decide between admin and tenant render branches. Admin callers and JWT callers receive org_scope=null and org=null.",
+                "operationId": "get_me_users_me_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MeResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "API Key": []
+                    }
+                ]
+            }
+        },
         "/users/permissions/check": {
             "get": {
                 "tags": [
@@ -17274,7 +17301,8 @@
                     "TASK-ADMIN",
                     "VALIDATION-USER",
                     "ORG-AUDITOR",
-                    "ORG-ADMIN"
+                    "ORG-ADMIN",
+                    "TENANT-USER"
                 ],
                 "title": "APIKeysRolesEnum"
             },
@@ -24414,6 +24442,49 @@
                 "title": "ManualAgentCreationSource",
                 "description": "Creation source for manually created tasks."
             },
+            "MeResponse": {
+                "properties": {
+                    "user_id": {
+                        "type": "string",
+                        "title": "User Id"
+                    },
+                    "roles": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Roles"
+                    },
+                    "org_scope": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Org Scope"
+                    },
+                    "org": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/OrganizationResponse"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "user_id",
+                    "roles"
+                ],
+                "title": "MeResponse"
+            },
             "MessageRole": {
                 "type": "string",
                 "enum": [
@@ -24964,7 +25035,7 @@
                             }
                         ],
                         "title": "Roles",
-                        "description": "Role that will be assigned to API key. Allowed values: [<APIKeysRolesEnum.DEFAULT_RULE_ADMIN: 'DEFAULT-RULE-ADMIN'>, <APIKeysRolesEnum.TASK_ADMIN: 'TASK-ADMIN'>, <APIKeysRolesEnum.VALIDATION_USER: 'VALIDATION-USER'>, <APIKeysRolesEnum.ORG_AUDITOR: 'ORG-AUDITOR'>, <APIKeysRolesEnum.ORG_ADMIN: 'ORG-ADMIN'>]",
+                        "description": "Role that will be assigned to API key. Allowed values: [<APIKeysRolesEnum.DEFAULT_RULE_ADMIN: 'DEFAULT-RULE-ADMIN'>, <APIKeysRolesEnum.TASK_ADMIN: 'TASK-ADMIN'>, <APIKeysRolesEnum.VALIDATION_USER: 'VALIDATION-USER'>, <APIKeysRolesEnum.ORG_AUDITOR: 'ORG-AUDITOR'>, <APIKeysRolesEnum.ORG_ADMIN: 'ORG-ADMIN'>, <APIKeysRolesEnum.TENANT_USER: 'TENANT-USER'>]",
                         "default": [
                             "VALIDATION-USER"
                         ]
@@ -26052,6 +26123,25 @@
                     "input_audio"
                 ],
                 "title": "OpenAIMessageType"
+            },
+            "OrganizationResponse": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "title": "OrganizationResponse"
             },
             "PIIConfig": {
                 "properties": {

--- a/genai-engine/tests/unit/utils/test_users_me.py
+++ b/genai-engine/tests/unit/utils/test_users_me.py
@@ -1,0 +1,130 @@
+"""GET /users/me returns identity+org info (UP-4426).
+
+Tests exercise the handler body directly via __wrapped__ (which the
+@public_endpoint decorator exposes through functools.wraps) so we don't
+need the full FastAPI client stack — sidesteps the tests/unit/routes/
+autouse client fixture which currently errors on tasks.org_id NOT NULL.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from arthur_common.models.common_schemas import AuthUserRole
+from fastapi import HTTPException
+
+from routers.user_routes import get_me
+from schemas.internal_schemas import User
+from schemas.response_schemas import MeResponse
+
+
+def _role(name: str) -> AuthUserRole:
+    return AuthUserRole(id="0", name=name, description="DUMMY", composite=True)
+
+
+def _user(
+    user_id: str = "user-123",
+    roles: list[str] | None = None,
+    org_scope: uuid.UUID | None = None,
+) -> User:
+    return User(
+        id=user_id,
+        email="x@example.com",
+        roles=[_role(r) for r in (roles or [])],
+        org_scope=org_scope,
+    )
+
+
+def _call_me(current_user: User | None) -> MeResponse:
+    # get_me is a sync handler wrapped by @public_endpoint; __wrapped__ is the
+    # original sync function (functools.wraps), so we can invoke it directly.
+    return get_me.__wrapped__(
+        current_user=current_user,
+        db_session=MagicMock(),
+    )
+
+
+@pytest.mark.unit_tests
+def test_get_me_unauthenticated_returns_401():
+    with pytest.raises(HTTPException) as exc:
+        _call_me(current_user=None)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.unit_tests
+def test_get_me_admin_api_key_has_null_org():
+    """Admin API key path: org_scope is None, no org lookup, org=null in response."""
+    user = _user(user_id="admin-uuid", roles=["ORG-ADMIN"], org_scope=None)
+    with patch(
+        "routers.user_routes.OrganizationsRepository",
+    ) as mock_repo_cls:
+        result = _call_me(current_user=user)
+        mock_repo_cls.assert_not_called()
+
+    assert result.user_id == "admin-uuid"
+    assert result.roles == ["ORG-ADMIN"]
+    assert result.org_scope is None
+    assert result.org is None
+
+
+@pytest.mark.unit_tests
+def test_get_me_tenant_api_key_populates_org():
+    """Tenant API key path: org_scope set, org lookup runs, org populated."""
+    org_id = uuid.uuid4()
+    user = _user(user_id="tenant-uuid", roles=["TENANT-USER"], org_scope=org_id)
+
+    db_org = MagicMock()
+    db_org.id = org_id
+    db_org.name = "demo-a3f9b2c1"
+
+    with patch(
+        "routers.user_routes.OrganizationsRepository",
+    ) as mock_repo_cls:
+        mock_repo_cls.return_value.get_organization_by_id.return_value = db_org
+        result = _call_me(current_user=user)
+        mock_repo_cls.return_value.get_organization_by_id.assert_called_once_with(
+            org_id,
+        )
+
+    assert result.user_id == "tenant-uuid"
+    assert result.roles == ["TENANT-USER"]
+    assert result.org_scope == org_id
+    assert result.org is not None
+    assert result.org.id == org_id
+    assert result.org.name == "demo-a3f9b2c1"
+
+
+@pytest.mark.unit_tests
+def test_get_me_jwt_user_has_null_org():
+    """JWT path: org_scope is None (set only by API-key validator), org=null."""
+    user = _user(
+        user_id="keycloak-sub-abc",
+        roles=["ORG-ADMIN", "default-roles-genai-engine"],
+        org_scope=None,
+    )
+    with patch(
+        "routers.user_routes.OrganizationsRepository",
+    ) as mock_repo_cls:
+        result = _call_me(current_user=user)
+        mock_repo_cls.assert_not_called()
+
+    assert result.user_id == "keycloak-sub-abc"
+    assert set(result.roles) == {"ORG-ADMIN", "default-roles-genai-engine"}
+    assert result.org_scope is None
+    assert result.org is None
+
+
+@pytest.mark.unit_tests
+def test_get_me_tenant_with_missing_org_record_returns_null_org():
+    """Defensive: if org_scope refers to a deleted org, org=null, no crash."""
+    org_id = uuid.uuid4()
+    user = _user(user_id="orphan-uuid", roles=["TENANT-USER"], org_scope=org_id)
+
+    with patch(
+        "routers.user_routes.OrganizationsRepository",
+    ) as mock_repo_cls:
+        mock_repo_cls.return_value.get_organization_by_id.return_value = None
+        result = _call_me(current_user=user)
+
+    assert result.org_scope == org_id
+    assert result.org is None


### PR DESCRIPTION
## Summary

Adds `GET /users/me` so the UI can decide on login between admin and tenant render branches. `/users/permissions/check` is a permission probe, not an identity returner — this fills the gap per UP-4426 / design §6.

**Response shape:**
```
{
  "user_id":   "…",
  "roles":     ["TENANT-USER"],
  "org_scope": "uuid" | null,
  "org":       { "id": "uuid", "name": "…" } | null
}
```

- Admin API key (`org_id IS NULL`) → `org_scope=null`, `org=null`.
- Tenant API key → both populated via new `OrganizationsRepository.get_organization_by_id`.
- JWT request → same shape as admin (org_scope is only set by the API-key auth path).
- Unauthenticated → 401.
- Defensive: if `org_scope` points to a deleted org, `org=null` (no 500).

## Files

- `src/routers/user_routes.py` — new `get_me` handler, `@public_endpoint`.
- `src/schemas/response_schemas.py` — `MeResponse`, `OrganizationResponse`.
- `src/repositories/organizations_repository.py` — new repo with `get_organization_by_id`.
- `tests/unit/utils/test_users_me.py` — 5 parametrized cases covering 401, admin, tenant, JWT, and the orphaned-org defensive path.

Tests run via `get_me.__wrapped__` to skip the FastAPI client (the `tests/unit/routes/` autouse `client` fixture is broken on this branch by UP-4423's `tasks.org_id NOT NULL` — pre-existing).

## Test plan

- [ ] Local: `uv run pytest tests/unit/utils/test_users_me.py -m unit_tests` → 5/5 pass.
- [ ] CI passes on this branch.
- [ ] FE consumer is UP-4427 (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)