### PR TITLE
feat(multitenancy): enforce org scope on routes (UP-4425)

### DIFF
--- a/genai-engine/alembic/versions/2026_05_19_1510-3abf881da275_denormalize_org_id_to_task_scoped_tables.py
+++ b/genai-engine/alembic/versions/2026_05_19_1510-3abf881da275_denormalize_org_id_to_task_scoped_tables.py
@@ -146,7 +146,7 @@ def upgrade() -> None:
         """)
     op.execute("""
         UPDATE agentic_annotations
-           SET org_id = (SELECT id FROM organizations WHERE name = 'system')
+           SET org_id = '00000000-0000-0000-0000-000000000002'  -- system org
          WHERE org_id IS NULL
         """)
 

--- a/genai-engine/alembic/versions/2026_05_19_1510-3abf881da275_denormalize_org_id_to_task_scoped_tables.py
+++ b/genai-engine/alembic/versions/2026_05_19_1510-3abf881da275_denormalize_org_id_to_task_scoped_tables.py
@@ -31,6 +31,7 @@ CK constraints on that table.
 import sqlalchemy as sa
 
 from alembic import op
+from utils.constants import SYSTEM_ORG_ID
 
 # revision identifiers, used by Alembic.
 revision = "3abf881da275"
@@ -144,11 +145,12 @@ def upgrade() -> None:
          WHERE aa.continuous_eval_id = ce.id
            AND aa.org_id IS NULL
         """)
-    op.execute("""
-        UPDATE agentic_annotations
-           SET org_id = '00000000-0000-0000-0000-000000000002'  -- system org
-         WHERE org_id IS NULL
-        """)
+    op.execute(
+        sa.text(
+            "UPDATE agentic_annotations SET org_id = :system_id "
+            "WHERE org_id IS NULL"
+        ).bindparams(system_id=str(SYSTEM_ORG_ID))
+    )
 
     # Step C: SET NOT NULL + index + FK on every table. If any row's parent
     # chain was broken (orphan data not covered by the fallbacks above),

--- a/genai-engine/alembic/versions/2026_05_19_1510-514464b8ca3d_create_organizations_table.py
+++ b/genai-engine/alembic/versions/2026_05_19_1510-514464b8ca3d_create_organizations_table.py
@@ -5,14 +5,18 @@ Revises: b3f7a2c1d9e0
 Create Date: 2026-05-19 15:10:05.190824
 
 Multi-tenancy step 1 of 5. Creates the `organizations` table that owns
-tasks and (transitively) every task-scoped resource. Seeds two rows:
+tasks and (transitively) every task-scoped resource. Seeds two rows
+with well-known UUIDs so application code references them by id rather
+than by name (name is likely to become user-editable in v2):
 
-  - `default` — the bucket for pre-multi-tenancy tasks and any admin-
-    created task without tenant context. Tenants never carry org_id = default.
-  - `system`  — internal tasks (is_system_task=True) live here. Tenants
-    never carry org_id = system.
+  - `default` — id `00000000-0000-0000-0000-000000000001`. The bucket
+    for pre-multi-tenancy tasks and any admin-created task without
+    tenant context. Tenants never carry org_id = default.
+  - `system`  — id `00000000-0000-0000-0000-000000000002`. Internal
+    tasks (is_system_task=True) live here. Tenants never carry
+    org_id = system.
 
-Subsequent migrations backfill `tasks.org_id` from these orgs.
+Subsequent migrations backfill `tasks.org_id` from these orgs by id.
 
 Partial unique index `uq_organizations_is_system_true` enforces "at most
 one row with is_system=TRUE."
@@ -66,9 +70,14 @@ def upgrade() -> None:
         postgresql_where=sa.text("is_system = TRUE"),
     )
 
+    # Seed with well-known UUIDs so application code can reference them
+    # by id without a name lookup. These ids are also asserted in
+    # `repositories/organizations_repository.py` and used by the
+    # backfill step in the next migration.
     op.execute(
-        "INSERT INTO organizations (name, is_system) VALUES "
-        "('default', FALSE), ('system', TRUE) "
+        "INSERT INTO organizations (id, name, is_system) VALUES "
+        "('00000000-0000-0000-0000-000000000001', 'default', FALSE), "
+        "('00000000-0000-0000-0000-000000000002', 'system',  TRUE) "
         "ON CONFLICT (name) DO NOTHING"
     )
 

--- a/genai-engine/alembic/versions/2026_05_19_1510-514464b8ca3d_create_organizations_table.py
+++ b/genai-engine/alembic/versions/2026_05_19_1510-514464b8ca3d_create_organizations_table.py
@@ -29,6 +29,7 @@ doesn't double-insert.
 import sqlalchemy as sa
 
 from alembic import op
+from utils.constants import DEFAULT_ORG_ID, SYSTEM_ORG_ID
 
 # revision identifiers, used by Alembic.
 revision = "514464b8ca3d"
@@ -71,14 +72,19 @@ def upgrade() -> None:
     )
 
     # Seed with well-known UUIDs so application code can reference them
-    # by id without a name lookup. These ids are also asserted in
-    # `repositories/organizations_repository.py` and used by the
-    # backfill step in the next migration.
+    # by id without a name lookup. UUIDs are sourced from `utils.constants`
+    # — the single source of truth shared with app code and the
+    # task / annotation backfill migrations below.
     op.execute(
-        "INSERT INTO organizations (id, name, is_system) VALUES "
-        "('00000000-0000-0000-0000-000000000001', 'default', FALSE), "
-        "('00000000-0000-0000-0000-000000000002', 'system',  TRUE) "
-        "ON CONFLICT (name) DO NOTHING"
+        sa.text(
+            "INSERT INTO organizations (id, name, is_system) VALUES "
+            "(:default_id, 'default', FALSE), "
+            "(:system_id,  'system',  TRUE) "
+            "ON CONFLICT (name) DO NOTHING"
+        ).bindparams(
+            default_id=str(DEFAULT_ORG_ID),
+            system_id=str(SYSTEM_ORG_ID),
+        )
     )
 
 

--- a/genai-engine/alembic/versions/2026_05_19_1510-697657f9af66_add_org_id_to_tasks.py
+++ b/genai-engine/alembic/versions/2026_05_19_1510-697657f9af66_add_org_id_to_tasks.py
@@ -27,14 +27,17 @@ depends_on = None
 def upgrade() -> None:
     op.add_column("tasks", sa.Column("org_id", sa.UUID(), nullable=True))
 
+    # Backfill against the well-known UUIDs seeded by the
+    # create_organizations_table migration. Looking up by id (not name)
+    # keeps the backfill robust against future name changes.
     op.execute("""
         UPDATE tasks
-           SET org_id = (SELECT id FROM organizations WHERE name = 'system')
+           SET org_id = '00000000-0000-0000-0000-000000000002'  -- system org
          WHERE is_system_task = TRUE
         """)
     op.execute("""
         UPDATE tasks
-           SET org_id = (SELECT id FROM organizations WHERE name = 'default')
+           SET org_id = '00000000-0000-0000-0000-000000000001'  -- default org
          WHERE org_id IS NULL
         """)
 

--- a/genai-engine/alembic/versions/2026_05_19_1510-697657f9af66_add_org_id_to_tasks.py
+++ b/genai-engine/alembic/versions/2026_05_19_1510-697657f9af66_add_org_id_to_tasks.py
@@ -16,6 +16,7 @@ Backfill:
 import sqlalchemy as sa
 
 from alembic import op
+from utils.constants import DEFAULT_ORG_ID, SYSTEM_ORG_ID
 
 # revision identifiers, used by Alembic.
 revision = "697657f9af66"
@@ -28,18 +29,18 @@ def upgrade() -> None:
     op.add_column("tasks", sa.Column("org_id", sa.UUID(), nullable=True))
 
     # Backfill against the well-known UUIDs seeded by the
-    # create_organizations_table migration. Looking up by id (not name)
-    # keeps the backfill robust against future name changes.
-    op.execute("""
-        UPDATE tasks
-           SET org_id = '00000000-0000-0000-0000-000000000002'  -- system org
-         WHERE is_system_task = TRUE
-        """)
-    op.execute("""
-        UPDATE tasks
-           SET org_id = '00000000-0000-0000-0000-000000000001'  -- default org
-         WHERE org_id IS NULL
-        """)
+    # create_organizations_table migration. UUIDs sourced from
+    # `utils.constants` — single source of truth shared with app code.
+    op.execute(
+        sa.text(
+            "UPDATE tasks SET org_id = :system_id WHERE is_system_task = TRUE"
+        ).bindparams(system_id=str(SYSTEM_ORG_ID))
+    )
+    op.execute(
+        sa.text(
+            "UPDATE tasks SET org_id = :default_id WHERE org_id IS NULL"
+        ).bindparams(default_id=str(DEFAULT_ORG_ID))
+    )
 
     op.alter_column("tasks", "org_id", nullable=False)
     op.create_index(op.f("ix_tasks_org_id"), "tasks", ["org_id"], unique=False)

--- a/genai-engine/alembic/versions/2026_05_19_1510-d894934c8994_backfill_orphan_inferences_to_unmapped_.py
+++ b/genai-engine/alembic/versions/2026_05_19_1510-d894934c8994_backfill_orphan_inferences_to_unmapped_.py
@@ -55,7 +55,7 @@ def upgrade() -> None:
             '{UNMAPPED_TASK_ID}', '{DEFAULT_SERVICE_NAME}',
             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
             false, false, false, true,
-            (SELECT id FROM organizations WHERE name = 'system')
+            '00000000-0000-0000-0000-000000000002'  -- system org
         )
         ON CONFLICT (id) DO NOTHING
         """)

--- a/genai-engine/alembic/versions/2026_05_19_1510-d894934c8994_backfill_orphan_inferences_to_unmapped_.py
+++ b/genai-engine/alembic/versions/2026_05_19_1510-d894934c8994_backfill_orphan_inferences_to_unmapped_.py
@@ -28,7 +28,11 @@ came from THIS migration.
 """
 
 from alembic import op
-from utils.constants import DEFAULT_SERVICE_NAME, UNMAPPED_TASK_ID
+from utils.constants import (
+    DEFAULT_SERVICE_NAME,
+    SYSTEM_ORG_ID,
+    UNMAPPED_TASK_ID,
+)
 
 # revision identifiers, used by Alembic.
 revision = "d894934c8994"
@@ -55,7 +59,7 @@ def upgrade() -> None:
             '{UNMAPPED_TASK_ID}', '{DEFAULT_SERVICE_NAME}',
             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
             false, false, false, true,
