### PR TITLE
fix: restore definition field on TraceTransformResponse from latest version

### DIFF
--- a/genai-engine/pyproject.toml
+++ b/genai-engine/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
   "jinja2>=3.1.6,<4",
   "python-benedict>=0.35.0,<0.36",
   "weaviate-client>=4.17.0,<5",
-  "arthur-common==2.4.59",
+  "arthur-common==2.4.61",
   "google-auth>=2.48.0,<3",
   "google-cloud-aiplatform>=1.38",
   "google-cloud-trace>=1.11.0,<2",

--- a/genai-engine/src/api_changelog.md
+++ b/genai-engine/src/api_changelog.md
@@ -2,6 +2,13 @@ The intention of this changelog is to document API changes as they happen to eff
 
 ---
 
+# 05/21/2026
+- **CHANGE** for **URL**: /api/v1/tasks/{task_id}/traces/transforms  added the required property 'transforms/items/definition' to the response with the '200' status
+- **CHANGE** for **URL**: /api/v1/tasks/{task_id}/traces/transforms  added the required property 'definition' to the response with the '200' status
+- **CHANGE** for **URL**: /api/v1/traces/transforms/{transform_id}  added the required property 'definition' to the response with the '200' status
+- **CHANGE** for **URL**: /api/v1/traces/transforms/{transform_id}  added the required property 'definition' to the response with the '200' status
+- **CHANGE** for **URL**: /auth/api_keys/  added the new 'TENANT-USER' enum value to the request property 'roles/anyOf[subschema #1]/items/'
+
 # 05/15/2026
 - **CHANGE** for **URL**: /api/v2/validate endpoint added
 

--- a/genai-engine/src/repositories/trace_transform_repository.py
+++ b/genai-engine/src/repositories/trace_transform_repository.py
@@ -106,38 +106,23 @@ class TraceTransformRepository:
         if not transform_ids:
             return {}
 
-        latest_version_subq = (
-            self.db_session.query(
-                DatabaseTraceTransformVersion.transform_id,
-                func.max(DatabaseTraceTransformVersion.version_number).label(
-                    "max_version",
-                ),
-            )
-            .filter(DatabaseTraceTransformVersion.transform_id.in_(transform_ids))
-            .group_by(DatabaseTraceTransformVersion.transform_id)
-            .subquery()
-        )
-
+        # Fetch all versions for these transforms, newest first.
+        # Since transforms are paginated, N is small so fetching all versions is fine.
         versions = (
             self.db_session.query(DatabaseTraceTransformVersion)
-            .join(
-                latest_version_subq,
-                (
-                    DatabaseTraceTransformVersion.transform_id
-                    == latest_version_subq.c.transform_id
-                )
-                & (
-                    DatabaseTraceTransformVersion.version_number
-                    == latest_version_subq.c.max_version
-                ),
-            )
+            .filter(DatabaseTraceTransformVersion.transform_id.in_(transform_ids))
+            .order_by(desc(DatabaseTraceTransformVersion.version_number))
             .all()
         )
 
-        return {
-            v.transform_id: TraceTransformDefinition.model_validate(v.definition)
-            for v in versions
-        }
+        # Take the first (highest version number) seen per transform_id.
+        result: Dict[UUID, TraceTransformDefinition] = {}
+        for v in versions:
+            if v.transform_id not in result:
+                result[v.transform_id] = TraceTransformDefinition.model_validate(
+                    v.definition,
+                )
+        return result
 
     def get_transform_by_id(self, transform_id: UUID) -> TraceTransform | None:
         db_transform = self._get_db_transform_by_id(transform_id)

--- a/genai-engine/src/repositories/trace_transform_repository.py
+++ b/genai-engine/src/repositories/trace_transform_repository.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List
+from typing import Dict, List
 from uuid import UUID, uuid4
 
 from arthur_common.models.common_schemas import PaginationParameters
@@ -97,6 +97,47 @@ class TraceTransformRepository:
     def get_latest_definition(self, transform_id: UUID) -> TraceTransformDefinition:
         """Public accessor for the latest version's definition."""
         return self._get_latest_definition(transform_id)
+
+    def get_latest_definitions_for_transforms(
+        self,
+        transform_ids: List[UUID],
+    ) -> Dict[UUID, TraceTransformDefinition]:
+        """Fetch the latest version definition for each transform in a single query."""
+        if not transform_ids:
+            return {}
+
+        latest_version_subq = (
+            self.db_session.query(
+                DatabaseTraceTransformVersion.transform_id,
+                func.max(DatabaseTraceTransformVersion.version_number).label(
+                    "max_version",
+                ),
+            )
+            .filter(DatabaseTraceTransformVersion.transform_id.in_(transform_ids))
+            .group_by(DatabaseTraceTransformVersion.transform_id)
+            .subquery()
+        )
+
+        versions = (
+            self.db_session.query(DatabaseTraceTransformVersion)
+            .join(
+                latest_version_subq,
+                (
+                    DatabaseTraceTransformVersion.transform_id
+                    == latest_version_subq.c.transform_id
+                )
+                & (
+                    DatabaseTraceTransformVersion.version_number
+                    == latest_version_subq.c.max_version
+                ),
+            )
+            .all()
+        )
+
+        return {
+            v.transform_id: TraceTransformDefinition.model_validate(v.definition)
+            for v in versions
+        }
 
     def get_transform_by_id(self, transform_id: UUID) -> TraceTransform | None:
         db_transform = self._get_db_transform_by_id(transform_id)

