### PR TITLE
CI failure: yarn install --immutable checksum mismatch

### DIFF
--- a/genai-engine/ui/package.json
+++ b/genai-engine/ui/package.json
@@ -32,7 +32,7 @@
     "@mui/material": "7.3.9",
     "@mui/x-charts": "8.27.4",
     "@mui/x-date-pickers": "8.27.2",
-    "@tanstack/react-form": "https://pkg.pr.new/@tanstack/react-form@2128",
+    "@tanstack/react-form": "https://pkg.pr.new/TanStack/form/@tanstack/react-form@3aac089",
     "@tanstack/react-pacer": "0.19.4",
     "@tanstack/react-query": "5.90.21",
     "@tanstack/react-query-devtools": "5.91.3",

--- a/genai-engine/ui/package.json
+++ b/genai-engine/ui/package.json
@@ -32,7 +32,7 @@
     "@mui/material": "7.3.9",
     "@mui/x-charts": "8.27.4",
     "@mui/x-date-pickers": "8.27.2",
-    "@tanstack/react-form": "https://pkg.pr.new/@tanstack/react-form@2128",
+    "@tanstack/react-form": "^1.32.1",
     "@tanstack/react-pacer": "0.19.4",
     "@tanstack/react-query": "5.90.21",
     "@tanstack/react-query-devtools": "5.91.3",

--- a/genai-engine/ui/package.json
+++ b/genai-engine/ui/package.json
@@ -32,7 +32,7 @@
     "@mui/material": "7.3.9",
     "@mui/x-charts": "8.27.4",
     "@mui/x-date-pickers": "8.27.2",
-    "@tanstack/react-form": "^1.32.1",
+    "@tanstack/react-form": "https://pkg.pr.new/@tanstack/react-form@2128",
     "@tanstack/react-pacer": "0.19.4",
     "@tanstack/react-query": "5.90.21",
     "@tanstack/react-query-devtools": "5.91.3",

--- a/genai-engine/ui/yarn.lock
+++ b/genai-engine/ui/yarn.lock
@@ -2497,6 +2497,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/form-core@https://pkg.pr.new/TanStack/form/@tanstack/form-core@a030e78":
+  version: 1.32.0
+  resolution: "@tanstack/form-core@https://pkg.pr.new/TanStack/form/@tanstack/form-core@a030e78"
+  dependencies:
+    "@tanstack/devtools-event-client": "npm:^0.4.1"
+    "@tanstack/pacer-lite": "npm:^0.1.1"
+    "@tanstack/store": "npm:^0.11.0"
+  checksum: 10c0/087a458d78171a5dd2e62d46884e890733216c7197f5fc0ea311968e11771afc33bd3f74542e44085f5ef1f525abe16a45c9c681ab688158825b5d4a7f26acb5
+  languageName: node
+  linkType: hard
+
 "@tanstack/form-core@npm:1.27.7":
   version: 1.27.7
   resolution: "@tanstack/form-core@npm:1.27.7"
@@ -2505,17 +2516,6 @@ __metadata:
     "@tanstack/pacer-lite": "npm:^0.1.1"
     "@tanstack/store": "npm:^0.7.7"
   checksum: 10c0/dc5057a6cb3cb2aa759b91cc7af913f80bf2967d0cc946f886a47ac9195a773ecaa8eb27604dd052f7182aab45a561da086bc9045fc35bbfbdb8a475f110958a
-  languageName: node
-  linkType: hard
-
-"@tanstack/form-core@npm:1.32.1":
-  version: 1.32.1
-  resolution: "@tanstack/form-core@npm:1.32.1"
-  dependencies:
-    "@tanstack/devtools-event-client": "npm:^0.4.1"
-    "@tanstack/pacer-lite": "npm:^0.1.1"
-    "@tanstack/store": "npm:^0.9.1"
-  checksum: 10c0/d5c802964c0c01b0ede2781de72ab919b005fde41075b7568791b68696d7681759ceb2db75b3e870cd380976d424f3cefbbdfee790647fb67fdcfedba8f04d6f
   languageName: node
   linkType: hard
 