-            '00000000-0000-0000-0000-000000000002'  -- system org
+            '{SYSTEM_ORG_ID}'
         )
         ON CONFLICT (id) DO NOTHING
         """)

--- a/genai-engine/docs/MULTI_TENANCY_DESIGN.md
+++ b/genai-engine/docs/MULTI_TENANCY_DESIGN.md
@@ -407,63 +407,44 @@ The UI caches the response in `AuthContext` and uses it to pick its render branc
 
 ## 7. Enforcement Patterns
 
-Every endpoint that touches task-scoped data falls into one of five enforcement patterns, depending on how the affected task is identified in the request. The first four resolve a task ID to its `org_id` and compare against `request.state.org_scope`. The fifth is admin-only — never reachable by tenant keys.
+Every endpoint that touches task-scoped data falls into one of four enforcement patterns (down from five — see "Pattern B" below), depending on how the affected task is identified in the request. Patterns A and D resolve task IDs to their `org_id` via a FastAPI decorator. Pattern C pushes the check into the repository layer. Pattern E is admin-only — never reachable by tenant keys.
 
 ### Pattern A — Path task_id
 
 The endpoint takes `{task_id}` in its URL path. Example: `POST /api/v2/tasks/{task_id}/rules`.
 
-Enforced by a decorator that resolves the path's task to its org and compares:
+Enforced by a decorator that resolves the path's task to its org and compares against the caller's `org_scope`:
 
 ```python
 def enforce_org_scope(path_param: str = "task_id"):
     def decorator(func):
         @wraps(func)
         async def wrapper(*args, **kwargs):
-            request = kwargs["request"]
-            scope = request.state.org_scope
-            if scope is None:
-                return await func(*args, **kwargs)   # admin passthrough
-            task_id = kwargs.get(path_param)
-            task = tasks_repo.get_task_by_id(task_id)
-            if task is None or str(task.org_id) != str(scope):
+            user = kwargs.get("current_user")
+            if _is_admin(user):                          # admin passthrough
+                return await _call(func, *args, **kwargs)
+            path_task_id = kwargs.get(path_param)
+            db_session = _get_db_session_from_kwargs(kwargs)
+            task_org_id = _fetch_task_org_id(db_session, path_task_id)
+            if task_org_id is None or task_org_id != str(user.org_scope):
+                # 404 (not 403) so tenants can't enumerate foreign tasks.
                 raise HTTPException(404, "Task not found")
-            request.state.cached_task = task          # cache for the handler
-            return await func(*args, **kwargs)
+            return await _call(func, *args, **kwargs)
         return wrapper
     return decorator
 ```
 
-The resolved task is cached on `request.state` so handler-side repository calls don't re-fetch it. Mismatch returns 404 (not 403) to prevent enumeration.
+The decorator requires that the handler receives `current_user` and `db_session` as kwargs via FastAPI `Depends(...)` — which every authenticated route does.
 
-### Pattern B — Body task_id
+The fetch is a single `SELECT org_id FROM tasks WHERE id = ?` — no full task hydration. Routes that need the full `Task` continue to use the existing `get_validated_task` dependency, which was extended with the same `org_scope` check so it returns an identical `"Task not found"` 404 on either "missing" or "in another org" — closing a 404-body enumeration oracle.
 
-The endpoint accepts a `task_id` field in its request body. Example: `POST /api/v1/inferences` with body `{"task_id": "...", ...}`.
+Applied to **60 endpoints** across 17 router files (every path with `{task_id}` in genai-engine).
 
-A decorator pulls the field off the parsed Pydantic body and applies the same resolution:
+### Pattern B — Body task_id  *(removed)*
 
-```python
-def enforce_body_org_scope(body_field: str = "task_id"):
-    def decorator(func):
-        @wraps(func)
-        async def wrapper(*args, **kwargs):
-            request = kwargs["request"]
-            scope = request.state.org_scope
-            if scope is None:
-                return await func(*args, **kwargs)
-            body = next((v for v in kwargs.values() if hasattr(v, body_field)), None)
-            body_task_id = getattr(body, body_field, None)
-            if body_task_id is None:
-                raise HTTPException(400, f"{body_field} required in body")
-            task = tasks_repo.get_task_by_id(body_task_id)
-            if task is None or str(task.org_id) != str(scope):
-                raise HTTPException(404, "Task not found")
-            return await func(*args, **kwargs)
-        return wrapper
-    return decorator
-```
+The original design called for a third decorator (`enforce_body_org_scope`) for endpoints that accept `task_id` in the request body. **It was implemented and then deleted** because no endpoint in genai-engine actually takes `task_id` in the body — every endpoint that touches a specific task carries it in the URL path. The candidate endpoints originally listed for Pattern B (`POST /agentic-prompts`, `POST /chatbots`, etc.) actually have the shape `POST /tasks/{task_id}/<resource>` and are covered by Pattern A.
 
-Same 404-on-mismatch behavior.
+If a body-task_id endpoint is ever added, restore `enforce_body_org_scope` from git history (commit `72dced7f`).
 
 ### Pattern C — Resource-id-scoped (repository-level filter)
 
@@ -507,27 +488,40 @@ def enforce_query_org_scope(query_param: str = "task_ids"):
     def decorator(func):
         @wraps(func)
         async def wrapper(*args, **kwargs):
-            request = kwargs["request"]
-            scope = request.state.org_scope
-            if scope is None:
-                return await func(*args, **kwargs)
-            user_task_ids = kwargs.get(query_param) or []
-            if not user_task_ids:
-                # no filter supplied — expand to all tasks in caller's org
-                kwargs[query_param] = [str(t.id) for t in tasks_repo.list_tasks_by_org(scope)]
+            user = kwargs.get("current_user")
+            if _is_admin(user):
+                return await _call(func, *args, **kwargs)
+
+            # Get every task ID this tenant is allowed to see.
+            db_session = _get_db_session_from_kwargs(kwargs)
+            org_task_ids = {
+                str(tid) for tid in db_session.execute(
+                    select(DatabaseTask.id).where(DatabaseTask.org_id == str(user.org_scope))
+                ).scalars()
+            }
+
+            # Locate the field either as a direct kwarg (`task_ids: list[str] = Query(...)`)
+            # or as an attribute on a Pydantic dependency object (e.g. `TraceQueryRequest`).
+            holder, key, supplied = _find_task_ids_holder(kwargs, query_param)
+            if not supplied:
+                # No filter supplied — inject all of the caller's org's tasks.
+                _set_task_ids(holder, key, list(org_task_ids))
             else:
-                # filter supplied — every id must resolve to a task in caller's org
-                tasks = tasks_repo.get_tasks_by_ids(user_task_ids)
-                missing = set(user_task_ids) - {str(t.id) for t in tasks}
-                outside = [t for t in tasks if str(t.org_id) != str(scope)]
-                if missing or outside:
-                    raise HTTPException(403, "task_ids include items outside caller's org")
-            return await func(*args, **kwargs)
+                requested = {str(tid) for tid in (supplied if isinstance(supplied, list) else [supplied])}
+                if not requested.issubset(org_task_ids):
+                    raise HTTPException(403, "task_ids include items outside the caller's org")
+            return await _call(func, *args, **kwargs)
         return wrapper
     return decorator
 ```
 
 Mismatched IDs return 403 (not 404) because the caller explicitly named them — there is no enumeration concern to hide.
+
+The decorator also handles single-value `task_id` query params (e.g. `GET /feedback/query?task_id=…`) via `@enforce_query_org_scope(query_param="task_id")`; the value is normalized to a list before the subset check.
+
+Applied to **11 endpoints** in `trace_api_routes`, `legacy_span_routes`, `query_routes`, `feedback_routes`, and `task_management_routes` (search).
+
+**`inference_id` shortcut in `GET /api/v2/inferences/query`** — the route also accepts `?inference_id=…` and shortcuts to a direct fetch by ID, bypassing the `task_ids` filter. To keep tenant isolation honest, the handler now verifies the fetched inference's `task_id` is in the decorator-rewritten `task_ids` set (which is the caller's org's task list) and returns "not found" otherwise. Admin callers skip the check.
 
 ### Pattern E — Admin-only
 
@@ -540,7 +534,7 @@ No decorator change. These endpoints are gated by `@permission_checker` against 
 | Pattern | Match | Mismatch |
 |---|---|---|
 | A — Path | proceed | 404 |
-| B — Body | proceed | 404 (400 if field missing) |
+| ~~B — Body~~ | *(removed; no live callers)* | — |
 | C — Resource ID | proceed | 404 (row appears not to exist) |
 | D — Query | proceed | 403 (caller explicitly named the IDs) |
 | E — Admin-only | n/a | 403 from `permission_checker` |
@@ -563,13 +557,13 @@ Symbols: ✅ allowed for tenant keys · ❌ 403 or 404 · 🪟 allowed but filte
 
 ### One example per pattern
 
-**Pattern A — Path task_id.** Example: `POST /api/v2/tasks/{task_id}/rules`. Decorated `@enforce_org_scope`. Tenant succeeds if the path's task is in their org; 404 otherwise. Every `/tasks/{task_id}/*` endpoint in v2 plus every `{task_id}` path in v1 (continuous_eval, llm_eval, validate) follows this pattern.
+**Pattern A — Path task_id.** Example: `POST /api/v2/tasks/{task_id}/rules`. Decorated `@enforce_org_scope`. Tenant succeeds if the path's task is in their org; 404 otherwise. Covers 60 endpoints across 17 router files: every `/tasks/{task_id}/*` endpoint in v2 (task_management, validate, dataset_management) plus every `{task_id}` path in v1 (agent_polling, agentic_experiment, agentic_notebook, agentic_prompt, chatbot, continuous_eval, llm_eval, notebook, prompt_experiment, rag, rag_setting, rag_experiment, rag_notebook, transform).
 
-**Pattern B — Body task_id.** Example: `POST /api/v1/inferences` with body `{"task_id": "...", ...}`. Decorated `@enforce_body_org_scope`. Tenant succeeds if `body.task_id` is in their org; 404 otherwise. Used by ~10 POST endpoints across v1 (inferences, agentic-prompts, agentic-experiments, agentic-notebooks, prompt_experiments, agent_polling, chatbots, chat) and v2 chat.
+**~~Pattern B — Body task_id.~~** Removed during implementation. Every endpoint that originally seemed to be a Pattern B candidate (e.g. `POST /agentic-prompts`, `POST /chatbots`) actually has the shape `POST /tasks/{task_id}/<resource>` and is covered by Pattern A.
 
-**Pattern C — Resource-id-scoped.** Example: `GET /api/v1/inferences/{inference_id}`. Repository method `inference_repository.get_inference(id, org_scope)` filters at fetch time. Tenant gets the row only if its task belongs to their org; 404 otherwise. Used by ~35 endpoints across trace/span/session lookups, inference + feedback by-id, agentic prompt/experiment/notebook by-id, continuous eval by-id, prompt experiments by-id, chat conversations by-id, chatbots by-id, dataset by-id.
+**Pattern C — Resource-id-scoped.** Example: `GET /api/v1/inferences/{inference_id}`. Repository method `inference_repository.get_inference(id, org_scope)` filters at fetch time. Tenant gets the row only if its task belongs to their org; 404 otherwise. Used by trace/span/session lookups, inference + feedback by-id, agentic prompt/experiment/notebook by-id, continuous eval by-id, prompt experiments by-id, chat conversations by-id, chatbots by-id, dataset by-id. Tracked in UP-4429.
 
-**Pattern D — Query-param task_ids.** Example: `GET /api/v2/inferences/query?task_ids=...`. Decorated `@enforce_query_org_scope`. No `task_ids` → decorator injects all of the caller's org's task IDs. With `task_ids` supplied, every value must resolve to a task in the caller's org or the request 403s. Used by `GET /api/v1/traces`, `/traces/spans`, `/traces/sessions`, `/traces/users`, `/inferences`, `/api/v2/inferences/query`, `/api/v2/feedback/query`.
+**Pattern D — Query-param task_ids.** Example: `GET /api/v2/inferences/query?task_ids=...`. Decorated `@enforce_query_org_scope`. No `task_ids` → decorator injects all of the caller's org's task IDs. With `task_ids` supplied, every value must resolve to a task in the caller's org or the request 403s. Covers 11 endpoints in trace_api, legacy_span, query_routes, feedback (uses `task_id` singular), and `POST /api/v2/tasks/search`.
 
 **Pattern E — Admin-only.** Example: `POST /api/v1/traces`. Permission frozenset (`TRACES_WRITE`) excludes `TENANT-USER`. Tenant receives 403 from `permission_checker` before any handler logic runs.
 
@@ -581,13 +575,13 @@ Symbols: ✅ allowed for tenant keys · ❌ 403 or 404 · 🪟 allowed but filte
 | Task lifecycle on caller's own tasks (`POST /api/v2/tasks`, `GET/DELETE /api/v2/tasks/{id}`, unarchive) | ✅ in caller's org |
 | Task list / search (`GET /api/v2/tasks`, `POST /api/v2/tasks/search`) | 🪟 filtered to caller's org |
 | Task-scoped rules + metrics (`/api/v2/tasks/{task_id}/rules/*`, `/metrics/*`) | ✅ in caller's org (Pattern A) |
-| Inference writes (`POST /api/v1/inferences`, validate endpoints) | ✅ in caller's org (Pattern B) |
+| Inference writes (validate endpoints) | ✅ in caller's org (Pattern A — `/tasks/{task_id}/validate_*`) |
 | Inference / feedback / rule-result reads by ID | ✅ in caller's org (Pattern C) |
 | Trace / span / session / annotation **reads** | ✅ in caller's org (Patterns C and D) |
 | **Trace uploads** (`POST /api/v1/traces`) | ❌ admin-only (Pattern E) |
-| Agentic resources (prompts, experiments, notebooks; CRUD) | ✅ in caller's org (Patterns B and C) |
+| Agentic resources (prompts, experiments, notebooks; CRUD) | ✅ in caller's org (Patterns A and C) |
 | Continuous eval CRUD | ✅ in caller's org (Patterns A and C) |
-| Chat (conversations, messages, regenerate) | ✅ in caller's org (Patterns B and C) |
+| Chat (conversations, messages, regenerate) | ✅ in caller's org (Patterns A and C) |
 | Default rules — read | ✅ (globals visible to tenants) |
 | Default rules — write (`POST/DELETE /api/v2/default_rules`) | ❌ admin-only |
 | Rules search (`POST /api/v2/rules/search`) | 🪟 defaults + caller's org rules |
@@ -725,16 +719,15 @@ No behavior change. Adds the data model and the auth-context plumbing without ch
 
 ### Phase 2 — Enforcement
 
-Wires the five patterns into the endpoint surface. Still no user-visible behavior change for admin callers; tenant keys do not exist yet because the signup flow ships in Phase 3.
+Wires the four patterns into the endpoint surface. Still no user-visible behavior change for admin callers; tenant keys do not exist yet because the signup flow ships in Phase 3.
 
 1. Implement decorators in `src/utils/users.py` alongside the existing `permission_checker`:
-   - `@enforce_org_scope` (path, Pattern A)
-   - `@enforce_body_org_scope` (body, Pattern B)
-   - `@enforce_query_org_scope` (query, Pattern D)
-2. Apply Pattern A decorator to every endpoint with `{task_id}` in the URL path: task_management, continuous_eval, llm_eval, validate, and similar v1 routes.
-3. Apply Pattern B decorator to the ~10 body-task_id endpoints from the audit (inferences, agentic-prompts, agentic-experiments, agentic-notebooks, prompt_experiments, agent_polling, chatbots, chat).
-4. Apply Pattern D decorator to the 7 query-param `task_ids` endpoints.
-5. Update repository methods (Pattern C) to accept `org_scope`:
+   - `@enforce_org_scope` (path, Pattern A) — **shipped in UP-4425**
+   - `@enforce_query_org_scope` (query, Pattern D) — **shipped in UP-4425**
+   - *(Pattern B `@enforce_body_org_scope` was implemented and then deleted; no live callers — see section 7.)*
+2. Apply Pattern A decorator to every endpoint with `{task_id}` in the URL path — 60 endpoints across 17 router files (task_management, validate, dataset_management, agent_polling, agentic_experiment, agentic_notebook, agentic_prompt, chatbot, continuous_eval, llm_eval, notebook, prompt_experiment, rag, rag_setting, rag_experiment, rag_notebook, transform). **Shipped in UP-4425.**
+3. Apply Pattern D decorator to the 11 query-param endpoints (trace_api, legacy_span, query_routes, feedback, task_management/search). **Shipped in UP-4425.**
+4. Update repository methods (Pattern C) to accept `org_scope` — tracked in **UP-4429**:
    - `inference_repository.get_inference`
    - `span_repository.get_trace_by_id`, `get_span_by_id`, `get_session_by_id`, `compute_span_metrics`
    - `feedback_repository.create_feedback` (resource lookup before write)
@@ -748,9 +741,9 @@ Wires the five patterns into the endpoint surface. Still no user-visible behavio
    - `chatbot_repository.get_chatbot_by_id`
    - `annotation_repository.get_annotation_by_id`
    - `tasks_repository.get_task_by_id` plus new `list_tasks_by_org`, `get_tasks_by_ids`
-6. Extend `PermissionLevelsEnum` frozensets (section 6) to include `TENANT-USER`.
-7. Narrow `TRACES_WRITE` to exclude `TENANT-USER` (admin-only trace uploads).
-8. `POST /api/v2/tasks` handler: read `request.state.org_scope`; admin → `default` org, tenant → caller's org.
+5. Extend `PermissionLevelsEnum` frozensets (section 6) to include `TENANT-USER`. **Shipped in UP-4428.**
+6. Narrow `TRACES_WRITE` to exclude `TENANT-USER` (admin-only trace uploads). **Shipped in UP-4428.**
+7. `POST /api/v2/tasks` handler: read `request.state.org_scope`; admin → `default` org, tenant → caller's org. **Shipped in UP-4425.**
 
 **Estimated effort:** ~7-10 days human / ~5-7 hours CC. The bulk of the work is touching repositories and applying decorators across the existing endpoint surface.
 
@@ -784,7 +777,7 @@ Adds the public signup endpoint and the feature flag.
 
 ### Total estimate
 
-Roughly **16-22 days human / 10-14 hours CC** for v1. The repository work in Phase 2 dominates because the audit surfaced ~35 resource-id-scoped endpoints + 10 body-task_id endpoints + 7 query-param endpoints, each needing wiring.
+Roughly **16-22 days human / 10-14 hours CC** for v1. The repository work in Phase 2 dominates because the audit surfaced 60 path-task_id endpoints, 11 query-param endpoints, and ~35 resource-id-scoped endpoints (Pattern C, UP-4429) each needing wiring.
 
 ---
 
@@ -801,7 +794,6 @@ Three layers of testing: unit tests cover individual pieces, integration tests c
   - Migration 3: each denormalized table has `org_id` NOT NULL; backfilled values match the join chain.
 - `MultiMethodValidator` sets `request.state.org_scope` correctly for API key, JWT, and admin paths.
 - `@enforce_org_scope` raises 404 when the path's task belongs to a different org; passes when it matches; passes through for admin.
-- `@enforce_body_org_scope` raises 404 on mismatch, 400 when the field is missing, passes through for admin.
 - `@enforce_query_org_scope` raises 403 when `task_ids` contains anything outside scope; expands the filter to all-org-tasks when `task_ids` is empty; passes through for admin.
 - Repository methods (Pattern C): `get_X(id, org_scope=O2)` returns `None` for a row whose task is in `O1`. With `org_scope=None`, the row is returned regardless.
 - `permission_checker` admits/rejects `TENANT-USER` per the updated frozensets, including the negative case for `TRACES_WRITE`.
@@ -813,8 +805,7 @@ Seed two orgs (O1, O2), each with two tasks (O1 → {T1a, T1b}, O2 → {T2a, T2b
 
 - **Multi-task within org:** K1 reads both T1a and T1b. Both succeed; K1 sees every resource type across both tasks.
 - **Pattern A — Path scope:** K1 hits every `/tasks/{task_id}/*` endpoint with `task_id = T2a`. Every response is 404.
-- **Pattern B — Body scope:** K1 POSTs to every body-task_id endpoint with `body.task_id = T2a`. Every response is 404. With `body.task_id = T1a`, every response is the normal success code.
-- **Pattern C — Resource ID scope:** K1 calls every resource-id-scoped GET/PATCH/DELETE with a T2a-owned resource ID. Every response is 404. **Feedback planting:** K1 POSTs `/api/v2/feedback/{T2a_inference_id}` — expect 404, verify no feedback row written.
+- **Pattern C — Resource ID scope:** K1 calls every resource-id-scoped GET/PATCH/DELETE with a T2a-owned resource ID. Every response is 404. **Feedback planting:** K1 POSTs `/api/v2/feedback/{T2a_inference_id}` — expect 404, verify no feedback row written. **`inference_id` shortcut:** K1 hits `GET /api/v2/inferences/query?inference_id={T2a_inference_id}` — expect empty result (no 404; the empty list is the tenant-safe response shape).
 - **Pattern D — Query-param scope:** K1 calls every `task_ids`-accepting endpoint with `?task_ids=T2a`. Every response is 403. With no `task_ids`, every response transparently filters to {T1a, T1b}. With `?task_ids=T1a,T1b`, normal 200.
 - **Trace uploads blocked for tenants:** K1 POSTs `/api/v1/traces` with any payload. Expect 403. A (admin) posts the same payload — expect the existing 201 path.
 - **`POST /api/v2/tasks` routing:** K1 creates a task with the existing body shape. Verify the task lands in O1. A (admin) creates a task with the same body. Verify the task lands in the `default` org.
@@ -842,15 +833,10 @@ for route in app.routes:
     if "task_id" in route.path_params:
         assert has_decorator(handler, enforce_org_scope), \
             f"{route.path} has {{task_id}} in path but is missing @enforce_org_scope"
-    # Pattern B
-    body_model = inspect_body_model(handler)
-    if body_model is not None and "task_id" in body_model.__fields__:
-        assert has_decorator(handler, enforce_body_org_scope), \
-            f"{route.path} body has task_id but is missing @enforce_body_org_scope"
     # Pattern D
-    if "task_ids" in inspect_query_params(handler):
+    if "task_ids" in inspect_query_params(handler) or "task_id" in inspect_query_params(handler):
         assert has_decorator(handler, enforce_query_org_scope), \
-            f"{route.path} accepts task_ids query but is missing @enforce_query_org_scope"
+            f"{route.path} accepts task_ids/task_id query but is missing @enforce_query_org_scope"
 ```
 
 Pattern C is harder to assert generically. A complementary repository coverage test asserts every method on a task-scoped repository that takes a resource-id parameter also accepts `org_scope: UUID | None = None`. Easier to enforce via code review than fully automated.

--- a/genai-engine/src/db_models/agentic_annotation_models.py
+++ b/genai-engine/src/db_models/agentic_annotation_models.py
@@ -11,8 +11,8 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
+    Uuid,
 )
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import TIMESTAMP
 
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 class DatabaseAgenticAnnotation(Base):
     __tablename__ = "agentic_annotations"
     id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
         index=True,
@@ -66,7 +66,7 @@ class DatabaseAgenticAnnotation(Base):
     )
 
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,

--- a/genai-engine/src/db_models/auth_models.py
+++ b/genai-engine/src/db_models/auth_models.py
@@ -2,8 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import TIMESTAMP, Boolean, ForeignKey, Index, String, text
-from sqlalchemy.dialects import postgresql
+from sqlalchemy import TIMESTAMP, Boolean, ForeignKey, Index, String, Uuid, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from db_models.base import Base
@@ -33,7 +32,7 @@ class DatabaseApiKey(Base):
         nullable=False,
     )
     org_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=True,
     )

--- a/genai-engine/src/db_models/inference_models.py
+++ b/genai-engine/src/db_models/inference_models.py
@@ -5,7 +5,15 @@ from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
 
 from arthur_common.models.enums import InferenceFeedbackTarget
-from sqlalchemy import TIMESTAMP, ForeignKey, Index, Integer, String, UniqueConstraint, Uuid
+from sqlalchemy import (
+    TIMESTAMP,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    Uuid,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from db_models.base import Base, CustomerDataString

--- a/genai-engine/src/db_models/inference_models.py
+++ b/genai-engine/src/db_models/inference_models.py
@@ -5,8 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional
 
 from arthur_common.models.enums import InferenceFeedbackTarget
-from sqlalchemy import TIMESTAMP, ForeignKey, Index, Integer, String, UniqueConstraint
-from sqlalchemy.dialects import postgresql
+from sqlalchemy import TIMESTAMP, ForeignKey, Index, Integer, String, UniqueConstraint, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from db_models.base import Base, CustomerDataString
@@ -137,7 +136,7 @@ class DatabaseInferenceFeedback(Base):
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP, default=datetime.now())
     updated_at: Mapped[datetime] = mapped_column(TIMESTAMP, default=datetime.now())
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,

--- a/genai-engine/src/db_models/organization_models.py
+++ b/genai-engine/src/db_models/organization_models.py
@@ -1,8 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import TIMESTAMP, Boolean, Index, String, text
-from sqlalchemy.dialects import postgresql
+from sqlalchemy import TIMESTAMP, Boolean, Index, String, Uuid, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from db_models.base import Base
@@ -11,8 +10,12 @@ from db_models.base import Base
 class DatabaseOrganization(Base):
     __tablename__ = "organizations"
 
+    # Use SQLAlchemy's cross-dialect `Uuid` type instead of postgresql.UUID
+    # so the in-memory test DB (SQLite) round-trips UUIDs as strings.
+    # On PostgreSQL the underlying column is still UUID; the migration
+    # uses `sa.UUID()` which renders to the same column type.
     id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         primary_key=True,
         server_default=text("gen_random_uuid()"),
     )

--- a/genai-engine/src/db_models/rule_result_models.py
+++ b/genai-engine/src/db_models/rule_result_models.py
@@ -13,9 +13,9 @@ from sqlalchemy import (
     Integer,
     String,
     UniqueConstraint,
+    Uuid,
     text,
 )
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from db_models.base import Base, CustomerDataString
@@ -42,7 +42,7 @@ class DatabasePromptRuleResult(Base):
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP)
     updated_at: Mapped[datetime] = mapped_column(TIMESTAMP)
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,
@@ -69,7 +69,7 @@ class DatabaseResponseRuleResult(Base):
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP)
     updated_at: Mapped[datetime] = mapped_column(TIMESTAMP)
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,
@@ -94,7 +94,7 @@ class DatabaseRuleResultDetail(Base):
     score: Mapped[bool] = mapped_column(Boolean, nullable=True)
     message: Mapped[str] = mapped_column(String, nullable=True)
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,
@@ -126,7 +126,7 @@ class DatabaseHallucinationClaim(Base):
     reason: Mapped[str] = mapped_column(CustomerDataString)
     order_number: Mapped[int] = mapped_column(Integer, server_default=text("-1"))
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,
@@ -145,7 +145,7 @@ class DatabasePIIEntity(Base):
     span: Mapped[str] = mapped_column(CustomerDataString)
     confidence: Mapped[float] = mapped_column(Float, nullable=True)
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,
@@ -162,7 +162,7 @@ class DatabaseKeywordEntity(Base):
     )
     keyword: Mapped[str] = mapped_column(String)
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,
@@ -181,7 +181,7 @@ class DatabaseRegexEntity(Base):
     # Nullable for past inferences before this feature that won't have this field populated
     pattern: Mapped[str] = mapped_column(String, nullable=True)
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,
@@ -199,7 +199,7 @@ class DatabaseToxicityScore(Base):
     toxicity_score: Mapped[float] = mapped_column(Float)
     toxicity_violation_type: Mapped[str] = mapped_column(String)
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,

--- a/genai-engine/src/db_models/task_models.py
+++ b/genai-engine/src/db_models/task_models.py
@@ -4,8 +4,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional
 
-from sqlalchemy import JSON, TIMESTAMP, Boolean, ForeignKey, String
-from sqlalchemy.dialects import postgresql
+from sqlalchemy import JSON, TIMESTAMP, Boolean, ForeignKey, String, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from db_models.base import Base, IsArchivable
@@ -28,7 +27,7 @@ class DatabaseTask(Base, IsArchivable):
     is_autocreated: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     is_system_task: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     org_id: Mapped[uuid.UUID] = mapped_column(
-        postgresql.UUID(as_uuid=True),
+        Uuid(as_uuid=True),
         ForeignKey("organizations.id"),
         nullable=False,
         index=True,

--- a/genai-engine/src/dependencies.py
+++ b/genai-engine/src/dependencies.py
@@ -360,7 +360,19 @@ def get_validated_task(
     different org — 404 rather than 403 to prevent cross-org enumeration.
     """
     task_repo = get_task_repository(db_session, application_config)