--- a/genai-engine/src/routers/v1/transform_routes.py
+++ b/genai-engine/src/routers/v1/transform_routes.py
@@ -72,8 +72,14 @@ def list_transforms_for_task(
             pagination_parameters,
             filter_request,
         )
+        definitions = trace_transform_repo.get_latest_definitions_for_transforms(
+            [t.id for t in transforms],
+        )
         return ListTraceTransformsResponse(
-            transforms=[transform.to_response_model() for transform in transforms],
+            transforms=[
+                transform.to_response_model(definition=definitions[transform.id])
+                for transform in transforms
+            ],
             count=len(transforms),
         )
     except Exception as e:
@@ -102,7 +108,8 @@ def get_transform(
                 detail=f"Transform {transform_id} not found",
             )
 
-        return trace_transform.to_response_model()
+        definition = trace_transform_repo.get_latest_definition(transform_id)
+        return trace_transform.to_response_model(definition=definition)
     except HTTPException:
         raise
     except Exception as e:
@@ -151,7 +158,7 @@ def create_transform_for_task(
     try:
         trace_transform_repo = TraceTransformRepository(db_session)
         trace_transform = trace_transform_repo.create_transform(task.id, request)
-        return trace_transform.to_response_model()
+        return trace_transform.to_response_model(definition=request.definition)
     except HTTPException:
         raise
     except Exception as e:
@@ -174,7 +181,8 @@ def update_transform(
     try:
         trace_transform_repo = TraceTransformRepository(db_session)
         trace_transform = trace_transform_repo.update_transform(transform_id, request)
-        return trace_transform.to_response_model()
+        definition = trace_transform_repo.get_latest_definition(transform_id)
+        return trace_transform.to_response_model(definition=definition)
     except HTTPException:
         raise
     except Exception as e:

--- a/genai-engine/src/schemas/internal_schemas.py
+++ b/genai-engine/src/schemas/internal_schemas.py
@@ -75,6 +75,7 @@ from arthur_common.models.response_schemas import (
 from arthur_common.models.task_eval_schemas import (
     ContinuousEvalResponse,
     ContinuousEvalTransformVariableMappingResponse,
+    TraceTransformDefinition,
     TraceTransformResponse,
 )
 from fastapi import HTTPException
@@ -2538,12 +2539,16 @@ class TraceTransform(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    def to_response_model(self) -> TraceTransformResponse:
+    def to_response_model(
+        self,
+        definition: TraceTransformDefinition,
+    ) -> TraceTransformResponse:
         return TraceTransformResponse(
             id=self.id,
             task_id=self.task_id,
             name=self.name,
             description=self.description,
+            definition=definition,
             created_at=self.created_at,
             updated_at=self.updated_at,
         )

--- a/genai-engine/staging.openapi.json
+++ b/genai-engine/staging.openapi.json
@@ -2,7 +2,7 @@
     "openapi": "3.1.0",
     "info": {
         "title": "Arthur GenAI Engine",
-        "version": "2.1.570"
+        "version": "2.1.503"
     },
     "paths": {
         "/api/v2/engine-config": {
@@ -2325,7 +2325,7 @@
                     "API Keys"
                 ],
                 "summary": "Create Api Key",
-                "description": "Generates a new API key. Up to 1000 active keys can exist at the same time by default. Contact your system administrator if you need more. Allowed roles are: DEFAULT-RULE-ADMIN, TASK-ADMIN, VALIDATION-USER, ORG-AUDITOR, ORG-ADMIN.",
+                "description": "Generates a new API key. Up to 1000 active keys can exist at the same time by default. Contact your system administrator if you need more. Allowed roles are: DEFAULT-RULE-ADMIN, TASK-ADMIN, VALIDATION-USER, ORG-AUDITOR, ORG-ADMIN, TENANT-USER.",
                 "operationId": "create_api_key_auth_api_keys__post",
                 "requestBody": {
                     "content": {
@@ -17274,7 +17274,8 @@
                     "TASK-ADMIN",
                     "VALIDATION-USER",
                     "ORG-AUDITOR",
-                    "ORG-ADMIN"
+                    "ORG-ADMIN",
+                    "TENANT-USER"
                 ],
                 "title": "APIKeysRolesEnum"
             },
@@ -24964,7 +24965,7 @@
                             }
                         ],
                         "title": "Roles",
-                        "description": "Role that will be assigned to API key. Allowed values: [<APIKeysRolesEnum.DEFAULT_RULE_ADMIN: 'DEFAULT-RULE-ADMIN'>, <APIKeysRolesEnum.TASK_ADMIN: 'TASK-ADMIN'>, <APIKeysRolesEnum.VALIDATION_USER: 'VALIDATION-USER'>, <APIKeysRolesEnum.ORG_AUDITOR: 'ORG-AUDITOR'>, <APIKeysRolesEnum.ORG_ADMIN: 'ORG-ADMIN'>]",
+                        "description": "Role that will be assigned to API key. Allowed values: [<APIKeysRolesEnum.DEFAULT_RULE_ADMIN: 'DEFAULT-RULE-ADMIN'>, <APIKeysRolesEnum.TASK_ADMIN: 'TASK-ADMIN'>, <APIKeysRolesEnum.VALIDATION_USER: 'VALIDATION-USER'>, <APIKeysRolesEnum.ORG_AUDITOR: 'ORG-AUDITOR'>, <APIKeysRolesEnum.ORG_ADMIN: 'ORG-ADMIN'>, <APIKeysRolesEnum.TENANT_USER: 'TENANT-USER'>]",
                         "default": [
                             "VALIDATION-USER"
                         ]
@@ -31880,6 +31881,10 @@
                         "title": "Description",
                         "description": "Description of the transform."
                     },
+                    "definition": {
+                        "$ref": "#/components/schemas/TraceTransformDefinition",
+                        "description": "Latest version of the transform definition."
+                    },
                     "created_at": {
                         "type": "string",
                         "format": "date-time",
@@ -31898,6 +31903,7 @@
                     "id",
                     "task_id",
                     "name",
+                    "definition",
                     "created_at",
                     "updated_at"
                 ],

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "arthur-genai-engine"
-version = "2.1.552"
+version = "2.1.570"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -127,7 +127,7 @@ wheels = [
 
 [[package]]
 name = "arthur-common"
-version = "2.4.59"
+version = "2.4.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datasketches" },
@@ -143,9 +143,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/7f/87ee6fd469ad519c74a0a0f8f5c8c78709fe215baa3e2817184b58e5bc36/arthur_common-2.4.59.tar.gz", hash = "sha256:e32a44411486a5b40e94ecf07c2b0cb435920e44795d14e3e783005a5cef1039", size = 14636316 }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/e7/5038ac5cf43579f350bc94504d570ffaf319a92e95a7dc38d88516c05bd6/arthur_common-2.4.61.tar.gz", hash = "sha256:2367908780b410d6f76390da22eb42476a28827822adffd1e73cbcf571244b81", size = 14636322 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/3c/2a8f929163edc32f410f17eb29748eac1b05dbd658770029e00c5d575c0e/arthur_common-2.4.59-py3-none-any.whl", hash = "sha256:2cbae01652a339a8d60e33070be6a19d77471f04c3156ecb9c56374b5a1e6224", size = 85954 },
+    { url = "https://files.pythonhosted.org/packages/f4/8d/4352791d8cd77c2d54a23587a81228b52b0b611b1104f944bcf6db3f4c90/arthur_common-2.4.61-py3-none-any.whl", hash = "sha256:2634c8a2a43ecd1a14e4ed04d0fa4b74e5c5820a30b551e15fba16804882bcef", size = 86000 },
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ performance = [
 requires-dist = [
     { name = "alembic", specifier = "==1.17.2" },
     { name = "amplitude-analytics", specifier = ">=1.1.5,<2" },
-    { name = "arthur-common", specifier = "==2.4.59" },
+    { name = "arthur-common", specifier = "==2.4.61" },
     { name = "authlib", specifier = "==1.6.9" },
     { name = "azure-storage-blob", specifier = "==12.27.1" },
     { name = "bcrypt", specifier = "==4.3.0" },


### PR DESCRIPTION
## Summary

Restores the `definition` field on `TraceTransformResponse` that was inadvertently lost when transform versioning was introduced (PR #1502). The field is now populated from the latest `TraceTransformVersion` so existing callers continue to receive the definition without any breaking changes.

**Changes:**
- `TraceTransform.to_response_model()` now accepts a `definition: TraceTransformDefinition` parameter
- Added `get_latest_definitions_for_transforms()` batch method to `TraceTransformRepository` — fetches latest version definition for N transforms in a single query (no N+1)
- All transform-returning routes updated to pass the definition:
  - `list_transforms` — batch-fetches definitions in one subquery
  - `get_transform` — fetches latest definition after lookup
  - `create_transform` — uses `request.definition` directly (just created version 1)
  - `update_transform` — fetches latest definition after update
- Bumps `arthur-common` dependency to `2.4.61` (which restores `definition: TraceTransformDefinition` on `TraceTransformResponse`)

## Why not just remove the field?

Removing `definition` from the API response is a breaking change — callers depend on it. Instead, the field is restored and populated from `MAX(version_number)` on the `transform_versions` table, keeping the API contract intact while the definition lives in the version table internally.

## Test plan
- [ ] `GET /tasks/{task_id}/traces/transforms` returns transforms with `definition` populated
- [ ] `GET /traces/transforms/{transform_id}` returns transform with `definition` populated
- [ ] `POST /tasks/{task_id}/traces/transforms` returns new transform with `definition` populated
- [ ] `PATCH /traces/transforms/{transform_id}` returns updated transform with `definition` populated
- [ ] Existing transform CRUD unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)