@@ -2573,6 +2573,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-form@https://pkg.pr.new/@tanstack/react-form@2128":
+  version: 1.32.0
+  resolution: "@tanstack/react-form@https://pkg.pr.new/@tanstack/react-form@2128"
+  dependencies:
+    "@tanstack/form-core": "https://pkg.pr.new/TanStack/form/@tanstack/form-core@a030e78"
+    "@tanstack/react-store": "npm:^0.11.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@tanstack/react-start":
+      optional: true
+  checksum: 10c0/ffef16d02511f7f7ff1fb9a7586d256b4b6043b1c3a8ad86e282d97c82c6e758f388c0cf180a757c58cc71595752251b7c05434085a3799022c651bae02a3e4c
+  languageName: node
+  linkType: hard
+
 "@tanstack/react-form@npm:1.27.7":
   version: 1.27.7
   resolution: "@tanstack/react-form@npm:1.27.7"
@@ -2585,21 +2600,6 @@ __metadata:
     "@tanstack/react-start":
       optional: true
   checksum: 10c0/6944f77a87108620017093fcf72b5bfe9d60b7cf22c170fed4569c0d261aeea9c42419943663a468cbf851dd1ea21f908523080aa93e8ef93ad08a2fd70a58f3
-  languageName: node
-  linkType: hard
-
-"@tanstack/react-form@npm:^1.32.1":
-  version: 1.32.1
-  resolution: "@tanstack/react-form@npm:1.32.1"
-  dependencies:
-    "@tanstack/form-core": "npm:1.32.1"
-    "@tanstack/react-store": "npm:^0.9.1"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@tanstack/react-start":
-      optional: true
-  checksum: 10c0/5371cba60280e2e72c70004e333e589a296acc226d807ebeee43083e056f5db6a41172e45f454fa4085ca5c9a3e7eec35f1268c8ff6c9746ab4af6d18f47f183
   languageName: node
   linkType: hard
 
@@ -2662,6 +2662,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-store@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@tanstack/react-store@npm:0.11.0"
+  dependencies:
+    "@tanstack/store": "npm:0.11.0"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/8b6bf5f2f572239ce3c55490dcd3595f266d517e3eb15b783fb5c38dc1e9b021a52acd0345b001b45707820322d4b87dbc7936bd1d4c5de1131baa6c80a847d0
+  languageName: node
+  linkType: hard
+
 "@tanstack/react-store@npm:^0.8.0":
   version: 0.8.1
   resolution: "@tanstack/react-store@npm:0.8.1"
@@ -2672,19 +2685,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10c0/83037681674e34361f5a6141af81a19788e7243892f5fcca45c9e70c73eb9da9693574a46ea80114589060969470a9b9657a3bd74a44f98e80de481c65204778
-  languageName: node
-  linkType: hard
-
-"@tanstack/react-store@npm:^0.9.1":
-  version: 0.9.3
-  resolution: "@tanstack/react-store@npm:0.9.3"
-  dependencies:
-    "@tanstack/store": "npm:0.9.3"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/4d043b7211129418efa5ec1fafec7315b46b7ef92658f434b8e7a9a5dbf7687418c70f3c11f9d1636f304fa868a6d969380444d2042442ef94fc5517d19c5e4c
   languageName: node
   linkType: hard
 
@@ -2724,17 +2724,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/store@npm:0.11.0, @tanstack/store@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@tanstack/store@npm:0.11.0"
+  checksum: 10c0/6fef9e81d30c3097709cfdd113407578849a7b8a6ce7a674467950620a67047c365552a01747a0f448d16ea4f607e58e97021583523ba5cdabcb1b98d0e2a632
+  languageName: node
+  linkType: hard
+
 "@tanstack/store@npm:0.8.1, @tanstack/store@npm:^0.8.0":
   version: 0.8.1
   resolution: "@tanstack/store@npm:0.8.1"
   checksum: 10c0/344180b689f87c3afa6ac3ea1c7d9b14257a1b961afea916f3ac666b2752972caba33c12105d588d297a932767fe0d8d25567e220777ec99d4ca6b61b5b652af