-    task = task_repo.get_task_by_id(str(task_id))
+    try:
+        task = task_repo.get_task_by_id(str(task_id))
+    except HTTPException as exc:
+        # For tenant callers, normalize the "task does not exist" 404 body to
+        # match the "task in another org" 404 below — otherwise the response
+        # body differs between the two cases and acts as an enumeration oracle.
+        if exc.status_code == 404 and org_scope is not None:
+            raise HTTPException(
+                status_code=404,
+                detail="Task not found",
+                headers={"full_stacktrace": "false"},
+            )
+        raise
 
     if org_scope is not None and str(task.org_id) != str(org_scope):
         raise HTTPException(

--- a/genai-engine/src/dependencies.py
+++ b/genai-engine/src/dependencies.py
@@ -351,10 +351,23 @@ def get_validated_task(
     task_id: UUID,
     db_session: Session = Depends(get_db_session),
     application_config: ApplicationConfiguration = Depends(get_application_config),
+    org_scope: UUID | None = Depends(get_org_scope),
 ) -> Task:
-    """Dependency that validates task exists"""
+    """Dependency that validates the task exists and (for tenant callers) belongs to caller's org.
+
+    Admin callers (org_scope is None) pass through and can resolve any task.
+    Tenant callers receive a 404 if the task does not exist or belongs to a
+    different org — 404 rather than 403 to prevent cross-org enumeration.
+    """
     task_repo = get_task_repository(db_session, application_config)
     task = task_repo.get_task_by_id(str(task_id))
+
+    if org_scope is not None and str(task.org_id) != str(org_scope):
+        raise HTTPException(
+            status_code=404,
+            detail="Task not found",
+            headers={"full_stacktrace": "false"},
+        )
 
     return task
 

--- a/genai-engine/src/repositories/continuous_eval_test_run_repository.py
+++ b/genai-engine/src/repositories/continuous_eval_test_run_repository.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from db_models.agentic_annotation_models import DatabaseAgenticAnnotation
 from db_models.continuous_eval_test_run_models import DatabaseContinuousEvalTestRun
 from db_models.llm_eval_models import DatabaseContinuousEval
+from db_models.task_models import DatabaseTask
 from db_models.telemetry_models import DatabaseTraceMetadata
 from schemas.enums import TestRunStatus
 from schemas.internal_schemas import AgenticAnnotation, ContinuousEvalTestRun
@@ -105,6 +106,12 @@ class ContinuousEvalTestRunRepository:
                 detail="Continuous eval queue service is not available.",
             )
 
+        task_org_id = (
+            self.db_session.query(DatabaseTask.org_id)
+            .filter(DatabaseTask.id == task_id)
+            .scalar()
+        )
+
         annotations = []
         for trace_id in existing_trace_ids:
             annotation = DatabaseAgenticAnnotation(
@@ -116,6 +123,7 @@ class ContinuousEvalTestRunRepository:
                 test_run_id=db_test_run.id,
                 created_at=now,
                 updated_at=now,
+                org_id=task_org_id,
             )
             self.db_session.add(annotation)
             annotations.append(annotation)

--- a/genai-engine/src/repositories/continuous_eval_test_run_repository.py
+++ b/genai-engine/src/repositories/continuous_eval_test_run_repository.py
@@ -10,7 +10,7 @@ from arthur_common.models.enums import (
     PaginationSortMethod,
 )
 from fastapi import HTTPException
-from sqlalchemy import asc, desc
+from sqlalchemy import asc, desc, select
 from sqlalchemy.orm import Session
 
 from db_models.agentic_annotation_models import DatabaseAgenticAnnotation
@@ -18,6 +18,7 @@ from db_models.continuous_eval_test_run_models import DatabaseContinuousEvalTest
 from db_models.llm_eval_models import DatabaseContinuousEval
 from db_models.task_models import DatabaseTask
 from db_models.telemetry_models import DatabaseTraceMetadata
+from repositories.organizations_repository import lookup_org_id
 from schemas.enums import TestRunStatus
 from schemas.internal_schemas import AgenticAnnotation, ContinuousEvalTestRun
 from services.continuous_eval import (
@@ -106,10 +107,9 @@ class ContinuousEvalTestRunRepository:
                 detail="Continuous eval queue service is not available.",
             )
 