-  languageName: node
-  linkType: hard
-
-"@tanstack/store@npm:0.9.3, @tanstack/store@npm:^0.9.1":
-  version: 0.9.3
-  resolution: "@tanstack/store@npm:0.9.3"
-  checksum: 10c0/ec022c792c298be0717d7a2d06d6db4459077db775a27d86a2a248f446257e133c5d7c77a74bf6a4fa6993cfaef09b6f58a68a601c3becca834ed0b457ebe824
   languageName: node
   linkType: hard
 
@@ -8675,7 +8675,7 @@ __metadata:
     "@rollup/rollup-linux-x64-gnu": "npm:4.54.0"
     "@tailwindcss/vite": "npm:4.2.1"
     "@tanstack/eslint-plugin-query": "npm:5.91.4"
-    "@tanstack/react-form": "npm:^1.32.1"
+    "@tanstack/react-form": "https://pkg.pr.new/@tanstack/react-form@2128"
     "@tanstack/react-pacer": "npm:0.19.4"
     "@tanstack/react-query": "npm:5.90.21"
     "@tanstack/react-query-devtools": "npm:5.91.3"

--- a/genai-engine/ui/yarn.lock
+++ b/genai-engine/ui/yarn.lock
@@ -2497,17 +2497,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/form-core@https://pkg.pr.new/TanStack/form/@tanstack/form-core@a030e78":
-  version: 1.32.0
-  resolution: "@tanstack/form-core@https://pkg.pr.new/TanStack/form/@tanstack/form-core@a030e78"
-  dependencies:
-    "@tanstack/devtools-event-client": "npm:^0.4.1"
-    "@tanstack/pacer-lite": "npm:^0.1.1"
-    "@tanstack/store": "npm:^0.11.0"
-  checksum: 10c0/087a458d78171a5dd2e62d46884e890733216c7197f5fc0ea311968e11771afc33bd3f74542e44085f5ef1f525abe16a45c9c681ab688158825b5d4a7f26acb5
-  languageName: node
-  linkType: hard
-
 "@tanstack/form-core@npm:1.27.7":
   version: 1.27.7
   resolution: "@tanstack/form-core@npm:1.27.7"
@@ -2516,6 +2505,17 @@ __metadata:
     "@tanstack/pacer-lite": "npm:^0.1.1"
     "@tanstack/store": "npm:^0.7.7"
   checksum: 10c0/dc5057a6cb3cb2aa759b91cc7af913f80bf2967d0cc946f886a47ac9195a773ecaa8eb27604dd052f7182aab45a561da086bc9045fc35bbfbdb8a475f110958a
+  languageName: node
+  linkType: hard
+
+"@tanstack/form-core@npm:1.32.1":
+  version: 1.32.1
+  resolution: "@tanstack/form-core@npm:1.32.1"
+  dependencies:
+    "@tanstack/devtools-event-client": "npm:^0.4.1"
+    "@tanstack/pacer-lite": "npm:^0.1.1"
+    "@tanstack/store": "npm:^0.9.1"
+  checksum: 10c0/d5c802964c0c01b0ede2781de72ab919b005fde41075b7568791b68696d7681759ceb2db75b3e870cd380976d424f3cefbbdfee790647fb67fdcfedba8f04d6f
   languageName: node
   linkType: hard
 
@@ -2573,21 +2573,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-form@https://pkg.pr.new/@tanstack/react-form@2128":
-  version: 1.32.0
-  resolution: "@tanstack/react-form@https://pkg.pr.new/@tanstack/react-form@2128"
-  dependencies:
-    "@tanstack/form-core": "https://pkg.pr.new/TanStack/form/@tanstack/form-core@a030e78"
-    "@tanstack/react-store": "npm:^0.11.0"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@tanstack/react-start":
-      optional: true
-  checksum: 10c0/ffef16d02511f7f7ff1fb9a7586d256b4b6043b1c3a8ad86e282d97c82c6e758f388c0cf180a757c58cc71595752251b7c05434085a3799022c651bae02a3e4c
-  languageName: node
-  linkType: hard
-
 "@tanstack/react-form@npm:1.27.7":
   version: 1.27.7
   resolution: "@tanstack/react-form@npm:1.27.7"
@@ -2600,6 +2585,21 @@ __metadata:
     "@tanstack/react-start":
       optional: true
   checksum: 10c0/6944f77a87108620017093fcf72b5bfe9d60b7cf22c170fed4569c0d261aeea9c42419943663a468cbf851dd1ea21f908523080aa93e8ef93ad08a2fd70a58f3
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-form@npm:^1.32.1":
+  version: 1.32.1
+  resolution: "@tanstack/react-form@npm:1.32.1"
+  dependencies:
+    "@tanstack/form-core": "npm:1.32.1"
+    "@tanstack/react-store": "npm:^0.9.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@tanstack/react-start":
+      optional: true
+  checksum: 10c0/5371cba60280e2e72c70004e333e589a296acc226d807ebeee43083e056f5db6a41172e45f454fa4085ca5c9a3e7eec35f1268c8ff6c9746ab4af6d18f47f183
   languageName: node
   linkType: hard
 
@@ -2662,19 +2662,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-store@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@tanstack/react-store@npm:0.11.0"
-  dependencies:
-    "@tanstack/store": "npm:0.11.0"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/8b6bf5f2f572239ce3c55490dcd3595f266d517e3eb15b783fb5c38dc1e9b021a52acd0345b001b45707820322d4b87dbc7936bd1d4c5de1131baa6c80a847d0
-  languageName: node
-  linkType: hard
-
 "@tanstack/react-store@npm:^0.8.0":
   version: 0.8.1
   resolution: "@tanstack/react-store@npm:0.8.1"
@@ -2685,6 +2672,19 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10c0/83037681674e34361f5a6141af81a19788e7243892f5fcca45c9e70c73eb9da9693574a46ea80114589060969470a9b9657a3bd74a44f98e80de481c65204778
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-store@npm:^0.9.1":
+  version: 0.9.3
+  resolution: "@tanstack/react-store@npm:0.9.3"
+  dependencies:
+    "@tanstack/store": "npm:0.9.3"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/4d043b7211129418efa5ec1fafec7315b46b7ef92658f434b8e7a9a5dbf7687418c70f3c11f9d1636f304fa868a6d969380444d2042442ef94fc5517d19c5e4c
   languageName: node
   linkType: hard
 
@@ -2724,17 +2724,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/store@npm:0.11.0, @tanstack/store@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@tanstack/store@npm:0.11.0"
-  checksum: 10c0/6fef9e81d30c3097709cfdd113407578849a7b8a6ce7a674467950620a67047c365552a01747a0f448d16ea4f607e58e97021583523ba5cdabcb1b98d0e2a632
-  languageName: node
-  linkType: hard
-
 "@tanstack/store@npm:0.8.1, @tanstack/store@npm:^0.8.0":
   version: 0.8.1
   resolution: "@tanstack/store@npm:0.8.1"
   checksum: 10c0/344180b689f87c3afa6ac3ea1c7d9b14257a1b961afea916f3ac666b2752972caba33c12105d588d297a932767fe0d8d25567e220777ec99d4ca6b61b5b652af
+  languageName: node
+  linkType: hard
+
+"@tanstack/store@npm:0.9.3, @tanstack/store@npm:^0.9.1":
+  version: 0.9.3
+  resolution: "@tanstack/store@npm:0.9.3"
+  checksum: 10c0/ec022c792c298be0717d7a2d06d6db4459077db775a27d86a2a248f446257e133c5d7c77a74bf6a4fa6993cfaef09b6f58a68a601c3becca834ed0b457ebe824
   languageName: node
   linkType: hard
 