-        task_org_id = (
-            self.db_session.query(DatabaseTask.org_id)
-            .filter(DatabaseTask.id == task_id)
-            .scalar()
+        task_org_id = lookup_org_id(
+            self.db_session,
+            select(DatabaseTask.org_id).where(DatabaseTask.id == task_id),
         )
 
         annotations = []

--- a/genai-engine/src/repositories/continuous_evals_repository.py
+++ b/genai-engine/src/repositories/continuous_evals_repository.py
@@ -19,6 +19,7 @@ from db_models import DatabaseSpan
 from db_models.agentic_annotation_models import DatabaseAgenticAnnotation
 from db_models.continuous_eval_test_run_models import DatabaseContinuousEvalTestRun
 from db_models.llm_eval_models import DatabaseContinuousEval
+from db_models.task_models import DatabaseTask
 from schemas.internal_schemas import AgenticAnnotation, ContinuousEval
 from schemas.request_schemas import (
     ContinuousEvalCreateRequest,
@@ -450,6 +451,12 @@ class ContinuousEvalsRepository:
             if not continuous_evals:
                 return
 
+            task_org_id = (
+                self.db_session.query(DatabaseTask.org_id)
+                .filter(DatabaseTask.id == task_id)
+                .scalar()
+            )
+
             # Create pending annotations and enqueue jobs
             for continuous_eval in continuous_evals:
                 annotation = DatabaseAgenticAnnotation(
@@ -460,6 +467,7 @@ class ContinuousEvalsRepository:
                     run_status=ContinuousEvalRunStatus.PENDING,
                     created_at=datetime.now(),
                     updated_at=datetime.now(),
+                    org_id=task_org_id,
                 )
                 self.db_session.add(annotation)
                 self.db_session.commit()

--- a/genai-engine/src/repositories/continuous_evals_repository.py
+++ b/genai-engine/src/repositories/continuous_evals_repository.py
@@ -11,7 +11,7 @@ from arthur_common.models.enums import (
 )
 from arthur_common.models.task_eval_schemas import LLMEval, TraceTransformDefinition
 from fastapi import HTTPException
-from sqlalchemy import asc, case, desc, func
+from sqlalchemy import asc, case, desc, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Query, Session
 
@@ -20,6 +20,7 @@ from db_models.agentic_annotation_models import DatabaseAgenticAnnotation
 from db_models.continuous_eval_test_run_models import DatabaseContinuousEvalTestRun
 from db_models.llm_eval_models import DatabaseContinuousEval
 from db_models.task_models import DatabaseTask
+from repositories.organizations_repository import lookup_org_id
 from schemas.internal_schemas import AgenticAnnotation, ContinuousEval
 from schemas.request_schemas import (
     ContinuousEvalCreateRequest,
@@ -451,10 +452,9 @@ class ContinuousEvalsRepository:
             if not continuous_evals:
                 return
 
-            task_org_id = (
-                self.db_session.query(DatabaseTask.org_id)
-                .filter(DatabaseTask.id == task_id)
-                .scalar()
+            task_org_id = lookup_org_id(
+                self.db_session,
+                select(DatabaseTask.org_id).where(DatabaseTask.id == task_id),
             )
 
             # Create pending annotations and enqueue jobs

--- a/genai-engine/src/repositories/feedback_repository.py
+++ b/genai-engine/src/repositories/feedback_repository.py
@@ -10,8 +10,9 @@ from opentelemetry import trace
 from sqlalchemy import asc, desc
 from sqlalchemy.orm import Session
 
-from db_models import DatabaseInference, DatabaseInferenceFeedback
+from db_models import DatabaseInference, DatabaseInferenceFeedback, DatabaseTask
 from dependencies import get_db_session
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 logger = logging.getLogger()
 tracer = trace.get_tracer(__name__)
@@ -29,6 +30,14 @@ class FeedbackRepository:
         reason: str,
         user_id: str | None,
     ) -> DatabaseInferenceFeedback:
+        org_id = (
+            self.db_session.query(DatabaseTask.org_id)
+            .join(DatabaseInference, DatabaseInference.task_id == DatabaseTask.id)
+            .filter(DatabaseInference.id == inference_id)
+            .scalar()
+        )
+        if org_id is None:
+            org_id = DEFAULT_ORG_ID
         db_feedback = DatabaseInferenceFeedback(
             id=str(uuid.uuid4()),
             inference_id=inference_id,
@@ -38,6 +47,7 @@ class FeedbackRepository:
             user_id=user_id,
             created_at=datetime.now(),
             updated_at=datetime.now(),
+            org_id=org_id,
         )
         self.db_session.add(db_feedback)
         self.db_session.commit()

--- a/genai-engine/src/repositories/feedback_repository.py
+++ b/genai-engine/src/repositories/feedback_repository.py
@@ -7,12 +7,13 @@ from arthur_common.models.enums import InferenceFeedbackTarget, PaginationSortMe
 from arthur_common.models.response_schemas import InferenceFeedbackResponse
 from fastapi import Depends
 from opentelemetry import trace
-from sqlalchemy import asc, desc
+from sqlalchemy import asc, desc, select
 from sqlalchemy.orm import Session
 
 from db_models import DatabaseInference, DatabaseInferenceFeedback, DatabaseTask
 from dependencies import get_db_session
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from repositories.organizations_repository import lookup_org_id
+from utils.constants import DEFAULT_ORG_ID
 
 logger = logging.getLogger()
 tracer = trace.get_tracer(__name__)
@@ -30,14 +31,13 @@ class FeedbackRepository:
         reason: str,
         user_id: str | None,
     ) -> DatabaseInferenceFeedback:
-        org_id = (
-            self.db_session.query(DatabaseTask.org_id)
+        org_id = lookup_org_id(
+            self.db_session,
+            select(DatabaseTask.org_id)
             .join(DatabaseInference, DatabaseInference.task_id == DatabaseTask.id)
-            .filter(DatabaseInference.id == inference_id)
-            .scalar()
+            .where(DatabaseInference.id == inference_id),
+            default=DEFAULT_ORG_ID,
         )
-        if org_id is None:
-            org_id = DEFAULT_ORG_ID
         db_feedback = DatabaseInferenceFeedback(
             id=str(uuid.uuid4()),
             inference_id=inference_id,

--- a/genai-engine/src/repositories/inference_repository.py
+++ b/genai-engine/src/repositories/inference_repository.py
@@ -26,6 +26,8 @@ from db_models import (
     DatabaseRule,
     DatabaseTask,
 )
+from db_models.rule_result_models import DatabaseRuleResultDetail
+from repositories.organizations_repository import DEFAULT_ORG_ID
 from schemas.custom_exceptions import AlreadyValidatedException
 from schemas.internal_schemas import (
     Embedding,
@@ -36,14 +38,15 @@ from schemas.internal_schemas import (
     ResponseRuleResult,
     RuleEngineResult,
 )
-from repositories.organizations_repository import DEFAULT_ORG_ID
 from utils.token_count import TokenCounter
 
 logger = logging.getLogger()
 tracer = trace.get_tracer(__name__)
 
 
-def _stamp_org_id_on_prompt(db_prompt, org_id) -> None:
+def _stamp_org_id_on_prompt(
+    db_prompt: Optional[DatabaseInferencePrompt], org_id: uuid.UUID
+) -> None:
     if db_prompt is None:
         return
     for rr in db_prompt.prompt_rule_results or []:
@@ -52,7 +55,9 @@ def _stamp_org_id_on_prompt(db_prompt, org_id) -> None:
             _stamp_org_id_on_rule_details(rr.rule_details, org_id)
 
 
-def _stamp_org_id_on_response(db_response, org_id) -> None:
+def _stamp_org_id_on_response(
+    db_response: Optional[DatabaseInferenceResponse], org_id: uuid.UUID
+) -> None:
     if db_response is None:
         return
     for rr in db_response.response_rule_results or []:
@@ -61,7 +66,9 @@ def _stamp_org_id_on_response(db_response, org_id) -> None:
             _stamp_org_id_on_rule_details(rr.rule_details, org_id)
 
 
-def _stamp_org_id_on_rule_details(details, org_id) -> None:
+def _stamp_org_id_on_rule_details(
+    details: DatabaseRuleResultDetail, org_id: uuid.UUID
+) -> None:
     details.org_id = org_id
     for c in details.claims or []:
         c.org_id = org_id

--- a/genai-engine/src/repositories/inference_repository.py
+++ b/genai-engine/src/repositories/inference_repository.py
@@ -36,10 +36,43 @@ from schemas.internal_schemas import (
     ResponseRuleResult,
     RuleEngineResult,
 )
+from repositories.organizations_repository import DEFAULT_ORG_ID
 from utils.token_count import TokenCounter
 
 logger = logging.getLogger()
 tracer = trace.get_tracer(__name__)
+
+
+def _stamp_org_id_on_prompt(db_prompt, org_id) -> None:
+    if db_prompt is None:
+        return
+    for rr in db_prompt.prompt_rule_results or []:
+        rr.org_id = org_id
+        if rr.rule_details is not None:
+            _stamp_org_id_on_rule_details(rr.rule_details, org_id)
+
+
+def _stamp_org_id_on_response(db_response, org_id) -> None:
+    if db_response is None:
+        return
+    for rr in db_response.response_rule_results or []:
+        rr.org_id = org_id
+        if rr.rule_details is not None:
+            _stamp_org_id_on_rule_details(rr.rule_details, org_id)
+
+
+def _stamp_org_id_on_rule_details(details, org_id) -> None:
+    details.org_id = org_id
+    for c in details.claims or []:
+        c.org_id = org_id
+    for e in details.pii_entities or []:
+        e.org_id = org_id
+    for k in details.keyword_matches or []:
+        k.org_id = org_id
+    for r in details.regex_matches or []:
+        r.org_id = org_id
+    if details.toxicity_score is not None:
+        details.toxicity_score.org_id = org_id
 
 
 class InferenceRepository:
@@ -318,6 +351,18 @@ class InferenceRepository:
         ):
             logger.warning(f"Inference {inference.id} prompt had failed rule results.")
         db_inference = inference._to_database_model()
+
+        org_id = DEFAULT_ORG_ID
+        if task_id is not None:
+            task_org_id = (
+                self.db_session.query(DatabaseTask.org_id)
+                .filter(DatabaseTask.id == task_id)
+                .scalar()
+            )
+            if task_org_id is not None:
+                org_id = task_org_id
+        _stamp_org_id_on_prompt(db_inference.inference_prompt, org_id)
+
         self.db_session.add(db_inference)
         self.db_session.commit()
 
@@ -342,8 +387,18 @@ class InferenceRepository:
 
         db_inference_response = inference_response._to_database_model()
         try:
-            self.db_session.add(db_inference_response)
             db_inference = self.get_inference(inference_id)
+            org_id = DEFAULT_ORG_ID
+            if db_inference is not None and db_inference.task_id is not None:
+                task_org_id = (
+                    self.db_session.query(DatabaseTask.org_id)
+                    .filter(DatabaseTask.id == db_inference.task_id)
+                    .scalar()
+                )
+                if task_org_id is not None:
+                    org_id = task_org_id
+            _stamp_org_id_on_response(db_inference_response, org_id)
+            self.db_session.add(db_inference_response)
             db_inference.updated_at = datetime.now()
             db_inference.result = (
                 RuleResultEnum.PASS

--- a/genai-engine/src/repositories/inference_repository.py
+++ b/genai-engine/src/repositories/inference_repository.py
@@ -12,7 +12,7 @@ from fastapi import HTTPException
 from fastapi_pagination import Page, Params
 from fastapi_pagination.ext.sqlalchemy import paginate
 from opentelemetry import trace
-from sqlalchemy import and_, asc, desc, func, or_
+from sqlalchemy import and_, asc, desc, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, aliased, selectinload
 
@@ -27,7 +27,7 @@ from db_models import (
     DatabaseTask,
 )
 from db_models.rule_result_models import DatabaseRuleResultDetail
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from repositories.organizations_repository import lookup_org_id
 from schemas.custom_exceptions import AlreadyValidatedException
 from schemas.internal_schemas import (
     Embedding,
@@ -38,6 +38,7 @@ from schemas.internal_schemas import (
     ResponseRuleResult,
     RuleEngineResult,
 )
+from utils.constants import DEFAULT_ORG_ID
 from utils.token_count import TokenCounter
 
 logger = logging.getLogger()
@@ -359,15 +360,15 @@ class InferenceRepository:
             logger.warning(f"Inference {inference.id} prompt had failed rule results.")
         db_inference = inference._to_database_model()
 
-        org_id = DEFAULT_ORG_ID
-        if task_id is not None:
-            task_org_id = (
-                self.db_session.query(DatabaseTask.org_id)
-                .filter(DatabaseTask.id == task_id)
-                .scalar()
+        org_id = (
+            lookup_org_id(
+                self.db_session,
+                select(DatabaseTask.org_id).where(DatabaseTask.id == task_id),
+                default=DEFAULT_ORG_ID,
             )
-            if task_org_id is not None:
-                org_id = task_org_id
+            if task_id is not None
+            else DEFAULT_ORG_ID
+        )
         _stamp_org_id_on_prompt(db_inference.inference_prompt, org_id)
 
         self.db_session.add(db_inference)
@@ -395,15 +396,17 @@ class InferenceRepository:
         db_inference_response = inference_response._to_database_model()
         try:
             db_inference = self.get_inference(inference_id)
-            org_id = DEFAULT_ORG_ID
-            if db_inference is not None and db_inference.task_id is not None:
-                task_org_id = (
-                    self.db_session.query(DatabaseTask.org_id)
-                    .filter(DatabaseTask.id == db_inference.task_id)
-                    .scalar()
+            org_id = (
+                lookup_org_id(
+                    self.db_session,
+                    select(DatabaseTask.org_id).where(
+                        DatabaseTask.id == db_inference.task_id
+                    ),
+                    default=DEFAULT_ORG_ID,
                 )
-                if task_org_id is not None:
-                    org_id = task_org_id
+                if db_inference is not None and db_inference.task_id is not None
+                else DEFAULT_ORG_ID
+            )
             _stamp_org_id_on_response(db_inference_response, org_id)
             self.db_session.add(db_inference_response)
             db_inference.updated_at = datetime.now()

--- a/genai-engine/src/repositories/organizations_repository.py
+++ b/genai-engine/src/repositories/organizations_repository.py
@@ -1,16 +1,36 @@
 import uuid
-from typing import Optional
+from typing import Optional, overload
 
+from sqlalchemy import Select
 from sqlalchemy.orm import Session
 
 from db_models import DatabaseOrganization
 
-# Well-known UUIDs for the seeded organizations. Mirrored in the
-# `create_organizations_table` migration's seed INSERT and in the
-# task / annotation backfills. Application code should reference these
-# constants (not the names) — names may eventually be user-editable.
-DEFAULT_ORG_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
-SYSTEM_ORG_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+
+@overload
+def lookup_org_id(
+    session: Session, query: Select[tuple[uuid.UUID]]
+) -> Optional[uuid.UUID]: ...
+@overload
+def lookup_org_id(
+    session: Session, query: Select[tuple[uuid.UUID]], default: uuid.UUID
+) -> uuid.UUID: ...
+
+
+def lookup_org_id(
+    session: Session,
+    query: Select[tuple[uuid.UUID]],
+    default: Optional[uuid.UUID] = None,
+) -> Optional[uuid.UUID]:
+    """Run a single-column `select(Task.org_id)` query and return the org id.
+
+    Centralizes the "fetch the owning task's org_id, fall back to a default"
+    pattern used by repositories that need to denormalize org_id onto new rows
+    (e.g. feedback, agentic annotations, rule results). When a non-None
+    `default` is supplied, the return type is non-Optional.
+    """
+    org_id = session.execute(query).scalar_one_or_none()
+    return org_id if org_id is not None else default
 
 
 class OrganizationsRepository:

--- a/genai-engine/src/repositories/organizations_repository.py
+++ b/genai-engine/src/repositories/organizations_repository.py
@@ -5,6 +5,13 @@ from sqlalchemy.orm import Session
 
 from db_models import DatabaseOrganization
 
+# Well-known UUIDs for the seeded organizations. Mirrored in the
+# `create_organizations_table` migration's seed INSERT and in the
+# task / annotation backfills. Application code should reference these
+# constants (not the names) — names may eventually be user-editable.
+DEFAULT_ORG_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+SYSTEM_ORG_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+
 
 class OrganizationsRepository:
     def __init__(self, db_session: Session) -> None:

--- a/genai-engine/src/repositories/system_task_repository.py
+++ b/genai-engine/src/repositories/system_task_repository.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import Session
 
 from db_models.task_models import DatabaseTask
 from repositories.agentic_prompts_repository import AgenticPromptRepository
-from repositories.organizations_repository import SYSTEM_ORG_ID
 from schemas.agentic_prompt_schemas import AgenticPrompt
 from schemas.request_schemas import CreateAgenticPromptRequest
 from services.chatbot.chatbot_prompts import (
@@ -27,6 +26,7 @@ from utils.constants import (
     CHATBOT_PROMPT_NAME,
     CHATBOT_SUMMARIZER_PROMPT_NAME,
     EMPTY_MODEL_PROVIDER,
+    SYSTEM_ORG_ID,
 )
 
 logger = logging.getLogger(__name__)

--- a/genai-engine/src/repositories/system_task_repository.py
+++ b/genai-engine/src/repositories/system_task_repository.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from db_models.task_models import DatabaseTask
 from repositories.agentic_prompts_repository import AgenticPromptRepository
+from repositories.organizations_repository import SYSTEM_ORG_ID
 from schemas.agentic_prompt_schemas import AgenticPrompt
 from schemas.request_schemas import CreateAgenticPromptRequest
 from services.chatbot.chatbot_prompts import (
@@ -170,6 +171,7 @@ class SystemTaskRepository:
                     is_agentic=True,
                     is_autocreated=False,
                     is_system_task=True,
+                    org_id=SYSTEM_ORG_ID,
                 ),
             )
             self.db_session.commit()

--- a/genai-engine/src/repositories/tasks_repository.py
+++ b/genai-engine/src/repositories/tasks_repository.py
@@ -364,6 +364,7 @@ class TaskRepository:
         - Are agentic (is_agentic=True)
         - Do NOT get default rules (with_default_rules=False)
         - Have no task_metadata (not a registered agent)
+        - Are owned by the `default` org (OTEL auto-discovery is an admin path)
 
         Args:
             service_name: The service name to create a task for
@@ -371,6 +372,8 @@ class TaskRepository:
         Returns:
             Task: The created task
         """
+        from repositories.organizations_repository import DEFAULT_ORG_ID
+
         task_id = str(uuid.uuid4())
 
         task = Task(
@@ -380,6 +383,7 @@ class TaskRepository:
             updated_at=datetime.now(),
             is_agentic=True,
             is_autocreated=True,
+            org_id=DEFAULT_ORG_ID,
         )
 
         return self.create_task(task, with_default_rules=False)

--- a/genai-engine/src/repositories/tasks_repository.py
+++ b/genai-engine/src/repositories/tasks_repository.py
@@ -32,6 +32,7 @@ from db_models import (
     DatabaseTaskToRules,
 )
 from repositories.metrics_repository import MetricRepository
+from repositories.organizations_repository import DEFAULT_ORG_ID
 from repositories.rules_repository import RuleRepository
 from repositories.service_name_mapping_repository import (
     ServiceNameMappingRepository,
@@ -372,8 +373,6 @@ class TaskRepository:
         Returns:
             Task: The created task
         """
-        from repositories.organizations_repository import DEFAULT_ORG_ID
-
         task_id = str(uuid.uuid4())
 
         task = Task(

--- a/genai-engine/src/repositories/tasks_repository.py
+++ b/genai-engine/src/repositories/tasks_repository.py
@@ -32,7 +32,6 @@ from db_models import (
     DatabaseTaskToRules,
 )
 from repositories.metrics_repository import MetricRepository
-from repositories.organizations_repository import DEFAULT_ORG_ID
 from repositories.rules_repository import RuleRepository
 from repositories.service_name_mapping_repository import (
     ServiceNameMappingRepository,
@@ -43,6 +42,7 @@ from schemas.internal_schemas import (
     Task,
 )
 from utils import constants
+from utils.constants import DEFAULT_ORG_ID
 from utils.trace import get_nested_value
 
 tracer = trace.get_tracer(__name__)

--- a/genai-engine/src/routers/v1/agent_polling_routes.py
+++ b/genai-engine/src/routers/v1/agent_polling_routes.py
@@ -14,7 +14,7 @@ from schemas.agent_discovery_schemas import (
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import User
 from services.task.global_agent_polling_service import get_global_agent_polling_service
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 
 agent_polling_routes = APIRouter(
     prefix="/api/v1",
@@ -32,6 +32,7 @@ agent_polling_routes = APIRouter(
     status_code=status.HTTP_200_OK,
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def execute_agent_polling(
     task_id: str,
     db_session: Session = Depends(get_db_session),

--- a/genai-engine/src/routers/v1/agentic_experiment_routes.py
+++ b/genai-engine/src/routers/v1/agentic_experiment_routes.py
@@ -19,7 +19,7 @@ from schemas.agentic_experiment_schemas import (
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import Task, User
 from services.agentic_experiment_executor import AgenticExperimentExecutor
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 agentic_experiment_routes = APIRouter(
@@ -37,6 +37,7 @@ agentic_experiment_routes = APIRouter(
     tags=["Agentic Experiments"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def list_agentic_experiments(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -93,6 +94,7 @@ def list_agentic_experiments(
     tags=["Agentic Experiments"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_agentic_experiment(
     experiment_request: CreateAgenticExperimentRequest,
     db_session: Session = Depends(get_db_session),

--- a/genai-engine/src/routers/v1/agentic_notebook_routes.py
+++ b/genai-engine/src/routers/v1/agentic_notebook_routes.py
@@ -21,7 +21,7 @@ from schemas.agentic_notebook_schemas import (
 )
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import Task, User
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 agentic_notebook_routes = APIRouter(
@@ -40,6 +40,7 @@ agentic_notebook_routes = APIRouter(
     tags=["Agentic Notebooks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_agentic_notebook(
     notebook_request: CreateAgenticNotebookRequest,
     db_session: Session = Depends(get_db_session),
@@ -76,6 +77,7 @@ def create_agentic_notebook(
     tags=["Agentic Notebooks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def list_agentic_notebooks(
     pagination_parameters: Annotated[
         PaginationParameters,

--- a/genai-engine/src/routers/v1/agentic_prompt_routes.py
+++ b/genai-engine/src/routers/v1/agentic_prompt_routes.py
@@ -43,7 +43,7 @@ from schemas.response_schemas import (
 )
 from services.prompt.chat_completion_service import ChatCompletionService
 from utils.url_encoding import decode_path_param
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 agentic_prompt_routes = APIRouter(
@@ -61,6 +61,7 @@ agentic_prompt_routes = APIRouter(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_agentic_prompt(
     prompt_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     prompt_version: str = Path(
@@ -98,6 +99,7 @@ def get_agentic_prompt(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_all_agentic_prompts(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -135,6 +137,7 @@ def get_all_agentic_prompts(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_all_agentic_prompt_versions(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -434,6 +437,7 @@ def get_unsaved_prompt_variables_list(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 async def run_saved_agentic_prompt(
     prompt_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     prompt_version: str = Path(
@@ -488,6 +492,7 @@ async def run_saved_agentic_prompt(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def render_saved_agentic_prompt(
     prompt_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     prompt_version: str = Path(
@@ -548,6 +553,7 @@ def render_saved_agentic_prompt(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def save_agentic_prompt(
     prompt_config: CreateAgenticPromptRequest,
     prompt_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
@@ -577,6 +583,7 @@ def save_agentic_prompt(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def delete_agentic_prompt(
     prompt_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     db_session: Session = Depends(get_db_session),
@@ -605,6 +612,7 @@ def delete_agentic_prompt(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def delete_agentic_prompt_version(
     prompt_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     prompt_version: str = Path(
@@ -643,6 +651,7 @@ def delete_agentic_prompt_version(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_agentic_prompt_by_tag(
     prompt_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     tag: Annotated[str, Path(), AfterValidator(decode_path_param)],
@@ -677,6 +686,7 @@ def get_agentic_prompt_by_tag(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def add_tag_to_agentic_prompt_version(
     prompt_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     prompt_version: str = Path(
@@ -725,6 +735,7 @@ def add_tag_to_agentic_prompt_version(
     tags=["Prompts"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def delete_tag_from_agentic_prompt_version(
     prompt_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     prompt_version: Annotated[

--- a/genai-engine/src/routers/v1/chatbot_routes.py
+++ b/genai-engine/src/routers/v1/chatbot_routes.py
@@ -17,7 +17,7 @@ from schemas.chatbot_schemas import (
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import Task, User
 from utils.constants import GENAI_ENGINE_INGRESS_URI_ENV_VAR
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import get_env_var
 
 chatbot_routes = APIRouter(
@@ -33,6 +33,7 @@ chatbot_routes = APIRouter(
     tags=["Chatbot"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 async def stream_chatbot(
     request: Request,
     body: ChatbotRequest,

--- a/genai-engine/src/routers/v1/continuous_eval_routes.py
+++ b/genai-engine/src/routers/v1/continuous_eval_routes.py
@@ -41,7 +41,7 @@ from schemas.response_schemas import (
     ListContinuousEvalTestRunsResponse,
 )
 from utils.url_encoding import decode_path_param
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 continuous_eval_routes = APIRouter(
@@ -89,6 +89,7 @@ def get_continuous_eval_by_id(
     tags=["Continuous Evals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def list_continuous_evals(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -129,6 +130,7 @@ def list_continuous_evals(
     tags=["Continuous Evals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def list_continuous_eval_run_results(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -170,6 +172,7 @@ def list_continuous_eval_run_results(
     tags=["Continuous Evals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_continuous_eval_variables_and_mappings(
     transform_id: Annotated[
         UUID,
@@ -244,6 +247,7 @@ def get_continuous_eval_variables_and_mappings(
     tags=["Continuous Evals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_continuous_eval(
     create_request: ContinuousEvalCreateRequest,
     db_session: Session = Depends(get_db_session),
@@ -532,6 +536,7 @@ def delete_continuous_eval(
     tags=["Continuous Evals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_daily_annotation_analytics(
     start_time: Annotated[
         Optional[datetime],

--- a/genai-engine/src/routers/v1/legacy_span_routes.py
+++ b/genai-engine/src/routers/v1/legacy_span_routes.py
@@ -32,7 +32,7 @@ from routers.route_handler import GenaiEngineRoute
 from routers.v2 import multi_validator
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import User
-from utils.users import permission_checker
+from utils.users import enforce_query_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 logger = logging.getLogger(__name__)
@@ -487,6 +487,7 @@ def receive_traces(
     tags=["Spans"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_READ.value)
+@enforce_query_org_scope()
 def query_spans(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -537,6 +538,7 @@ def query_spans(
     tags=["Spans"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_READ.value)
+@enforce_query_org_scope()
 def query_spans_with_metrics(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -591,6 +593,7 @@ def query_spans_with_metrics(
     },
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_READ.value)
+@enforce_query_org_scope()
 def query_spans_by_type(
     pagination_parameters: Annotated[
         PaginationParameters,

--- a/genai-engine/src/routers/v1/llm_eval_routes.py
+++ b/genai-engine/src/routers/v1/llm_eval_routes.py
@@ -31,7 +31,7 @@ from schemas.response_schemas import (
     LLMGetAllMetadataListResponse,
 )
 from utils.url_encoding import decode_path_param
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 llm_eval_routes = APIRouter(
@@ -49,6 +49,7 @@ llm_eval_routes = APIRouter(
     tags=["LLMEvals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_llm_eval(
     eval_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     eval_version: str = Path(
@@ -86,6 +87,7 @@ def get_llm_eval(
     tags=["LLMEvals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_all_llm_eval_versions(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -126,6 +128,7 @@ def get_all_llm_eval_versions(
     tags=["LLMEvals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_all_llm_evals(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -163,6 +166,7 @@ def get_all_llm_evals(
     tags=["LLMEvals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def run_saved_llm_eval(
     completion_request: BaseCompletionRequest,
     eval_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
@@ -198,6 +202,7 @@ def run_saved_llm_eval(
     tags=["LLMEvals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def save_llm_eval(
     eval_config: CreateEvalRequest,
     eval_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
@@ -227,6 +232,7 @@ def save_llm_eval(
     tags=["LLMEvals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def delete_llm_eval(
     eval_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     db_session: Session = Depends(get_db_session),
@@ -257,6 +263,7 @@ def delete_llm_eval(
     tags=["LLMEvals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def soft_delete_llm_eval_version(
     eval_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     eval_version: str = Path(
@@ -295,6 +302,7 @@ def soft_delete_llm_eval_version(
     tags=["LLMEvals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_llm_eval_by_tag(
     eval_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     tag: Annotated[str, Path(), AfterValidator(decode_path_param)],
@@ -332,6 +340,7 @@ def get_llm_eval_by_tag(
     tags=["LLMEvals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def add_tag_to_llm_eval_version(
     eval_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     eval_version: str = Path(
@@ -376,6 +385,7 @@ def add_tag_to_llm_eval_version(
     tags=["LLMEvals"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def delete_tag_from_llm_eval_version(
     eval_name: Annotated[str, Path(), AfterValidator(decode_path_param)],
     eval_version: Annotated[

--- a/genai-engine/src/routers/v1/notebook_routes.py
+++ b/genai-engine/src/routers/v1/notebook_routes.py
@@ -21,7 +21,7 @@ from schemas.notebook_schemas import (
 from schemas.prompt_experiment_schemas import (
     PromptExperimentListResponse,
 )
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 notebook_routes = APIRouter(
@@ -40,6 +40,7 @@ notebook_routes = APIRouter(
     tags=["Notebooks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_notebook(
     notebook_request: CreateNotebookRequest,
     db_session: Session = Depends(get_db_session),
@@ -76,6 +77,7 @@ def create_notebook(
     tags=["Notebooks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def list_notebooks(
     pagination_parameters: Annotated[
         PaginationParameters,

--- a/genai-engine/src/routers/v1/prompt_experiment_routes.py
+++ b/genai-engine/src/routers/v1/prompt_experiment_routes.py
@@ -20,7 +20,7 @@ from schemas.prompt_experiment_schemas import (
     TestCaseListResponse,
 )
 from services.prompt_experiment_executor import PromptExperimentExecutor
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 prompt_experiment_routes = APIRouter(
@@ -38,6 +38,7 @@ prompt_experiment_routes = APIRouter(
     tags=["Prompt Experiments"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def list_prompt_experiments(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -100,6 +101,7 @@ def list_prompt_experiments(
     tags=["Prompt Experiments"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_prompt_experiment(
     experiment_request: CreatePromptExperimentRequest,
     db_session: Session = Depends(get_db_session),

--- a/genai-engine/src/routers/v1/rag_experiment_routes.py
+++ b/genai-engine/src/routers/v1/rag_experiment_routes.py
@@ -20,7 +20,7 @@ from schemas.rag_experiment_schemas import (
     RagTestCaseListResponse,
 )
 from services.rag_experiment_executor import RagExperimentExecutor
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 rag_experiment_routes = APIRouter(
@@ -38,6 +38,7 @@ rag_experiment_routes = APIRouter(
     tags=["RAG Experiments"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def list_rag_experiments(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -100,6 +101,7 @@ def list_rag_experiments(
     tags=["RAG Experiments"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_rag_experiment(
     experiment_request: CreateRagExperimentRequest,
     db_session: Session = Depends(get_db_session),

--- a/genai-engine/src/routers/v1/rag_notebook_routes.py
+++ b/genai-engine/src/routers/v1/rag_notebook_routes.py
@@ -21,7 +21,7 @@ from schemas.rag_notebook_schemas import (
     SetRagNotebookStateRequest,
     UpdateRagNotebookRequest,
 )
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 rag_notebook_routes = APIRouter(
@@ -40,6 +40,7 @@ rag_notebook_routes = APIRouter(
     tags=["RAG Notebooks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_rag_notebook(
     notebook_request: CreateRagNotebookRequest,
     db_session: Session = Depends(get_db_session),
@@ -76,6 +77,7 @@ def create_rag_notebook(
     tags=["RAG Notebooks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def list_rag_notebooks(
     pagination_parameters: Annotated[
         PaginationParameters,

--- a/genai-engine/src/routers/v1/rag_routes.py
+++ b/genai-engine/src/routers/v1/rag_routes.py
@@ -41,7 +41,7 @@ from schemas.response_schemas import (
     SearchRagProviderCollectionsResponse,
     SearchRagProviderConfigurationsResponse,
 )
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 rag_routes = APIRouter(
@@ -62,6 +62,7 @@ rag_router_tag = "RAG Providers"
     tags=[rag_router_tag],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_rag_provider(
     request: RagProviderConfigurationRequest,
     task_id: str = Path(
@@ -100,6 +101,7 @@ def create_rag_provider(
     tags=[rag_router_tag],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_rag_providers(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -243,6 +245,7 @@ def list_rag_provider_collections(
     tags=[rag_router_tag],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def test_rag_provider_connection(
     request: RagProviderTestConfigurationRequest,
     task_id: str = Path(

--- a/genai-engine/src/routers/v1/rag_setting_routes.py
+++ b/genai-engine/src/routers/v1/rag_setting_routes.py
@@ -37,7 +37,7 @@ from schemas.response_schemas import (
     RagSearchSettingConfigurationVersionResponse,
 )
 from utils.url_encoding import decode_path_param
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 rag_setting_routes = APIRouter(
@@ -59,6 +59,7 @@ rag_settings_router_tag = "RAG Settings"
     operation_id="create_rag_search_settings",
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_rag_search_settings(
     request: RagSearchSettingConfigurationRequest,
     task_id: str = Path(
@@ -178,6 +179,7 @@ def update_rag_search_settings(
     tags=[rag_settings_router_tag],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_task_rag_search_settings(
     pagination_parameters: Annotated[
         PaginationParameters,

--- a/genai-engine/src/routers/v1/trace_api_routes.py
+++ b/genai-engine/src/routers/v1/trace_api_routes.py
@@ -49,7 +49,7 @@ from utils.currency_display import (
     apply_currency_to_token_cost_item,
     get_display_currency,
 )
-from utils.users import permission_checker
+from utils.users import enforce_query_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 logger = logging.getLogger(__name__)
@@ -113,6 +113,7 @@ def receive_traces(
     tags=["Traces"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_READ.value)
+@enforce_query_org_scope()
 def list_traces_metadata(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -184,6 +185,7 @@ def list_traces_metadata(
     tags=["Spans"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_READ.value)
+@enforce_query_org_scope()
 def list_spans_metadata(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -387,6 +389,7 @@ def compute_span_metrics(
     tags=["Sessions"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_READ.value)
+@enforce_query_org_scope()
 def list_sessions_metadata(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -580,6 +583,7 @@ def compute_session_metrics(
     tags=["Users"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_READ.value)
+@enforce_query_org_scope()
 def list_users_metadata(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -648,6 +652,7 @@ def list_users_metadata(
     tags=["Users"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_READ.value)
+@enforce_query_org_scope()
 def get_user_details(
     user_id: str,
     task_ids: list[str] = Query(

--- a/genai-engine/src/routers/v1/transform_routes.py
+++ b/genai-engine/src/routers/v1/transform_routes.py
@@ -36,7 +36,7 @@ from schemas.response_schemas import (
     TransformExtractionResponseList,
 )
 from utils.transform_executor import execute_transform
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 transform_routes = APIRouter(
@@ -52,6 +52,7 @@ transform_routes = APIRouter(
     tags=["Transforms"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def list_transforms_for_task(
     pagination_parameters: Annotated[
         PaginationParameters,
@@ -142,6 +143,7 @@ def get_transform_dependents(
     tags=["Transforms"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_transform_for_task(
     request: NewTraceTransformRequest,
     db_session: Session = Depends(get_db_session),

--- a/genai-engine/src/routers/v2/dataset_management_routes.py
+++ b/genai-engine/src/routers/v2/dataset_management_routes.py
@@ -41,7 +41,7 @@ from utils.constants import (
     SYNTHETIC_DATA_SYSTEM_PROMPT_NAME,
     SYNTHETIC_DATASET_TASK_ID,
 )
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 dataset_management_routes = APIRouter(
@@ -63,6 +63,7 @@ datasets_router_tag = "Datasets"
     tags=[datasets_router_tag],
 )
 @permission_checker(permissions=PermissionLevelsEnum.DATASET_WRITE.value)
+@enforce_org_scope()
 def create_dataset(
     request: NewDatasetRequest,
     db_session: Session = Depends(get_db_session),
@@ -127,6 +128,7 @@ def delete_dataset(
     response_model=SearchDatasetsResponse,
 )
 @permission_checker(permissions=PermissionLevelsEnum.DATASET_READ.value)
+@enforce_org_scope()
 def get_datasets(
     pagination_parameters: Annotated[
         PaginationParameters,

--- a/genai-engine/src/routers/v2/feedback_routes.py
+++ b/genai-engine/src/routers/v2/feedback_routes.py
@@ -20,7 +20,7 @@ from routers.v2 import multi_validator
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import InferenceFeedback, User
 from utils import constants
-from utils.users import permission_checker
+from utils.users import enforce_query_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 feedback_routes = APIRouter(
@@ -62,6 +62,7 @@ def post_feedback(
     response_model=QueryFeedbackResponse,
 )
 @permission_checker(permissions=PermissionLevelsEnum.FEEDBACK_READ.value)
+@enforce_query_org_scope(query_param="task_id")
 def query_feedback(
     pagination_parameters: Annotated[
         PaginationParameters,

--- a/genai-engine/src/routers/v2/query_routes.py
+++ b/genai-engine/src/routers/v2/query_routes.py
@@ -7,7 +7,7 @@ from arthur_common.models.response_schemas import QueryInferencesResponse
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from dependencies import get_db_session
+from dependencies import get_db_session, get_org_scope
 from repositories.inference_repository import InferenceRepository
 from routers.route_handler import GenaiEngineRoute
 from routers.v2 import multi_validator
@@ -74,6 +74,7 @@ def query_inferences(
     ),
     db_session: Session = Depends(get_db_session),
     current_user: User | None = Depends(multi_validator.validate_api_multi_auth),
+    org_scope=Depends(get_org_scope),
 ) -> QueryInferencesResponse:
     try:
         valid_stage_results = {RuleResultEnum.PASS, RuleResultEnum.FAIL}
@@ -94,13 +95,23 @@ def query_inferences(
         inference_repo = InferenceRepository(db_session)
         if inference_id:
             try:
-                results = [
-                    Inference._from_database_model(
-                        inference_repo.get_inference(inference_id=inference_id),
-                    ),
-                ]
+                db_inference = inference_repo.get_inference(inference_id=inference_id)
             except HTTPException:
-                results = []
+                db_inference = None
+            # Enforce tenant isolation: if the caller is org-scoped, the
+            # inference must belong to a task in their org. We bypass this
+            # for admin callers (org_scope is None).
+            if (
+                db_inference is not None
+                and org_scope is not None
+                and str(db_inference.task_id) not in {str(t) for t in (task_ids or [])}
+            ):
+                db_inference = None
+            results = (
+                [Inference._from_database_model(db_inference)]
+                if db_inference is not None
+                else []
+            )
             count = len(results)
         else:
             results, count = inference_repo.query_inferences(

--- a/genai-engine/src/routers/v2/query_routes.py
+++ b/genai-engine/src/routers/v2/query_routes.py
@@ -14,7 +14,7 @@ from routers.v2 import multi_validator
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import Inference, User
 from utils import constants as constants
-from utils.users import permission_checker
+from utils.users import enforce_query_org_scope, permission_checker
 from utils.utils import common_pagination_parameters
 
 query_routes = APIRouter(
@@ -30,6 +30,7 @@ query_routes = APIRouter(
     response_model=QueryInferencesResponse,
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_READ.value)
+@enforce_query_org_scope()
 def query_inferences(
     pagination_parameters: Annotated[
         PaginationParameters,

--- a/genai-engine/src/routers/v2/query_routes.py
+++ b/genai-engine/src/routers/v2/query_routes.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 from typing import Annotated
 
@@ -74,7 +75,7 @@ def query_inferences(
     ),
     db_session: Session = Depends(get_db_session),
     current_user: User | None = Depends(multi_validator.validate_api_multi_auth),
-    org_scope=Depends(get_org_scope),
+    org_scope: uuid.UUID | None = Depends(get_org_scope),
 ) -> QueryInferencesResponse:
     try:
         valid_stage_results = {RuleResultEnum.PASS, RuleResultEnum.FAIL}

--- a/genai-engine/src/routers/v2/task_management_routes.py
+++ b/genai-engine/src/routers/v2/task_management_routes.py
@@ -31,7 +31,6 @@ from clients.telemetry.telemetry_client import (
 from config.cache_config import cache_config
 from dependencies import get_application_config, get_db_session
 from repositories.metrics_repository import MetricRepository
-from repositories.organizations_repository import DEFAULT_ORG_ID
 from repositories.rules_repository import RuleRepository
 from repositories.task_polling_state_repository import TaskPollingStateRepository
 from repositories.tasks_metrics_repository import TasksMetricsRepository
@@ -48,6 +47,7 @@ from schemas.internal_schemas import (
     User,
 )
 from utils import constants
+from utils.constants import DEFAULT_ORG_ID
 from utils.users import enforce_org_scope, enforce_query_org_scope, permission_checker
 from utils.utils import common_pagination_parameters, public_endpoint
 

--- a/genai-engine/src/routers/v2/task_management_routes.py
+++ b/genai-engine/src/routers/v2/task_management_routes.py
@@ -31,6 +31,7 @@ from clients.telemetry.telemetry_client import (
 from config.cache_config import cache_config
 from dependencies import get_application_config, get_db_session
 from repositories.metrics_repository import MetricRepository
+from repositories.organizations_repository import DEFAULT_ORG_ID
 from repositories.rules_repository import RuleRepository
 from repositories.task_polling_state_repository import TaskPollingStateRepository
 from repositories.tasks_metrics_repository import TasksMetricsRepository
@@ -47,7 +48,7 @@ from schemas.internal_schemas import (
     User,
 )
 from utils import constants
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, enforce_query_org_scope, permission_checker
 from utils.utils import common_pagination_parameters, public_endpoint
 
 task_management_routes = APIRouter(
@@ -89,7 +90,16 @@ def create_task(
         MetricRepository(db_session),
         application_config,
     )
-    task = Task._from_request_model(request)
+
+    # Determine the owning org from the caller's identity:
+    #   admin/JWT  (org_scope is None) -> default org
+    #   tenant key (org_scope is set)  -> caller's org
+    if current_user is not None and current_user.org_scope is not None:
+        org_id = current_user.org_scope
+    else:
+        org_id = DEFAULT_ORG_ID
+
+    task = Task._from_request_model(request, org_id=org_id)
     task = tasks_repo.create_task(task)
 
     send_telemetry_event(TelemetryEventTypes.TASK_CREATE_COMPLETED)
@@ -126,6 +136,7 @@ def get_all_tasks(
     tags=["Tasks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def archive_task(
     task_id: UUID,
     db_session: Session = Depends(get_db_session),
@@ -149,6 +160,7 @@ def archive_task(
     tags=["Tasks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def unarchive_task(
     task_id: UUID,
     db_session: Session = Depends(get_db_session),
@@ -173,6 +185,7 @@ def unarchive_task(
     tags=["Tasks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_org_scope()
 def get_task(
     task_id: UUID,
     db_session: Session = Depends(get_db_session),
@@ -306,6 +319,7 @@ def redirect_to_tasks() -> RedirectResponse:
     tags=["Tasks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_READ.value)
+@enforce_query_org_scope()
 def search_tasks(
     request: SearchTasksRequest,
     pagination_parameters: Annotated[
@@ -357,6 +371,7 @@ def search_tasks(
     tags=["Tasks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_task_rule(
     task_id: UUID,
     request: NewRuleRequest = Body(
@@ -395,6 +410,7 @@ def create_task_rule(
     tags=["Tasks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def update_task_rules(
     task_id: UUID,
     rule_id: UUID,
@@ -420,6 +436,7 @@ def update_task_rules(
     tags=["Tasks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def archive_task_rule(
     task_id: UUID,
     rule_id: UUID,
@@ -476,6 +493,7 @@ def archive_task_rule(
     tags=["Tasks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def create_task_metric(
     task_id: UUID,
     request: NewMetricRequest = Body(
@@ -506,6 +524,7 @@ def create_task_metric(
     tags=["Tasks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def update_task_metric(
     task_id: UUID,
     metric_id: UUID,
@@ -531,6 +550,7 @@ def update_task_metric(
     tags=["Tasks"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.TASK_WRITE.value)
+@enforce_org_scope()
 def archive_task_metric(
     task_id: UUID,
     metric_id: UUID,

--- a/genai-engine/src/routers/v2/validate_routes.py
+++ b/genai-engine/src/routers/v2/validate_routes.py
@@ -28,7 +28,7 @@ from schemas.internal_schemas import (
     ValidationRequest,
 )
 from scorer.score import ScorerClient
-from utils.users import permission_checker
+from utils.users import enforce_org_scope, permission_checker
 from validation.prompt import validate_prompt
 from validation.response import validate_response
 
@@ -119,6 +119,7 @@ def default_validate_response(
     tags=["Task Based Validation"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_WRITE.value)
+@enforce_org_scope()
 def validate_prompt_endpoint(
     body: PromptValidationRequest,
     task_id: UUID,
@@ -158,6 +159,7 @@ def validate_prompt_endpoint(
     tags=["Task Based Validation"],
 )
 @permission_checker(permissions=PermissionLevelsEnum.INFERENCE_WRITE.value)
+@enforce_org_scope()
 def validate_response_endpoint(
     inference_id: UUID,
     body: ResponseValidationRequest,

--- a/genai-engine/src/schemas/internal_schemas.py
+++ b/genai-engine/src/schemas/internal_schemas.py
@@ -590,6 +590,10 @@ class Task(BaseModel):
     is_autocreated: bool = False
     is_system_task: bool = False
     is_archived: bool = False
+    # FK to organizations.id; required after multi-tenancy. Caller identity
+    # determines the value at create time (admin -> default org, tenant ->
+    # caller's org). Not user-settable via request bodies.
+    org_id: uuid.UUID
     task_metadata: Optional[TaskMetadata] = None
     service_names: List[str] = Field(
         default_factory=list,
@@ -599,7 +603,7 @@ class Task(BaseModel):
     metric_links: Optional[List[TaskToMetricLink]] = None
 
     @staticmethod
-    def _from_request_model(x: NewTaskRequest) -> "Task":
+    def _from_request_model(x: NewTaskRequest, org_id: uuid.UUID) -> "Task":
         # Convert AgentMetadata request to new TaskMetadata format for DB storage
         task_metadata = None
         if x.agent_metadata:
@@ -629,6 +633,7 @@ class Task(BaseModel):
             created_at=datetime.now(),
             updated_at=datetime.now(),
             is_agentic=x.is_agentic,
+            org_id=org_id,
             task_metadata=task_metadata,
         )
 
@@ -643,6 +648,7 @@ class Task(BaseModel):
             is_autocreated=x.is_autocreated,
             is_system_task=x.is_system_task,
             is_archived=x.archived,
+            org_id=x.org_id,
             task_metadata=(
                 TaskMetadata.model_validate(x.task_metadata)
                 if x.task_metadata
@@ -665,6 +671,7 @@ class Task(BaseModel):
             is_agentic=self.is_agentic,
             is_autocreated=self.is_autocreated,
             is_system_task=self.is_system_task,
+            org_id=self.org_id,
             task_metadata=(
                 self.task_metadata.model_dump(exclude_none=True)
                 if self.task_metadata

--- a/genai-engine/src/services/system_tasks_service.py
+++ b/genai-engine/src/services/system_tasks_service.py
@@ -15,7 +15,6 @@ from db_models.agentic_prompt_models import (
     DatabaseAgenticPromptVersionTag,
 )
 from db_models.task_models import DatabaseTask
-from repositories.organizations_repository import SYSTEM_ORG_ID
 from services.synthetic_data_prompts import (
     CONVERSATION_USER_PROMPT_TEMPLATE,
     INITIAL_GENERATION_USER_PROMPT_TEMPLATE,
@@ -30,6 +29,7 @@ from utils.constants import (
     SYNTHETIC_DATA_SYSTEM_PROMPT_NAME,
     SYNTHETIC_DATASET_TASK_ID,
     SYNTHETIC_DATASET_TASK_NAME,
+    SYSTEM_ORG_ID,
 )
 
 logger = logging.getLogger(__name__)

--- a/genai-engine/src/services/system_tasks_service.py
+++ b/genai-engine/src/services/system_tasks_service.py
@@ -15,6 +15,7 @@ from db_models.agentic_prompt_models import (
     DatabaseAgenticPromptVersionTag,
 )
 from db_models.task_models import DatabaseTask
+from repositories.organizations_repository import SYSTEM_ORG_ID
 from services.synthetic_data_prompts import (
     CONVERSATION_USER_PROMPT_TEMPLATE,
     INITIAL_GENERATION_USER_PROMPT_TEMPLATE,
@@ -47,6 +48,8 @@ def _ensure_synthetic_dataset_task(db_session: Session) -> None:
     existing = db_session.get(DatabaseTask, SYNTHETIC_DATASET_TASK_ID)
     if not existing:
         logger.info(f"Creating system task: {SYNTHETIC_DATASET_TASK_NAME}")
+        # System tasks live in the seeded `system` org so they cannot be
+        # reached by tenant API keys via any org-scope code path.
         db_task = DatabaseTask(
             id=SYNTHETIC_DATASET_TASK_ID,
             name=SYNTHETIC_DATASET_TASK_NAME,
@@ -55,6 +58,7 @@ def _ensure_synthetic_dataset_task(db_session: Session) -> None:
             is_agentic=True,
             is_system_task=True,
             is_autocreated=False,
+            org_id=SYSTEM_ORG_ID,
         )
         db_session.add(db_task)
         try:

--- a/genai-engine/src/services/task/global_agent_polling_service.py
+++ b/genai-engine/src/services/task/global_agent_polling_service.py
@@ -18,6 +18,7 @@ from db_models import DatabaseTask
 from dependencies import get_db_session
 from repositories.configuration_repository import ConfigurationRepository
 from repositories.metrics_repository import MetricRepository
+from repositories.organizations_repository import DEFAULT_ORG_ID
 from repositories.rules_repository import RuleRepository
 from repositories.service_name_mapping_repository import ServiceNameMappingRepository
 from repositories.span_repository import SpanRepository
@@ -237,6 +238,7 @@ class GlobalAgentPollingService(BaseQueueService[AgentPollingJob]):
                         updated_at=datetime.now(),
                         is_agentic=True,
                         is_autocreated=True,
+                        org_id=DEFAULT_ORG_ID,
                         task_metadata=task_metadata,
                     )
                     created_task = task_repository.create_task(

--- a/genai-engine/src/services/task/global_agent_polling_service.py
+++ b/genai-engine/src/services/task/global_agent_polling_service.py
@@ -18,7 +18,6 @@ from db_models import DatabaseTask
 from dependencies import get_db_session
 from repositories.configuration_repository import ConfigurationRepository
 from repositories.metrics_repository import MetricRepository
-from repositories.organizations_repository import DEFAULT_ORG_ID
 from repositories.rules_repository import RuleRepository
 from repositories.service_name_mapping_repository import ServiceNameMappingRepository
 from repositories.span_repository import SpanRepository
@@ -32,6 +31,7 @@ from services.trace.external_trace_retrieval_service import (
     ExternalTraceRetrievalService,
 )
 from utils import constants
+from utils.constants import DEFAULT_ORG_ID
 from utils.gcp import parse_gcp_resource_path
 from utils.utils import get_env_var
 

--- a/genai-engine/src/services/trace/trace_annotation_service.py
+++ b/genai-engine/src/services/trace/trace_annotation_service.py
@@ -7,13 +7,14 @@ from arthur_common.models.enums import AgenticAnnotationType, PaginationSortMeth
 from arthur_common.models.response_schemas import (
     TraceResponse,
 )
-from sqlalchemy import asc, desc
+from sqlalchemy import asc, desc, select
 from sqlalchemy.orm import Session
 
 from custom_types import QueryT
 from db_models.agentic_annotation_models import DatabaseAgenticAnnotation
 from db_models.task_models import DatabaseTask
 from db_models.telemetry_models import DatabaseTraceMetadata
+from repositories.organizations_repository import lookup_org_id
 from schemas.internal_schemas import AgenticAnnotation
 from schemas.request_schemas import (
     AgenticAnnotationListFilterRequest,
@@ -91,10 +92,9 @@ class TraceAnnotationService:
             existing_annotation.updated_at = datetime.now()
             db_annotation = existing_annotation
         else:
-            task_org_id = (
-                self.db_session.query(DatabaseTask.org_id)
-                .filter(DatabaseTask.id == trace.task_id)
-                .scalar()
+            task_org_id = lookup_org_id(
+                self.db_session,
+                select(DatabaseTask.org_id).where(DatabaseTask.id == trace.task_id),
             )
             db_annotation = DatabaseAgenticAnnotation(
                 id=uuid.uuid4(),

--- a/genai-engine/src/services/trace/trace_annotation_service.py
+++ b/genai-engine/src/services/trace/trace_annotation_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from custom_types import QueryT
 from db_models.agentic_annotation_models import DatabaseAgenticAnnotation
+from db_models.task_models import DatabaseTask
 from db_models.telemetry_models import DatabaseTraceMetadata
 from schemas.internal_schemas import AgenticAnnotation
 from schemas.request_schemas import (
@@ -90,6 +91,11 @@ class TraceAnnotationService:
             existing_annotation.updated_at = datetime.now()
             db_annotation = existing_annotation
         else:
+            task_org_id = (
+                self.db_session.query(DatabaseTask.org_id)
+                .filter(DatabaseTask.id == trace.task_id)
+                .scalar()
+            )
             db_annotation = DatabaseAgenticAnnotation(
                 id=uuid.uuid4(),
                 annotation_type=AgenticAnnotationType.HUMAN,
@@ -98,6 +104,7 @@ class TraceAnnotationService:
                 annotation_description=annotation_request.annotation_description,
                 created_at=datetime.now(),
                 updated_at=datetime.now(),
+                org_id=task_org_id,
             )
             self.db_session.add(db_annotation)
 

--- a/genai-engine/src/utils/constants.py
+++ b/genai-engine/src/utils/constants.py
@@ -1,5 +1,6 @@
 import math
 import os
+import uuid
 
 from openinference.semconv.trace import (
     OpenInferenceSpanKindValues,
@@ -418,6 +419,13 @@ UNMAPPED_TASK_ID = "539b1da6-ebf8-4fe2-91e5-db2dc8ff626d"
 
 ARTHUR_SYSTEM_TASK_ID = "fcba8383-55ce-42ec-a5c3-528f3492ea8a"
 ARTHUR_SYSTEM_TASK_NAME = "__arthur_system_task__"
+
+# Well-known organizations seeded by the create_organizations_table migration.
+# Single source of truth — application code, migrations, and tests must
+# reference these constants instead of duplicating the UUID literals.
+# Names ("default", "system") may eventually be user-editable; the UUIDs are stable.
+DEFAULT_ORG_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+SYSTEM_ORG_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-000000000002")
 
 # Chatbot system prompt name (stored as an agentic prompt on the chatbot system task)
 CHATBOT_PROMPT_NAME = "__chatbot_prompt__"

--- a/genai-engine/src/utils/users.py
+++ b/genai-engine/src/utils/users.py
@@ -144,55 +144,6 @@ def enforce_org_scope(
     return decorator
 
 
-def enforce_body_org_scope(
-    body_field: str = "task_id",
-) -> Callable[[FunctionT], FunctionT]:
-    """Pattern B: enforce that the request body's `task_id` belongs to the caller's org.
-
-    Locates the Pydantic body model in handler kwargs by attribute presence
-    (the first kwarg that exposes `body_field`). Admin callers pass through;
-    tenants get 404 on mismatch or 400 when the field is missing.
-    """
-
-    def decorator(func: FunctionT) -> FunctionT:
-        @wraps(func)
-        async def wrapper(*args: Any, **kwargs: Any) -> Any:
-            user: User | None = kwargs.get("current_user")
-            if _is_admin(user):
-                return await _call(func, *args, **kwargs)
-
-            assert user is not None
-            body_task_id: Any = None
-            for value in kwargs.values():
-                if value is user:
-                    continue
-                if hasattr(value, body_field):
-                    body_task_id = getattr(value, body_field)
-                    if body_task_id is not None:
-                        break
-
-            if body_task_id is None:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"{body_field!r} is required in the request body",
-                )
-
-            db_session = _get_db_session_from_kwargs(kwargs)
-            task_org_id = _fetch_task_org_id(db_session, body_task_id)
-            if task_org_id is None or task_org_id != str(user.org_scope):
-                raise HTTPException(
-                    status_code=404,
-                    detail="Task not found",
-                    headers={"full_stacktrace": "false"},
-                )
-
-            return await _call(func, *args, **kwargs)
-
-        return cast(FunctionT, wrapper)
-
-    return decorator
-
-
 def _find_task_ids_holder(
     kwargs: dict[str, Any],
     field: str,

--- a/genai-engine/src/utils/users.py
+++ b/genai-engine/src/utils/users.py
@@ -5,8 +5,11 @@ from typing import Any, cast
 
 from arthur_common.models.common_schemas import AuthUserRole
 from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from custom_types.custom_types import FunctionT
+from db_models.task_models import DatabaseTask
 from schemas.internal_schemas import User
 
 
@@ -66,3 +69,228 @@ def permission_checker(permissions: frozenset[str]) -> Callable[[FunctionT], Fun
         return cast(FunctionT, wrapper)
 
     return auth_required
+
+
+def _is_admin(user: User | None) -> bool:
+    """An admin caller has no org scope. JWT users and admin API keys."""
+    return user is None or user.org_scope is None
+
+
+def _get_db_session_from_kwargs(kwargs: dict[str, Any]) -> Session:
+    db_session = kwargs.get("db_session")
+    if db_session is None:
+        raise HTTPException(
+            status_code=500,
+            detail="db_session missing from handler kwargs; org-scope enforcement requires it",
+        )
+    return cast(Session, db_session)
+
+
+def _fetch_task_org_id(db_session: Session, task_id: Any) -> str | None:
+    """Single-column lookup used by the org-scope decorators."""
+    org_id = db_session.execute(
+        select(DatabaseTask.org_id).where(DatabaseTask.id == str(task_id)),
+    ).scalar_one_or_none()
+    return None if org_id is None else str(org_id)
+
+
+async def _call(func: FunctionT, *args: Any, **kwargs: Any) -> Any:
+    if iscoroutinefunction(func):
+        return await func(*args, **kwargs)
+    return func(*args, **kwargs)
+
+
+def enforce_org_scope(
+    path_param: str = "task_id",
+) -> Callable[[FunctionT], FunctionT]:
+    """Pattern A: enforce that the path's `task_id` belongs to the caller's org.
+
+    Admin callers (`current_user.org_scope is None`) pass through. Tenant callers
+    receive 404 if the path's task does not exist or belongs to a different org.
+
+    The decorator requires that the route handler accepts `current_user` and
+    `db_session` as keyword arguments via FastAPI `Depends(...)`.
+    """
+
+    def decorator(func: FunctionT) -> FunctionT:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            user: User | None = kwargs.get("current_user")
+            if _is_admin(user):
+                return await _call(func, *args, **kwargs)
+
+            assert user is not None  # _is_admin guarantees non-None below
+            path_task_id = kwargs.get(path_param)
+            if path_task_id is None:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"path param {path_param!r} not in handler kwargs",
+                )
+
+            db_session = _get_db_session_from_kwargs(kwargs)
+            task_org_id = _fetch_task_org_id(db_session, path_task_id)
+            if task_org_id is None or task_org_id != str(user.org_scope):
+                # 404 rather than 403 to prevent enumeration of foreign tasks.
+                raise HTTPException(
+                    status_code=404,
+                    detail="Task not found",
+                    headers={"full_stacktrace": "false"},
+                )
+
+            return await _call(func, *args, **kwargs)
+
+        return cast(FunctionT, wrapper)
+
+    return decorator
+
+
+def enforce_body_org_scope(
+    body_field: str = "task_id",
+) -> Callable[[FunctionT], FunctionT]:
+    """Pattern B: enforce that the request body's `task_id` belongs to the caller's org.
+
+    Locates the Pydantic body model in handler kwargs by attribute presence
+    (the first kwarg that exposes `body_field`). Admin callers pass through;
+    tenants get 404 on mismatch or 400 when the field is missing.
+    """
+
+    def decorator(func: FunctionT) -> FunctionT:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            user: User | None = kwargs.get("current_user")
+            if _is_admin(user):
+                return await _call(func, *args, **kwargs)
+
+            assert user is not None
+            body_task_id: Any = None
+            for value in kwargs.values():
+                if value is user:
+                    continue
+                if hasattr(value, body_field):
+                    body_task_id = getattr(value, body_field)
+                    if body_task_id is not None:
+                        break
+
+            if body_task_id is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{body_field!r} is required in the request body",
+                )
+
+            db_session = _get_db_session_from_kwargs(kwargs)
+            task_org_id = _fetch_task_org_id(db_session, body_task_id)
+            if task_org_id is None or task_org_id != str(user.org_scope):
+                raise HTTPException(
+                    status_code=404,
+                    detail="Task not found",
+                    headers={"full_stacktrace": "false"},
+                )
+
+            return await _call(func, *args, **kwargs)
+
+        return cast(FunctionT, wrapper)
+
+    return decorator
+
+
+def _find_task_ids_holder(
+    kwargs: dict[str, Any],
+    field: str,
+) -> tuple[Any, str, list[str] | None] | None:
+    """Locate the `task_ids` source in handler kwargs.
+
+    Returns (holder, key_or_attr, current_value) where holder is either the
+    kwargs dict or a Pydantic model on which the field lives. Returns None when
+    the field is not present anywhere.
+
+    Looks first at direct kwargs (e.g. `task_ids: list[str] = Query(...)`),
+    then at any object in kwargs that exposes the attribute (e.g. a
+    `TraceQueryRequest` or `SearchTasksRequest` body model).
+    """
+    # Direct kwarg
+    if field in kwargs:
+        return kwargs, field, kwargs.get(field)
+
+    # Nested on a Pydantic model passed via Depends/Body
+    for value in kwargs.values():
+        if value is None:
+            continue
+        if isinstance(value, (str, bytes, int, float, bool, list, dict)):
+            # Avoid scanning primitive containers
+            continue
+        if hasattr(value, field):
+            return value, field, getattr(value, field)
+
+    return None
+
+
+def _set_task_ids(holder: Any, key_or_attr: str, value: list[str]) -> None:
+    if isinstance(holder, dict):
+        holder[key_or_attr] = value
+    else:
+        setattr(holder, key_or_attr, value)
+
+
+def enforce_query_org_scope(
+    query_param: str = "task_ids",
+) -> Callable[[FunctionT], FunctionT]:
+    """Pattern D: enforce that a list of `task_ids` is within the caller's org.
+
+    The field can live as a direct query/kwarg on the handler or as an attribute
+    on a Pydantic dependency (e.g. `TraceQueryRequest.task_ids`,
+    `SearchTasksRequest.task_ids`).
+
+    If the caller is a tenant and supplies values, every value must belong to
+    the caller's org or the request 403s. If the caller is a tenant and supplies
+    no values (None or empty), the decorator expands the filter to all of the
+    caller's org's task IDs so downstream queries are transparently scoped.
+
+    Admin callers pass through unchanged.
+    """
+
+    def decorator(func: FunctionT) -> FunctionT:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            user: User | None = kwargs.get("current_user")
+            if _is_admin(user):
+                return await _call(func, *args, **kwargs)
+
+            assert user is not None
+            db_session = _get_db_session_from_kwargs(kwargs)
+            org_task_ids = {
+                str(tid)
+                for tid in db_session.execute(
+                    select(DatabaseTask.id).where(
+                        DatabaseTask.org_id == str(user.org_scope),
+                    ),
+                ).scalars()
+            }
+
+            located = _find_task_ids_holder(kwargs, query_param)
+            if located is None:
+                # The handler doesn't accept this field — nothing to constrain.
+                return await _call(func, *args, **kwargs)
+
+            holder, key_or_attr, supplied = located
+            if not supplied:
+                # No filter supplied — inject all of the caller's org's tasks.
+                _set_task_ids(holder, key_or_attr, list(org_task_ids))
+            else:
+                # Normalize single-value (str/UUID) into a list for validation.
+                supplied_list = (
+                    [supplied] if isinstance(supplied, (str, bytes)) else list(supplied)
+                )
+                requested = {str(tid) for tid in supplied_list}
+                if not requested.issubset(org_task_ids):
+                    # 403 (not 404): the caller named these IDs explicitly.
+                    raise HTTPException(
+                        status_code=403,
+                        detail="task_ids include items outside the caller's org",
+                        headers={"full_stacktrace": "false"},
+                    )
+
+            return await _call(func, *args, **kwargs)
+
+        return cast(FunctionT, wrapper)
+
+    return decorator

--- a/genai-engine/src/utils/utils.py
+++ b/genai-engine/src/utils/utils.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Session
 
 import utils.constants as constants
 from custom_types import P, PadTextT, T
+from utils.constants import DEFAULT_ORG_ID, SYSTEM_ORG_ID
 
 _root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _genai_engine_version = None
@@ -189,11 +190,6 @@ def seed_database(db_session: Session) -> None:
     # the Postgres `now()` server default. We INSERT via raw SQL so SQLite
     # stores the UUIDs as CHAR text (matching the as_uuid=True read path)
     # rather than dialect-dependent integer/binary encodings.
-    # Imported lazily — repositories.organizations_repository -> db_models
-    # would create a circular import at module load time (db_models.base
-    # imports utils.utils for get_env_var).
-    from repositories.organizations_repository import DEFAULT_ORG_ID, SYSTEM_ORG_ID
-
     now = datetime.now(timezone.utc).isoformat()
     db_session.execute(
         text(

--- a/genai-engine/src/utils/utils.py
+++ b/genai-engine/src/utils/utils.py
@@ -6,7 +6,7 @@ import re
 import traceback
 import urllib
 from concurrent.futures import Future, ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, Literal, overload
 
 from arthur_common.models.common_schemas import (
@@ -20,6 +20,7 @@ from langchain_community.callbacks import OpenAICallbackHandler
 from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.trace import Tracer
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 import utils.constants as constants
@@ -188,10 +189,9 @@ def seed_database(db_session: Session) -> None:
     # the Postgres `now()` server default. We INSERT via raw SQL so SQLite
     # stores the UUIDs as CHAR text (matching the as_uuid=True read path)
     # rather than dialect-dependent integer/binary encodings.
-    from datetime import datetime, timezone
-
-    from sqlalchemy import text
-
+    # Imported lazily — repositories.organizations_repository -> db_models
+    # would create a circular import at module load time (db_models.base
+    # imports utils.utils for get_env_var).
     from repositories.organizations_repository import DEFAULT_ORG_ID, SYSTEM_ORG_ID
 
     now = datetime.now(timezone.utc).isoformat()

--- a/genai-engine/src/utils/utils.py
+++ b/genai-engine/src/utils/utils.py
@@ -179,9 +179,36 @@ def get_auth_logout_uri(redirect_uri: str, id_token: str) -> str:
 
 
 def seed_database(db_session: Session) -> None:
-    rows: list[Any] = []
+    # In production, Alembic seeds the well-known orgs via the
+    # `create_organizations_table` migration. The in-memory test DB
+    # uses Base.metadata.create_all() and doesn't run migrations, so
+    # we seed the same two rows here to keep ORM construction sites
+    # (system task creation, default-org backfill on POST /tasks) honest.
+    # created_at is passed explicitly because SQLite doesn't recognize
+    # the Postgres `now()` server default. We INSERT via raw SQL so SQLite
+    # stores the UUIDs as CHAR text (matching the as_uuid=True read path)
+    # rather than dialect-dependent integer/binary encodings.
+    from datetime import datetime, timezone
 
-    db_session.add_all(rows)
+    from sqlalchemy import text
+
+    from repositories.organizations_repository import DEFAULT_ORG_ID, SYSTEM_ORG_ID
+
+    now = datetime.now(timezone.utc).isoformat()
+    db_session.execute(
+        text(
+            "INSERT INTO organizations (id, name, is_system, created_at) "
+            "VALUES (:default_id, 'default', :is_system_false, :now), "
+            "       (:system_id,  'system',  :is_system_true,  :now)",
+        ),
+        {
+            "default_id": str(DEFAULT_ORG_ID),
+            "system_id": str(SYSTEM_ORG_ID),
+            "is_system_false": False,
+            "is_system_true": True,
+            "now": now,
+        },
+    )
     db_session.commit()
 
 

--- a/genai-engine/tests/conftest.py
+++ b/genai-engine/tests/conftest.py
@@ -88,13 +88,15 @@ def create_prompt_in_db(
 
 @pytest.fixture
 def create_task() -> Generator[Task, None, None]:
+    from repositories.organizations_repository import DEFAULT_ORG_ID
+
     db_session = override_get_db_session()
     application_config = get_application_config(session=db_session)
     request = NewTaskRequest(name="dummy_task_name")
     rules_repo = RuleRepository(db_session)
     metric_repo = MetricRepository(db_session)
     tasks_repo = TaskRepository(db_session, rules_repo, metric_repo, application_config)
-    task = Task._from_request_model(request)
+    task = Task._from_request_model(request, org_id=DEFAULT_ORG_ID)
     task = tasks_repo.create_task(task)
 
     yield task

--- a/genai-engine/tests/conftest.py
+++ b/genai-engine/tests/conftest.py
@@ -16,7 +16,7 @@ from arthur_common.models.request_schemas import NewRuleRequest, NewTaskRequest
 from dependencies import get_application_config
 from repositories.inference_repository import InferenceRepository
 from repositories.metrics_repository import MetricRepository
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 from repositories.rules_repository import RuleRepository
 from repositories.tasks_repository import TaskRepository
 from schemas.internal_schemas import InferencePrompt, Rule, Task

--- a/genai-engine/tests/conftest.py
+++ b/genai-engine/tests/conftest.py
@@ -16,6 +16,7 @@ from arthur_common.models.request_schemas import NewRuleRequest, NewTaskRequest
 from dependencies import get_application_config
 from repositories.inference_repository import InferenceRepository
 from repositories.metrics_repository import MetricRepository
+from repositories.organizations_repository import DEFAULT_ORG_ID
 from repositories.rules_repository import RuleRepository
 from repositories.tasks_repository import TaskRepository
 from schemas.internal_schemas import InferencePrompt, Rule, Task
@@ -88,8 +89,6 @@ def create_prompt_in_db(
 
 @pytest.fixture
 def create_task() -> Generator[Task, None, None]:
-    from repositories.organizations_repository import DEFAULT_ORG_ID
-
     db_session = override_get_db_session()
     application_config = get_application_config(session=db_session)
     request = NewTaskRequest(name="dummy_task_name")

--- a/genai-engine/tests/routes/legacy_span/conftest.py
+++ b/genai-engine/tests/routes/legacy_span/conftest.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 from typing import Generator, List
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 import pytest
 from arthur_common.models.enums import MetricType
@@ -547,12 +548,14 @@ def create_test_spans() -> Generator[List[InternalSpan], None, None]:
         name="Test Task 1",
         created_at=base_time,
         updated_at=base_time,
+        org_id=DEFAULT_ORG_ID,
     )
     task2 = DatabaseTask(
         id="task2",
         name="Test Task 2",
         created_at=base_time,
         updated_at=base_time,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(task1)
     db_session.add(task2)

--- a/genai-engine/tests/routes/legacy_span/conftest.py
+++ b/genai-engine/tests/routes/legacy_span/conftest.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 from typing import Generator, List
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 
 import pytest
 from arthur_common.models.enums import MetricType

--- a/genai-engine/tests/routes/legacy_span/test_query_span_count_filtering.py
+++ b/genai-engine/tests/routes/legacy_span/test_query_span_count_filtering.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime, timedelta
 from typing import Generator
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 
 import pytest
 

--- a/genai-engine/tests/routes/legacy_span/test_query_span_count_filtering.py
+++ b/genai-engine/tests/routes/legacy_span/test_query_span_count_filtering.py
@@ -3,6 +3,7 @@
 import uuid
 from datetime import datetime, timedelta
 from typing import Generator
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 import pytest
 
@@ -122,7 +123,7 @@ def spans_with_varied_counts() -> Generator:
             ),
         )
 
-    task = DatabaseTask(id="task_x", name="Test Task X", created_at=base_time, updated_at=base_time)
+    task = DatabaseTask(id="task_x", name="Test Task X", created_at=base_time, updated_at=base_time, org_id=DEFAULT_ORG_ID)
     db_session.add(task)
     db_session.commit()
 

--- a/genai-engine/tests/routes/trace_api/conftest.py
+++ b/genai-engine/tests/routes/trace_api/conftest.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 from typing import Generator, List
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 import pytest
 from arthur_common.models.enums import MetricType
@@ -69,6 +70,7 @@ def unmapped_task():
         updated_at=current_time,
         is_agentic=True,
         archived=False,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(unmapped_task)
     db_session.commit()
@@ -708,12 +710,14 @@ def comprehensive_test_data() -> Generator[List[InternalSpan], None, None]:
         name="API Test Task 1",
         created_at=base_time,
         updated_at=base_time,
+        org_id=DEFAULT_ORG_ID,
     )
     task2 = DatabaseTask(
         id="api_task2",
         name="API Test Task 2",
         created_at=base_time,
         updated_at=base_time,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(task1)
     db_session.add(task2)

--- a/genai-engine/tests/routes/trace_api/conftest.py
+++ b/genai-engine/tests/routes/trace_api/conftest.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 from typing import Generator, List
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 
 import pytest
 from arthur_common.models.enums import MetricType

--- a/genai-engine/tests/routes/trace_api/test_continuous_eval_execution.py
+++ b/genai-engine/tests/routes/trace_api/test_continuous_eval_execution.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Optional
 from unittest.mock import MagicMock, patch
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 
 import pytest
 from arthur_common.models.enums import AgenticAnnotationType, ContinuousEvalRunStatus

--- a/genai-engine/tests/routes/trace_api/test_continuous_eval_execution.py
+++ b/genai-engine/tests/routes/trace_api/test_continuous_eval_execution.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Optional
 from unittest.mock import MagicMock, patch
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 import pytest
 from arthur_common.models.enums import AgenticAnnotationType, ContinuousEvalRunStatus
@@ -50,6 +51,7 @@ def create_mock_annotation(
         run_status=run_status.value if run_status else None,
         created_at=datetime.now() if created_at is None else created_at,
         updated_at=datetime.now() if updated_at is None else updated_at,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(db_annotation)
     db_session.commit()
@@ -93,6 +95,7 @@ def setup_test_data():
         created_at=datetime.now(),
         updated_at=datetime.now(),
         is_agentic=True,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(task)
     db_session.commit()

--- a/genai-engine/tests/routes/trace_api/test_filtering_and_pagination.py
+++ b/genai-engine/tests/routes/trace_api/test_filtering_and_pagination.py
@@ -7,6 +7,7 @@ from arthur_common.models.enums import AgenticAnnotationType, ContinuousEvalRunS
 
 from db_models.agentic_annotation_models import DatabaseAgenticAnnotation
 from db_models.llm_eval_models import DatabaseContinuousEval
+from repositories.organizations_repository import DEFAULT_ORG_ID
 from schemas.internal_schemas import AgenticAnnotation
 from schemas.request_schemas import AgenticAnnotationRequest
 from tests.clients.base_test_client import (
@@ -113,6 +114,7 @@ def create_mock_continuous_eval_run_result(
         annotation_description=annotation_description,
         input_variables=input_variables,
         cost=cost,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(db_continuous_eval_run_result)
     db_session.commit()

--- a/genai-engine/tests/routes/trace_api/test_filtering_and_pagination.py
+++ b/genai-engine/tests/routes/trace_api/test_filtering_and_pagination.py
@@ -7,7 +7,7 @@ from arthur_common.models.enums import AgenticAnnotationType, ContinuousEvalRunS
 
 from db_models.agentic_annotation_models import DatabaseAgenticAnnotation
 from db_models.llm_eval_models import DatabaseContinuousEval
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 from schemas.internal_schemas import AgenticAnnotation
 from schemas.request_schemas import AgenticAnnotationRequest
 from tests.clients.base_test_client import (

--- a/genai-engine/tests/routes/trace_api/test_trace_annotation.py
+++ b/genai-engine/tests/routes/trace_api/test_trace_annotation.py
@@ -8,7 +8,7 @@ from arthur_common.models.response_schemas import TraceResponse
 
 from db_models.agentic_annotation_models import DatabaseAgenticAnnotation
 from db_models.llm_eval_models import DatabaseContinuousEval
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 from schemas.internal_schemas import AgenticAnnotation
 from schemas.request_schemas import AgenticAnnotationRequest
 from schemas.response_schemas import SessionTracesResponse

--- a/genai-engine/tests/routes/trace_api/test_trace_annotation.py
+++ b/genai-engine/tests/routes/trace_api/test_trace_annotation.py
@@ -8,6 +8,7 @@ from arthur_common.models.response_schemas import TraceResponse
 
 from db_models.agentic_annotation_models import DatabaseAgenticAnnotation
 from db_models.llm_eval_models import DatabaseContinuousEval
+from repositories.organizations_repository import DEFAULT_ORG_ID
 from schemas.internal_schemas import AgenticAnnotation
 from schemas.request_schemas import AgenticAnnotationRequest
 from schemas.response_schemas import SessionTracesResponse
@@ -75,6 +76,7 @@ def create_mock_annotation(
         run_status=run_status.value if run_status else None,
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(db_annotation)
     db_session.commit()

--- a/genai-engine/tests/routes/trace_api/test_trace_ingestion.py
+++ b/genai-engine/tests/routes/trace_api/test_trace_ingestion.py
@@ -3,6 +3,7 @@ import random
 from datetime import datetime
 from unittest.mock import patch
 from uuid import uuid4
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 import pytest
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
@@ -718,6 +719,7 @@ def _create_gcp_task(db_session, engine_id: str, name: str = None) -> DatabaseTa
         is_autocreated=False,
         task_metadata=task_metadata.model_dump(mode="json"),
         archived=False,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(db_task)
     db_session.commit()
@@ -962,6 +964,7 @@ def test_resolve_task_id_existing_mapping_takes_priority_over_resource_id():
         is_agentic=True,
         is_autocreated=True,
         archived=False,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(other_task)
     db_session.commit()

--- a/genai-engine/tests/routes/trace_api/test_trace_ingestion.py
+++ b/genai-engine/tests/routes/trace_api/test_trace_ingestion.py
@@ -3,7 +3,7 @@ import random
 from datetime import datetime
 from unittest.mock import patch
 from uuid import uuid4
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 
 import pytest
 from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue

--- a/genai-engine/tests/unit/repositories/test_service_name_mapping_repository.py
+++ b/genai-engine/tests/unit/repositories/test_service_name_mapping_repository.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 
 import pytest
 import sqlalchemy as sa

--- a/genai-engine/tests/unit/repositories/test_service_name_mapping_repository.py
+++ b/genai-engine/tests/unit/repositories/test_service_name_mapping_repository.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 import pytest
 import sqlalchemy as sa
@@ -27,6 +28,7 @@ def test_task():
         updated_at=current_time,
         is_agentic=True,
         archived=False,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(task)
     db_session.commit()
@@ -51,6 +53,7 @@ def test_task_2():
         updated_at=current_time,
         is_agentic=True,
         archived=False,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(task)
     db_session.commit()

--- a/genai-engine/tests/unit/repositories/test_trace_retention_repository.py
+++ b/genai-engine/tests/unit/repositories/test_trace_retention_repository.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime, timedelta, timezone
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 
 import pytest
 from sqlalchemy import delete, select

--- a/genai-engine/tests/unit/repositories/test_trace_retention_repository.py
+++ b/genai-engine/tests/unit/repositories/test_trace_retention_repository.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import datetime, timedelta, timezone
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 import pytest
 from sqlalchemy import delete, select
@@ -83,6 +84,7 @@ def _make_task(session: Session) -> str:
         updated_at=now,
         is_agentic=False,
         archived=False,
+        org_id=DEFAULT_ORG_ID,
     )
     session.add(task)
     session.commit()
@@ -330,6 +332,7 @@ def test_delete_trace_batch_removes_agentic_annotations() -> None:
             trace_id=trace_to_delete,
             created_at=now,
             updated_at=now,
+            org_id=DEFAULT_ORG_ID,
         )
     )
     db_session.add(
@@ -340,6 +343,7 @@ def test_delete_trace_batch_removes_agentic_annotations() -> None:
             trace_id=trace_survivor,
             created_at=now,
             updated_at=now,
+            org_id=DEFAULT_ORG_ID,
         )
     )
     db_session.commit()

--- a/genai-engine/tests/unit/routes/feedback/test_query_feedback.py
+++ b/genai-engine/tests/unit/routes/feedback/test_query_feedback.py
@@ -17,6 +17,7 @@ from db_models import (
     DatabaseInferenceResponse,
     DatabaseInferenceResponseContent,
 )
+from repositories.organizations_repository import DEFAULT_ORG_ID
 from tests.clients.base_test_client import GenaiEngineTestClientBase
 from tests.unit.routes.feedback import FEEDBACK_DB_SESSION
 
@@ -105,6 +106,7 @@ def initialize_feedback(db_session: Session) -> None:
             score=score,
             reason=reason,
             user_id=user_id,
+            org_id=DEFAULT_ORG_ID,
         )
         db_session.add(db_feedback)
     db_session.commit()

--- a/genai-engine/tests/unit/routes/feedback/test_query_feedback.py
+++ b/genai-engine/tests/unit/routes/feedback/test_query_feedback.py
@@ -17,7 +17,7 @@ from db_models import (
     DatabaseInferenceResponse,
     DatabaseInferenceResponseContent,
 )
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 from tests.clients.base_test_client import GenaiEngineTestClientBase
 from tests.unit.routes.feedback import FEEDBACK_DB_SESSION
 

--- a/genai-engine/tests/unit/routes/inferences/conftest.py
+++ b/genai-engine/tests/unit/routes/inferences/conftest.py
@@ -8,6 +8,7 @@ from db_models import DatabaseInference
 from dependencies import get_application_config
 from repositories.inference_repository import InferenceRepository
 from repositories.metrics_repository import MetricRepository
+from repositories.organizations_repository import DEFAULT_ORG_ID
 from repositories.rules_repository import RuleRepository
 from repositories.tasks_repository import TaskRepository
 from schemas.internal_schemas import (
@@ -27,8 +28,6 @@ from tests.clients.base_test_client import override_get_db_session
 
 @pytest.fixture
 def create_task() -> Generator[Task, None, None]:
-    from repositories.organizations_repository import DEFAULT_ORG_ID
-
     db_session = override_get_db_session()
     application_config = get_application_config(session=db_session)
     request = NewTaskRequest(name="dummy_task_name")

--- a/genai-engine/tests/unit/routes/inferences/conftest.py
+++ b/genai-engine/tests/unit/routes/inferences/conftest.py
@@ -8,7 +8,7 @@ from db_models import DatabaseInference
 from dependencies import get_application_config
 from repositories.inference_repository import InferenceRepository
 from repositories.metrics_repository import MetricRepository
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 from repositories.rules_repository import RuleRepository
 from repositories.tasks_repository import TaskRepository
 from schemas.internal_schemas import (

--- a/genai-engine/tests/unit/routes/inferences/conftest.py
+++ b/genai-engine/tests/unit/routes/inferences/conftest.py
@@ -27,13 +27,15 @@ from tests.clients.base_test_client import override_get_db_session
 
 @pytest.fixture
 def create_task() -> Generator[Task, None, None]:
+    from repositories.organizations_repository import DEFAULT_ORG_ID
+
     db_session = override_get_db_session()
     application_config = get_application_config(session=db_session)
     request = NewTaskRequest(name="dummy_task_name")
     rules_repo = RuleRepository(db_session)
     metric_repo = MetricRepository(db_session)
     tasks_repo = TaskRepository(db_session, rules_repo, metric_repo, application_config)
-    task = Task._from_request_model(request)
+    task = Task._from_request_model(request, org_id=DEFAULT_ORG_ID)
     task = tasks_repo.create_task(task)
 
     yield task

--- a/genai-engine/tests/unit/routes/tasks/test_agent_tasks.py
+++ b/genai-engine/tests/unit/routes/tasks/test_agent_tasks.py
@@ -3,7 +3,7 @@ import random
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 
 import pytest
 from openinference.semconv.trace import OpenInferenceSpanKindValues

--- a/genai-engine/tests/unit/routes/tasks/test_agent_tasks.py
+++ b/genai-engine/tests/unit/routes/tasks/test_agent_tasks.py
@@ -3,6 +3,7 @@ import random
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 import pytest
 from openinference.semconv.trace import OpenInferenceSpanKindValues
@@ -107,6 +108,7 @@ def test_get_agent_tasks_gcp_task(client: GenaiEngineTestClientBase):
             is_autocreated=False,
             task_metadata=task_metadata.model_dump(mode="json"),
             archived=False,
+            org_id=DEFAULT_ORG_ID,
         )
         db_session.add(db_task)
         db_session.commit()
@@ -307,6 +309,7 @@ def test_get_agent_tasks_with_last_fetched(client: GenaiEngineTestClientBase):
             is_autocreated=False,
             task_metadata=task_metadata.model_dump(mode="json"),
             archived=False,
+            org_id=DEFAULT_ORG_ID,
         )
         db_session.add(db_task)
 
@@ -381,6 +384,7 @@ def test_get_agent_tasks_autocreated_otel_task(client: GenaiEngineTestClientBase
             is_autocreated=True,  # Key: auto-created from traces
             task_metadata=None,  # No provider metadata
             archived=False,
+            org_id=DEFAULT_ORG_ID,
         )
         db_session.add(db_task)
         db_session.commit()

--- a/genai-engine/tests/unit/routes/tasks/test_continuous_eval_crud_routes.py
+++ b/genai-engine/tests/unit/routes/tasks/test_continuous_eval_crud_routes.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Optional
 from unittest.mock import MagicMock, patch
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 import pytest
 from arthur_common.models.enums import AgenticAnnotationType, ContinuousEvalRunStatus
@@ -77,6 +78,7 @@ def create_mock_annotation(
         run_status=run_status.value if run_status else None,
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(db_annotation)
     db_session.commit()
@@ -112,6 +114,7 @@ def setup_test_data():
         created_at=datetime.now(),
         updated_at=datetime.now(),
         is_agentic=True,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(task)
     db_session.commit()
@@ -2110,6 +2113,7 @@ def test_get_daily_annotation_analytics_time_filtering(
         cost=0.05,
         created_at=base_date,
         updated_at=base_date,
+        org_id=DEFAULT_ORG_ID,
     )
     annotation_passed_2 = DatabaseAgenticAnnotation(
         id=uuid.uuid4(),
@@ -2121,6 +2125,7 @@ def test_get_daily_annotation_analytics_time_filtering(
         cost=0.03,
         created_at=base_date,
         updated_at=base_date,
+        org_id=DEFAULT_ORG_ID,
     )
     annotation_failed = DatabaseAgenticAnnotation(
         id=uuid.uuid4(),
@@ -2132,6 +2137,7 @@ def test_get_daily_annotation_analytics_time_filtering(
         cost=0.02,
         created_at=base_date,
         updated_at=base_date,
+        org_id=DEFAULT_ORG_ID,
     )
     annotation_error = DatabaseAgenticAnnotation(
         id=uuid.uuid4(),
@@ -2143,6 +2149,7 @@ def test_get_daily_annotation_analytics_time_filtering(
         cost=0.01,
         created_at=base_date,
         updated_at=base_date,
+        org_id=DEFAULT_ORG_ID,
     )
     annotation_skipped = DatabaseAgenticAnnotation(
         id=uuid.uuid4(),
@@ -2154,6 +2161,7 @@ def test_get_daily_annotation_analytics_time_filtering(
         cost=None,
         created_at=base_date,
         updated_at=base_date,
+        org_id=DEFAULT_ORG_ID,
     )
 
     # Create annotations for yesterday
@@ -2168,6 +2176,7 @@ def test_get_daily_annotation_analytics_time_filtering(
         cost=0.04,
         created_at=yesterday,
         updated_at=yesterday,
+        org_id=DEFAULT_ORG_ID,
     )
     annotation_yesterday_failed = DatabaseAgenticAnnotation(
         id=uuid.uuid4(),
@@ -2179,6 +2188,7 @@ def test_get_daily_annotation_analytics_time_filtering(
         cost=0.02,
         created_at=yesterday,
         updated_at=yesterday,
+        org_id=DEFAULT_ORG_ID,
     )
 
     annotations = [

--- a/genai-engine/tests/unit/routes/tasks/test_continuous_eval_crud_routes.py
+++ b/genai-engine/tests/unit/routes/tasks/test_continuous_eval_crud_routes.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Optional
 from unittest.mock import MagicMock, patch
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 
 import pytest
 from arthur_common.models.enums import AgenticAnnotationType, ContinuousEvalRunStatus

--- a/genai-engine/tests/unit/routes/transforms/test_transform_execution.py
+++ b/genai-engine/tests/unit/routes/transforms/test_transform_execution.py
@@ -3,6 +3,7 @@
 import json
 import uuid
 from datetime import datetime
+from repositories.organizations_repository import DEFAULT_ORG_ID
 
 import pytest
 from sqlalchemy.orm import Session
@@ -31,6 +32,7 @@ def setup_test_data():
         name="Test Task for Transform Execution",
         created_at=datetime.now(),
         updated_at=datetime.now(),
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(task)
     db_session.commit()
@@ -506,6 +508,7 @@ def test_execute_transform_with_multiple_matching_spans(
         created_at=datetime.now(),
         updated_at=datetime.now(),
         is_agentic=True,
+        org_id=DEFAULT_ORG_ID,
     )
     db_session.add(task)
     db_session.commit()

--- a/genai-engine/tests/unit/routes/transforms/test_transform_execution.py
+++ b/genai-engine/tests/unit/routes/transforms/test_transform_execution.py
@@ -3,7 +3,7 @@
 import json
 import uuid
 from datetime import datetime
-from repositories.organizations_repository import DEFAULT_ORG_ID
+from utils.constants import DEFAULT_ORG_ID
 
 import pytest
 from sqlalchemy.orm import Session

--- a/genai-engine/tests/unit/utils/test_users.py
+++ b/genai-engine/tests/unit/utils/test_users.py
@@ -1,11 +1,21 @@
+import uuid
+from unittest.mock import MagicMock
+
 import pytest
 from arthur_common.models.common_schemas import AuthUserRole
 from fastapi import HTTPException
+from pydantic import BaseModel
 
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import User
 from utils import constants
-from utils.users import get_user_info_from_payload, permission_checker
+from utils.users import (
+    enforce_body_org_scope,
+    enforce_org_scope,
+    enforce_query_org_scope,
+    get_user_info_from_payload,
+    permission_checker,
+)
 
 pytest_plugins = ("pytest_asyncio",)
 
@@ -247,3 +257,253 @@ async def test_org_admin_passes_every_permission(permission):
 
     result = await x(current_user=_user_with_role(constants.ORG_ADMIN))
     assert result is True
+
+
+# -------------------------------------------------------------------------
+# Org-scope enforcement decorators (Patterns A, B, D — UP-4425).
+# -------------------------------------------------------------------------
+
+
+O1 = uuid.UUID("11111111-1111-1111-1111-111111111111")
+O2 = uuid.UUID("22222222-2222-2222-2222-222222222222")
+T1A = uuid.UUID("aaaaaaa1-0000-0000-0000-000000000000")  # belongs to O1
+T1B = uuid.UUID("aaaaaaa2-0000-0000-0000-000000000000")  # belongs to O1
+T2A = uuid.UUID("bbbbbbb1-0000-0000-0000-000000000000")  # belongs to O2
+
+
+def _admin() -> User:
+    return User(
+        id="admin-id",
+        email="admin@example.com",
+        roles=[
+            AuthUserRole(
+                id="0",
+                name=constants.ORG_ADMIN,
+                description="DUMMY",
+                composite=True,
+            ),
+        ],
+        org_scope=None,
+    )
+
+
+def _tenant(org_id: uuid.UUID) -> User:
+    return User(
+        id="tenant-id",
+        email="tenant@example.com",
+        roles=[
+            AuthUserRole(
+                id="0",
+                name=constants.TENANT_USER,
+                description="DUMMY",
+                composite=True,
+            ),
+        ],
+        org_scope=org_id,
+    )
+
+
+def _mock_session_with_task_org_map(task_to_org: dict[uuid.UUID, uuid.UUID]) -> MagicMock:
+    """Build a MagicMock SQLAlchemy session that responds to:
+
+    - select(DatabaseTask.org_id).where(DatabaseTask.id == <id>)   -> scalar_one_or_none
+    - select(DatabaseTask.id).where(DatabaseTask.org_id == <org>)  -> scalars()
+    """
+    session = MagicMock()
+
+    def execute_side_effect(stmt):
+        # Read the WHERE clause params without rendering literals; UUID
+        # types don't always have a literal processor for the default dialect.
+        compiled = stmt.compile()
+        params = dict(compiled.params)
+        compiled_str = str(compiled)
+        result = MagicMock()
+        if "tasks.org_id" in compiled_str and "WHERE tasks.id" in compiled_str:
+            # SELECT tasks.org_id WHERE tasks.id = :id_1
+            requested_id = next(iter(params.values()))
+            org = task_to_org.get(uuid.UUID(str(requested_id)))
+            result.scalar_one_or_none.return_value = org
+        elif "tasks.id" in compiled_str and "WHERE tasks.org_id" in compiled_str:
+            # SELECT tasks.id WHERE tasks.org_id = :org_id_1
+            requested_org = str(next(iter(params.values())))
+            ids = [t for t, o in task_to_org.items() if str(o) == requested_org]
+            result.scalars.return_value = iter(ids)
+        return result
+
+    session.execute.side_effect = execute_side_effect
+    return session
+
+
+# Pattern A — @enforce_org_scope
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_org_scope_admin_passthrough():
+    @enforce_org_scope()
+    def handler(task_id, db_session, current_user) -> bool:
+        return True
+
+    result = await handler(
+        task_id=T2A, db_session=MagicMock(), current_user=_admin()
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_org_scope_tenant_match():
+    @enforce_org_scope()
+    def handler(task_id, db_session, current_user) -> bool:
+        return True
+
+    session = _mock_session_with_task_org_map({T1A: O1, T1B: O1, T2A: O2})
+    result = await handler(
+        task_id=T1A, db_session=session, current_user=_tenant(O1)
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_org_scope_tenant_mismatch_returns_404():
+    @enforce_org_scope()
+    def handler(task_id, db_session, current_user) -> bool:
+        return True
+
+    session = _mock_session_with_task_org_map({T1A: O1, T2A: O2})
+    with pytest.raises(HTTPException) as exc:
+        await handler(task_id=T2A, db_session=session, current_user=_tenant(O1))
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_org_scope_tenant_task_missing_returns_404():
+    @enforce_org_scope()
+    def handler(task_id, db_session, current_user) -> bool:
+        return True
+
+    session = _mock_session_with_task_org_map({})  # no tasks
+    with pytest.raises(HTTPException) as exc:
+        await handler(task_id=T1A, db_session=session, current_user=_tenant(O1))
+    assert exc.value.status_code == 404
+
+
+# Pattern B — @enforce_body_org_scope
+
+
+class _BodyWithTaskId(BaseModel):
+    task_id: uuid.UUID
+    name: str = "x"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_body_org_scope_admin_passthrough():
+    @enforce_body_org_scope()
+    def handler(body, db_session, current_user) -> bool:
+        return True
+
+    result = await handler(
+        body=_BodyWithTaskId(task_id=T2A),
+        db_session=MagicMock(),
+        current_user=_admin(),
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_body_org_scope_tenant_match():
+    @enforce_body_org_scope()
+    def handler(body, db_session, current_user) -> bool:
+        return True
+
+    session = _mock_session_with_task_org_map({T1A: O1, T2A: O2})
+    result = await handler(
+        body=_BodyWithTaskId(task_id=T1A),
+        db_session=session,
+        current_user=_tenant(O1),
+    )
+    assert result is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_body_org_scope_tenant_mismatch_returns_404():
+    @enforce_body_org_scope()
+    def handler(body, db_session, current_user) -> bool:
+        return True
+
+    session = _mock_session_with_task_org_map({T1A: O1, T2A: O2})
+    with pytest.raises(HTTPException) as exc:
+        await handler(
+            body=_BodyWithTaskId(task_id=T2A),
+            db_session=session,
+            current_user=_tenant(O1),
+        )
+    assert exc.value.status_code == 404
+
+
+# Pattern D — @enforce_query_org_scope
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_query_org_scope_admin_passthrough():
+    @enforce_query_org_scope()
+    def handler(task_ids, db_session, current_user) -> list:
+        return task_ids
+
+    result = await handler(
+        task_ids=[T2A], db_session=MagicMock(), current_user=_admin()
+    )
+    assert result == [T2A]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_query_org_scope_tenant_match():
+    @enforce_query_org_scope()
+    def handler(task_ids, db_session, current_user) -> list:
+        return task_ids
+
+    session = _mock_session_with_task_org_map({T1A: O1, T1B: O1, T2A: O2})
+    result = await handler(
+        task_ids=[T1A, T1B], db_session=session, current_user=_tenant(O1)
+    )
+    assert {str(t) for t in result} == {str(T1A), str(T1B)}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_query_org_scope_tenant_outside_returns_403():
+    @enforce_query_org_scope()
+    def handler(task_ids, db_session, current_user) -> list:
+        return task_ids
+
+    session = _mock_session_with_task_org_map({T1A: O1, T2A: O2})
+    with pytest.raises(HTTPException) as exc:
+        await handler(
+            task_ids=[T2A], db_session=session, current_user=_tenant(O1)
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit_tests
+async def test_enforce_query_org_scope_tenant_empty_injects_org_tasks():
+    captured: dict = {}
+
+    @enforce_query_org_scope()
+    def handler(task_ids, db_session, current_user) -> bool:
+        captured["task_ids"] = task_ids
+        return True
+
+    session = _mock_session_with_task_org_map({T1A: O1, T1B: O1, T2A: O2})
+    await handler(task_ids=[], db_session=session, current_user=_tenant(O1))
+
+    # Should have been expanded to the caller's org's tasks (in some order).
+    # The decorator stores ids as strings for downstream query filters.
+    assert {str(t) for t in captured["task_ids"]} == {str(T1A), str(T1B)}

--- a/genai-engine/tests/unit/utils/test_users.py
+++ b/genai-engine/tests/unit/utils/test_users.py
@@ -4,13 +4,11 @@ from unittest.mock import MagicMock
 import pytest
 from arthur_common.models.common_schemas import AuthUserRole
 from fastapi import HTTPException
-from pydantic import BaseModel
 
 from schemas.enums import PermissionLevelsEnum
 from schemas.internal_schemas import User
 from utils import constants
 from utils.users import (
-    enforce_body_org_scope,
     enforce_org_scope,
     enforce_query_org_scope,
     get_user_info_from_payload,
@@ -303,7 +301,9 @@ def _tenant(org_id: uuid.UUID) -> User:
     )
 
 
-def _mock_session_with_task_org_map(task_to_org: dict[uuid.UUID, uuid.UUID]) -> MagicMock:
+def _mock_session_with_task_org_map(
+    task_to_org: dict[uuid.UUID, uuid.UUID],
+) -> MagicMock:
     """Build a MagicMock SQLAlchemy session that responds to:
 
     - select(DatabaseTask.org_id).where(DatabaseTask.id == <id>)   -> scalar_one_or_none
@@ -344,9 +344,7 @@ async def test_enforce_org_scope_admin_passthrough():
     def handler(task_id, db_session, current_user) -> bool:
         return True
 
-    result = await handler(
-        task_id=T2A, db_session=MagicMock(), current_user=_admin()
-    )
+    result = await handler(task_id=T2A, db_session=MagicMock(), current_user=_admin())
     assert result is True
 
 
@@ -358,9 +356,7 @@ async def test_enforce_org_scope_tenant_match():
         return True
 
     session = _mock_session_with_task_org_map({T1A: O1, T1B: O1, T2A: O2})
-    result = await handler(
-        task_id=T1A, db_session=session, current_user=_tenant(O1)
-    )
+    result = await handler(task_id=T1A, db_session=session, current_user=_tenant(O1))
     assert result is True
 
 
@@ -387,62 +383,6 @@ async def test_enforce_org_scope_tenant_task_missing_returns_404():
     session = _mock_session_with_task_org_map({})  # no tasks
     with pytest.raises(HTTPException) as exc:
         await handler(task_id=T1A, db_session=session, current_user=_tenant(O1))
-    assert exc.value.status_code == 404
-
-
-# Pattern B — @enforce_body_org_scope
-
-
-class _BodyWithTaskId(BaseModel):
-    task_id: uuid.UUID
-    name: str = "x"
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit_tests
-async def test_enforce_body_org_scope_admin_passthrough():
-    @enforce_body_org_scope()
-    def handler(body, db_session, current_user) -> bool:
-        return True
-
-    result = await handler(
-        body=_BodyWithTaskId(task_id=T2A),
-        db_session=MagicMock(),
-        current_user=_admin(),
-    )
-    assert result is True
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit_tests
-async def test_enforce_body_org_scope_tenant_match():
-    @enforce_body_org_scope()
-    def handler(body, db_session, current_user) -> bool:
-        return True
-
-    session = _mock_session_with_task_org_map({T1A: O1, T2A: O2})
-    result = await handler(
-        body=_BodyWithTaskId(task_id=T1A),
-        db_session=session,
-        current_user=_tenant(O1),
-    )
-    assert result is True
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit_tests
-async def test_enforce_body_org_scope_tenant_mismatch_returns_404():
-    @enforce_body_org_scope()
-    def handler(body, db_session, current_user) -> bool:
-        return True
-
-    session = _mock_session_with_task_org_map({T1A: O1, T2A: O2})
-    with pytest.raises(HTTPException) as exc:
-        await handler(
-            body=_BodyWithTaskId(task_id=T2A),
-            db_session=session,
-            current_user=_tenant(O1),
-        )
     assert exc.value.status_code == 404
 
 
@@ -485,9 +425,7 @@ async def test_enforce_query_org_scope_tenant_outside_returns_403():
 
     session = _mock_session_with_task_org_map({T1A: O1, T2A: O2})
     with pytest.raises(HTTPException) as exc:
-        await handler(
-            task_ids=[T2A], db_session=session, current_user=_tenant(O1)
-        )
+        await handler(task_ids=[T2A], db_session=session, current_user=_tenant(O1))
     assert exc.value.status_code == 403
 
 

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -1,11 +1,19 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'darwin'",
     "sys_platform == 'linux' or sys_platform == 'win32'",
     "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
+
+[options]
+exclude-newer = "2026-05-17T20:03:34.407943Z"
+exclude-newer-span = "P3D"
+
+[options.exclude-newer-package]
+arthur-common = false
+torch = false
 
 [[package]]
 name = "aiofiles"


### PR DESCRIPTION
## Summary

Implements API-level enforcement of organization scope for genai-engine routes. Tenant-scoped callers (`request.state.org_scope`, set by `multi_validator` from `api_key.org_id`) are blocked from touching another org's tasks at the path and query layers. Admin callers (`org_scope is None`) pass through unchanged.

## Decorators (`src/utils/users.py`)

- **`@enforce_org_scope()`** — Pattern A. Resolves the path's `{task_id}` to its `org_id` and 404s on mismatch.
- **`@enforce_query_org_scope()`** — Pattern D. Validates that supplied `task_ids` belong to the caller's org (403 on outside-org IDs); when absent, injects the full set of the caller's org's task IDs so downstream filters are transparent.

Both 404 (not 403) on miss/mismatch — `404` chosen to avoid cross-org enumeration oracles.

The `enforce_body_org_scope` (Pattern B) decorator was implemented but ultimately deleted in this PR — no current endpoint takes `task_id` in the request body (every `task_id`-using route puts it in the path).

## Coverage

- **Pattern A**: applied to all **60** path-`{task_id}` endpoints across 17 router files (task_management, validate, rag, rag_setting, agent_polling, agentic_experiment, agentic_notebook, agentic_prompt, chatbot, continuous_eval, llm_eval, notebook, prompt_experiment, rag_experiment, rag_notebook, transform, dataset_management).
- **Pattern D**: applied to all **11** query-`task_ids` endpoints (trace_api, legacy_span, query_routes, feedback, task_management/search).
- `get_validated_task` dependency was extended with an `org_scope` check so every route already using that dependency is covered automatically.

## Route-handler behavior changes

- `POST /api/v2/tasks` now routes by `org_scope`: admin → `DEFAULT_ORG_ID`, tenant → caller's org.
- `POST /api/v1/traces` remains admin-only (no change).

## Well-known org UUIDs

`DEFAULT_ORG_ID` and `SYSTEM_ORG_ID` live in `utils.constants` as the single source of truth (stable `…0001` / `…0002` UUIDs). All 4 multi-tenancy migrations and all app code reference them by import rather than duplicating UUID literals.

## Cross-dialect UUID columns

`sqlalchemy.Uuid(as_uuid=True)` replaces `postgresql.UUID(as_uuid=True)` on org_id columns so SQLite-backed unit tests round-trip UUIDs.

## Write-path `org_id` propagation

`org_id` is denormalized onto child rows by repositories at write time (needed to keep this PR's tests passing on top of UP-4424's NOT NULL constraints; overlaps with UP-4429's full Pattern C scope but is the minimum needed here):

- `InferenceRepository.save_prompt` / `save_response` stamp `org_id` onto prompt/response rule results and rule_details from the owning task.
- `FeedbackRepository.create_feedback` looks up `org_id` via `inference → task`.
- `ContinuousEvalsRepository`, `ContinuousEvalTestRunRepository`, `TraceAnnotationService` stamp `org_id` from the owning task on `agentic_annotations`.
- System task creators (`system_task_repository`, `services/system_tasks_service`, `global_agent_polling_service`, `tasks_repository.create_auto_task`) tag new tasks with `SYSTEM_ORG_ID` / `DEFAULT_ORG_ID` as appropriate.

The repeated `select(Task.org_id) ... or DEFAULT_ORG_ID` pattern is centralized in a single `lookup_org_id(session, query, default=...)` helper in `organizations_repository.py`. It uses `@overload` so the return type narrows to `UUID` when a non-None default is supplied.

## Review fixes folded in

- **Tenant isolation bypass on `inference_id`** — `query_inferences`'s `inference_id` shortcut now consults the decorator-rewritten `task_ids` (caller's org tasks) and treats a non-matching inference as "not found" for tenant callers.
- **404 enumeration oracle in `get_validated_task`** — both 404 paths (task absent vs. task in another org) now return identical `"Task not found"` bodies for tenant callers.
- **Inline imports** — moved out of function bodies except for one documented case in `utils.utils.seed_database` (now resolved by moving constants to `utils.constants`).

## Test plan

- [x] `uv run pytest -m unit_tests` — **1624 passed, 0 failed**
- [x] 51 new decorator unit tests cover path/query patterns + admin bypass + 404 on mismatch + permission_checker matrix for `TENANT-USER`
- [x] mypy: 0 errors (261 files)
- [x] routes_security_check: 0 unprotected (215 endpoints, 203 protected, 12 explicitly public)
- [ ] Integration tests on `UP-4387-multitenancy` after merge
- [ ] Manual smoke: hit `/api/v2/tasks/{id}` with a tenant key whose org owns the task → 200; with a different org → 404

## Scope of this PR (and what's not)

In scope: Patterns A, D, route-handler tweaks, well-known UUID constants, repository helpers for org_id stamping.

Out of scope (handled by sibling tickets):
- Pattern C (resource-id-scoped repo filtering for `{trace_id}`, `{span_id}`, `{inference_id}`, `{annotation_id}`, `{dataset_id}`, `{test_run_id}` paths) → **UP-4429**
- Full body-`task_id` decorator (Pattern B) → no endpoints need it today; decorator removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)