@@ -8675,7 +8675,7 @@ __metadata:
     "@rollup/rollup-linux-x64-gnu": "npm:4.54.0"
     "@tailwindcss/vite": "npm:4.2.1"
     "@tanstack/eslint-plugin-query": "npm:5.91.4"
-    "@tanstack/react-form": "https://pkg.pr.new/@tanstack/react-form@2128"
+    "@tanstack/react-form": "npm:^1.32.1"
     "@tanstack/react-pacer": "npm:0.19.4"
     "@tanstack/react-query": "npm:5.90.21"
     "@tanstack/react-query-devtools": "npm:5.91.3"

--- a/genai-engine/ui/yarn.lock
+++ b/genai-engine/ui/yarn.lock
@@ -2497,14 +2497,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/form-core@https://pkg.pr.new/TanStack/form/@tanstack/form-core@a030e78":
-  version: 1.32.0
-  resolution: "@tanstack/form-core@https://pkg.pr.new/TanStack/form/@tanstack/form-core@a030e78"
+"@tanstack/form-core@https://pkg.pr.new/TanStack/form/@tanstack/form-core@3aac089":
+  version: 1.32.1
+  resolution: "@tanstack/form-core@https://pkg.pr.new/TanStack/form/@tanstack/form-core@3aac089"
   dependencies:
     "@tanstack/devtools-event-client": "npm:^0.4.1"
     "@tanstack/pacer-lite": "npm:^0.1.1"
     "@tanstack/store": "npm:^0.11.0"
-  checksum: 10c0/087a458d78171a5dd2e62d46884e890733216c7197f5fc0ea311968e11771afc33bd3f74542e44085f5ef1f525abe16a45c9c681ab688158825b5d4a7f26acb5
+  checksum: 10c0/8a3d303d51e3e2f8a539295e183808c9baf102450a8a5a84c61b9d5fe251110aa09caa675c85c0a89ec2d0b8dff22221cc450619000dedfeded1e6def8d89701
   languageName: node
   linkType: hard
 
@@ -2573,18 +2573,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-form@https://pkg.pr.new/@tanstack/react-form@2128":
-  version: 1.32.0
-  resolution: "@tanstack/react-form@https://pkg.pr.new/@tanstack/react-form@2128"
+"@tanstack/react-form@https://pkg.pr.new/TanStack/form/@tanstack/react-form@3aac089":
+  version: 1.32.1
+  resolution: "@tanstack/react-form@https://pkg.pr.new/TanStack/form/@tanstack/react-form@3aac089"
   dependencies:
-    "@tanstack/form-core": "https://pkg.pr.new/TanStack/form/@tanstack/form-core@a030e78"
+    "@tanstack/form-core": "https://pkg.pr.new/TanStack/form/@tanstack/form-core@3aac089"
     "@tanstack/react-store": "npm:^0.11.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@tanstack/react-start":
       optional: true
-  checksum: 10c0/ffef16d02511f7f7ff1fb9a7586d256b4b6043b1c3a8ad86e282d97c82c6e758f388c0cf180a757c58cc71595752251b7c05434085a3799022c651bae02a3e4c
+  checksum: 10c0/f8e5c263870353e3258c537ca106610cb0f91ccea0e8fd141a03ef7e9092fec386031118659c8385f7df1331dd027c1d5a2aa847201b1e870762cff7d781996e
   languageName: node
   linkType: hard
 
@@ -8675,7 +8675,7 @@ __metadata:
     "@rollup/rollup-linux-x64-gnu": "npm:4.54.0"
     "@tailwindcss/vite": "npm:4.2.1"
     "@tanstack/eslint-plugin-query": "npm:5.91.4"
-    "@tanstack/react-form": "https://pkg.pr.new/@tanstack/react-form@2128"
+    "@tanstack/react-form": "https://pkg.pr.new/TanStack/form/@tanstack/react-form@3aac089"
     "@tanstack/react-pacer": "npm:0.19.4"
     "@tanstack/react-query": "npm:5.90.21"
     "@tanstack/react-query-devtools": "npm:5.91.3"


### PR DESCRIPTION
Problem
The Docker ui-build stage failed with:

YN0018: @tanstack/react-form@https://pkg.pr.new/@tanstack/react-form@2128:
        The remote archive doesn't match the expected checksum
@tanstack/react-form was pinned in package.json to https://pkg.pr.new/@tanstack/react-form@2128. The @2128 suffix is a PR-number URL — pkg.pr.new treats it as a mutable alias that always points to the latest commit on TanStack/form PR #2128 ("Form Groups"). Upstream pushed new commits to that PR after our yarn.lock was last generated, so the tarball served at that URL no longer matched the SHA-512 in our lockfile, and --immutable (correctly) refused to update it.

Local installs didn't catch this because:

Yarn's install-state.gz short-circuits re-resolution when package.json/yarn.lock haven't changed.
The originally-downloaded tarball was still in the global Yarn cache, so the cached bytes still matched the lockfile checksum.
Docker has neither cache, so it fetched fresh, got different bytes, and failed.

The error had nothing to do with GITLAB_UNIFY_FRONTEND_TOKEN: the token guard never fired, Resolution completed successfully (including the private @arthur/* packages from GitLab), and the failing URL is on a public CDN that doesn't use the GitLab token.

Why we can't just use the latest npm version
A side-investigation showed that @tanstack/react-form@1.32.1 on npm includes most of the Form Groups APIs (withForm, withFieldGroup), but not the <form.FormGroup> component method. That component method is only in the preview build from PR #2128, and the onboarding wizard uses it in three places:

genai-engine/ui/src/components/onboarding/try-it-out-form/wizard/steps/about.tsx
genai-engine/ui/src/components/onboarding/try-it-out-form/wizard/steps/discovery.tsx
genai-engine/ui/src/components/onboarding/try-it-out-form/wizard/steps/identity.tsx
Migrating to ^1.32.1 produced 9 type errors of the form Property 'FormGroup' does not exist on type 'AppFieldExtendedReactFormApi<…>', so we needed to stay on the preview build.

Fix
Switch from the mutable PR-number URL to an immutable commit-SHA URL — the same form pkg.pr.new documents and that our lockfile already uses for the transitive @tanstack/form-core dep.

 "@tanstack/react-form": "https://pkg.pr.new/@tanstack/react-form@2128",
 "@tanstack/react-form": "https://pkg.pr.new/TanStack/form/@tanstack/react-form@3aac089",
3aac089 is the current head of PR #2128. Both @tanstack/react-form and the transitive @tanstack/form-core now resolve at that commit (version 1.32.1) with fresh checksums in yarn.lock.

Verification
corepack yarn install — clean run, 2 packages refreshed (~2.1 MiB)
corepack yarn type-check — zero errors (Form Groups component API is back)
Total diff: 2 files changed, 11 insertions(+), 11 deletions(-) — just URL and checksum updates
CI will pass because pkg.pr.new's commit-SHA URLs are content-addressed and immutable; the tarball cannot drift under us.

Follow-up
pkg.pr.new retains commit-pinned tarballs for ~6 months. Two reasonable exit paths:

Wait for PR #2128 to merge and ship to npm, then swap the URL for ^x.y.z.
Refactor the three onboarding wizard files to use the withFieldGroup HOC instead of <form.FormGroup>, which is already in npm 1.32.1. That would let us drop the pkg.pr.new dependency entirely.
Notes for reviewers
If you're regenerating the lockfile locally, use corepack yarn install, not plain yarn install. The system yarn on PATH is Yarn Classic 1.22.22 and will silently overwrite yarn.lock with an 86-byte stub. Either corepack enable globally or invoke via corepack yarn to ensure Yarn 4 is used.