### PR TITLE
fix the demo dataset not matching with the transform variable names

### DIFF
--- a/genai-engine/src/utils/demo_task_fixtures/demo_task_resources.py
+++ b/genai-engine/src/utils/demo_task_fixtures/demo_task_resources.py
@@ -166,16 +166,16 @@ DEMO_TASK_DATASET_VERSION_REQUEST = NewDatasetVersionRequest(
         NewDatasetVersionRowRequest(
             data=[
                 NewDatasetVersionRowColumnItemRequest(
-                    column_name="query",
-                    column_value=query,
+                    column_name="input_messages",
+                    column_value=input_messages,
                 ),
                 NewDatasetVersionRowColumnItemRequest(
-                    column_name="response",
-                    column_value=response,
+                    column_name="output_messages",
+                    column_value=output_messages,
                 ),
             ],
         )
-        for query, response in DEMO_TASK_DATASET_ROWS
+        for input_messages, output_messages in DEMO_TASK_DATASET_ROWS
     ],
     rows_to_delete=[],
     rows_to_update=[],

--- a/genai-engine/src/utils/demo_task_fixtures/demo_task_resources.py
+++ b/genai-engine/src/utils/demo_task_fixtures/demo_task_resources.py
@@ -58,14 +58,14 @@ DEMO_TASK_SYSTEM_PROMPT = (
 )
 
 DEMO_TASK_ANSWER_RELEVANCE_EVAL_PROMPT = (
-    "Given a list of input and output messages:\n\n"
-    "<input_messages>\n"
-    "{{input_messages}}\n"
-    "</input_messages>\n\n"
-    "<output_messages>\n"
-    "{{output_messages}}\n"
-    "</output_messages>\n\n"
-    "Determine if the assistant's response is relevant to the input messages. "
+    "Given user's message and assistant's response:\n\n"
+    "<user_message>\n"
+    "{{query}}\n"
+    "</user_message>\n\n"
+    "<assistant_response>\n"
+    "{{response}}\n"
+    "</assistant_response>\n\n"
+    "Determine if the assistant's response is relevant to the user's message. "
     "Respond with 1 if it is and 0 if it is not. "
     "Ignore all formatting, structure, and metadata (e.g. markdown, json, tool calls, API responses, etc.) — "
     "extract and evaluate only the natural language text content within. "
@@ -80,12 +80,12 @@ DEMO_TASK_ANSWER_RELEVANCE_EVAL_TRANSFORM = NewTraceTransformRequest(
     definition=TraceTransformDefinition(
         variables=[
             TraceTransformVariableDefinition(
-                variable_name="input_messages",
+                variable_name="query",
                 span_name="chatbot",
-                attribute_path="attributes.input.value",
+                attribute_path="attributes.input.value.-1.content",
             ),
             TraceTransformVariableDefinition(
-                variable_name="output_messages",
+                variable_name="response",
                 span_name="chatbot",
                 attribute_path="attributes.output.value.text",
             ),
@@ -166,16 +166,16 @@ DEMO_TASK_DATASET_VERSION_REQUEST = NewDatasetVersionRequest(
         NewDatasetVersionRowRequest(
             data=[
                 NewDatasetVersionRowColumnItemRequest(
-                    column_name="input_messages",
-                    column_value=input_messages,
+                    column_name="query",
+                    column_value=query,
                 ),
                 NewDatasetVersionRowColumnItemRequest(
-                    column_name="output_messages",
-                    column_value=output_messages,
+                    column_name="response",
+                    column_value=response,
                 ),
             ],
         )
-        for input_messages, output_messages in DEMO_TASK_DATASET_ROWS
+        for query, response in DEMO_TASK_DATASET_ROWS
     ],
     rows_to_delete=[],
     rows_to_update=[],

--- a/genai-engine/src/utils/trace.py
+++ b/genai-engine/src/utils/trace.py
@@ -317,11 +317,12 @@ def get_nested_value(
             current = current[key]
         elif isinstance(current, list):
             # Try to parse key as integer index
-            if not key.isdigit():
+            try:
+                index = int(key)
+            except ValueError:
                 return default
 
-            index = int(key)
-            if 0 <= index < len(current):
+            if -len(current) <= index < len(current):
                 current = current[index]
             else:
                 return default
@@ -399,10 +400,11 @@ def _collect_wildcard(
         return _collect_wildcard(current[key], keys, index + 1)
 
     if isinstance(current, list):
-        if not key.isdigit():
+        try:
+            idx = int(key)
+        except ValueError:
             return []
-        idx = int(key)
-        if 0 <= idx < len(current):
+        if -len(current) <= idx < len(current):
             return _collect_wildcard(current[idx], keys, index + 1)
         return []
 

--- a/genai-engine/tests/unit/routes/transforms/test_transform_execution.py
+++ b/genai-engine/tests/unit/routes/transforms/test_transform_execution.py
@@ -1,5 +1,6 @@
 """Tests for transform execution endpoint."""
 
+import ast
 import json
 import uuid
 from datetime import datetime
@@ -856,6 +857,74 @@ def test_execute_transform_wildcard_extraction(
         variables = {var.name: var.value for var in result.variables}
         assert variables["missing_wildcard"] == "[]"
 
+    finally:
+        client.delete_transform(transform.id)
+
+        status_code = client.delete_task(agentic_task.id)
+        assert status_code == 204
+
+
+@pytest.mark.unit_tests
+def test_execute_transform_negative_index_extraction(
+    client: GenaiEngineTestClientBase,
+    setup_test_data,
+) -> None:
+    """Test transform execution with negative index extraction."""
+    test_data = setup_test_data
+
+    status_code, agentic_task = client.create_task(
+        name="test_execute_transform_complex_nested_data_task",
+        is_agentic=True,
+    )
+    assert status_code == 200
+
+    try:
+        # Create a transform that extracts data from the test spans successfully
+        transform_definition = {
+            "variables": [
+                {
+                    "variable_name": "last_result",
+                    "span_name": "rag-retrieval-savedQueries",
+                    "attribute_path": "attributes.output.value.results.-1",
+                    "fallback": "[]",
+                },
+                {
+                    "variable_name": "second_to_last_result_name",
+                    "span_name": "rag-retrieval-savedQueries",
+                    "attribute_path": "attributes.output.value.results.-2.name",
+                    "fallback": None,
+                },
+            ],
+        }
+
+        status_code, transform = client.create_transform(
+            task_id=agentic_task.id,
+            name="Test Negative Index Transform",
+            definition=transform_definition,
+        )
+        assert status_code == 200
+
+        # Execute the transform
+        status_code, result = client.execute_transform_extraction(
+            transform_id=transform.id,
+            trace_id=test_data["trace_id"],
+        )
+
+        assert status_code == 200
+        assert result is not None
+        assert len(result.variables) == 2
+
+        variables = {var.name: var.value for var in result.variables}
+
+        # Verify complex data is JSON stringified
+        assert "last_result" in variables
+        
+        last_result = ast.literal_eval(variables["last_result"])
+        assert last_result["id"] == 2
+        assert last_result["name"] == "Jane"
+        
+        assert "second_to_last_result_name" in variables
+        assert variables["second_to_last_result_name"] == "John"
     finally:
         client.delete_transform(transform.id)
 

--- a/genai-engine/ui/package.json
+++ b/genai-engine/ui/package.json
@@ -20,7 +20,7 @@
     "@amplitude/analytics-browser": "2.36.2",
     "@amplitude/experiment-js-client": "^1.21.1",
     "@arizeai/openinference-semantic-conventions": "2.1.7",
-    "@arthur/shared-components": "3.15.2",
+    "@arthur/shared-components": "3.16.1",
     "@base-ui/react": "1.2.0",
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/sortable": "10.0.0",

--- a/genai-engine/ui/src/components/traces/components/add-to-dataset/hooks/useSpanSelector.tsx
+++ b/genai-engine/ui/src/components/traces/components/add-to-dataset/hooks/useSpanSelector.tsx
@@ -26,15 +26,17 @@ function resolveNavigationData(rawData: unknown, keys: string[]): { data: unknow
       } else {
         return { data: {}, isArray: false };
       }
-    } else {
-      const idx = Number(key);
-      if (!Number.isNaN(idx) && Array.isArray(current)) {
-        current = current[idx];
-      } else if (typeof current === "object" && current !== null && key in current) {
-        current = (current as Record<string, unknown>)[key];
-      } else {
+    } else if (Array.isArray(current) && /^-?\d+$/.test(key)) {
+      const raw = Number(key);
+      const resolved = raw < 0 ? raw + current.length : raw;
+      if (resolved < 0 || resolved >= current.length) {
         return { data: {}, isArray: false };
       }
+      current = current[resolved];
+    } else if (typeof current === "object" && current !== null && key in current) {
+      current = (current as Record<string, unknown>)[key];
+    } else {
+      return { data: {}, isArray: false };
     }
   }
 

--- a/genai-engine/ui/yarn.lock
+++ b/genai-engine/ui/yarn.lock
@@ -302,7 +302,6 @@ __metadata:
   dependencies:
     react: "npm:^19.1.1"
   checksum: 10c0/ac173b6bb3b991a12bbfb916d85e8a4e7b4f296443a305fd4079d7f77db69ac86b8142ca8b4897d84673294e6f7a58b146a52c397c371fc9a4a52b2fdf26fde8
-  checksum: 10c0/ac173b6bb3b991a12bbfb916d85e8a4e7b4f296443a305fd4079d7f77db69ac86b8142ca8b4897d84673294e6f7a58b146a52c397c371fc9a4a52b2fdf26fde8
   languageName: node
   linkType: hard
 
@@ -311,7 +310,6 @@ __metadata:
   resolution: "@arthur/unify-types@npm:3.16.0::__archiveUrl=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F54848372%2Fpackages%2Fnpm%2F%40arthur%2Funify-types%2F-%2F%40arthur%2Funify-types-3.16.0.tgz"
   dependencies:
     react: "npm:^19.1.1"
-  checksum: 10c0/7081b574d32c79493927e0aa7e9dfd200f19629c8fcc94490a940ffe4ba39e922a11a3e0572190b0f8e0b3e44c3d9ba623062d632204fd05928c02d43da24ff5
   checksum: 10c0/7081b574d32c79493927e0aa7e9dfd200f19629c8fcc94490a940ffe4ba39e922a11a3e0572190b0f8e0b3e44c3d9ba623062d632204fd05928c02d43da24ff5
   languageName: node
   linkType: hard

--- a/genai-engine/ui/yarn.lock
+++ b/genai-engine/ui/yarn.lock
@@ -250,14 +250,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@arthur/shared-components@npm:3.15.2":
-  version: 3.15.2
-  resolution: "@arthur/shared-components@npm:3.15.2::__archiveUrl=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F54848372%2Fpackages%2Fnpm%2F%40arthur%2Fshared-components%2F-%2F%40arthur%2Fshared-components-3.15.2.tgz"
+"@arthur/shared-components@npm:3.16.1":
+  version: 3.16.1
+  resolution: "@arthur/shared-components@npm:3.16.1::__archiveUrl=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F54848372%2Fpackages%2Fnpm%2F%40arthur%2Fshared-components%2F-%2F%40arthur%2Fshared-components-3.16.1.tgz"
   dependencies:
     "@amplitude/analytics-browser": "npm:2.33.3"
     "@arizeai/openinference-semantic-conventions": "npm:2.1.0"
-    "@arthur/shield-types": "npm:^3.15.0"
-    "@arthur/unify-types": "npm:^3.15.0"
+    "@arthur/shield-types": "npm:^3.16.0"
+    "@arthur/unify-types": "npm:^3.16.0"
     "@base-ui/react": "npm:1.3.0"
     "@dnd-kit/core": "npm:6.3.1"
     "@dnd-kit/sortable": "npm:10.0.0"
@@ -287,29 +287,31 @@ __metadata:
     uuid: "npm:13.0.0"
     zod: "npm:4.3.5"
   peerDependencies:
-    i18next: ^25.3.2
+    i18next: ^26.2.0
     react: ^18.0.0 || ^19.1.0
     react-dom: ^18.0.0 || ^19.1.0
     react-error-boundary: ^4.0.0
     react-i18next: ^16.5.3
-  checksum: 10c0/ae4c2f4c7bdf3784b116176a3dd38078b229dc455e7940078a357ccfdec077b31ed35a07b40b525ccf2293495a25f319974352e7aa9fe217ca0568311880d0e0
+  checksum: 10c0/fdad15efa71bb15dfc9098ca94735f78e7ff9a200b9c996fc8c409fc28eab167153872a567d06c5c10a73915be861b0609eaa050bce45ea603c1a3871562f5da
   languageName: node
   linkType: hard
 
-"@arthur/shield-types@npm:^3.15.0":
+"@arthur/shield-types@npm:^3.16.0":
   version: 3.16.0
   resolution: "@arthur/shield-types@npm:3.16.0::__archiveUrl=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F54848372%2Fpackages%2Fnpm%2F%40arthur%2Fshield-types%2F-%2F%40arthur%2Fshield-types-3.16.0.tgz"
   dependencies:
     react: "npm:^19.1.1"
   checksum: 10c0/ac173b6bb3b991a12bbfb916d85e8a4e7b4f296443a305fd4079d7f77db69ac86b8142ca8b4897d84673294e6f7a58b146a52c397c371fc9a4a52b2fdf26fde8
+  checksum: 10c0/ac173b6bb3b991a12bbfb916d85e8a4e7b4f296443a305fd4079d7f77db69ac86b8142ca8b4897d84673294e6f7a58b146a52c397c371fc9a4a52b2fdf26fde8
   languageName: node
   linkType: hard
 
-"@arthur/unify-types@npm:^3.15.0":
+"@arthur/unify-types@npm:^3.16.0":
   version: 3.16.0
   resolution: "@arthur/unify-types@npm:3.16.0::__archiveUrl=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F54848372%2Fpackages%2Fnpm%2F%40arthur%2Funify-types%2F-%2F%40arthur%2Funify-types-3.16.0.tgz"
   dependencies:
     react: "npm:^19.1.1"
+  checksum: 10c0/7081b574d32c79493927e0aa7e9dfd200f19629c8fcc94490a940ffe4ba39e922a11a3e0572190b0f8e0b3e44c3d9ba623062d632204fd05928c02d43da24ff5
   checksum: 10c0/7081b574d32c79493927e0aa7e9dfd200f19629c8fcc94490a940ffe4ba39e922a11a3e0572190b0f8e0b3e44c3d9ba623062d632204fd05928c02d43da24ff5
   languageName: node
   linkType: hard
@@ -8411,7 +8413,7 @@ __metadata:
     "@amplitude/analytics-browser": "npm:2.36.2"
     "@amplitude/experiment-js-client": "npm:^1.21.1"
     "@arizeai/openinference-semantic-conventions": "npm:2.1.7"
-    "@arthur/shared-components": "npm:3.15.2"
+    "@arthur/shared-components": "npm:3.16.1"
     "@base-ui/react": "npm:1.2.0"
     "@dnd-kit/core": "npm:6.3.1"
     "@dnd-kit/sortable": "npm:10.0.0"

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -8,11 +8,12 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-23T14:46:46.626774Z"
+exclude-newer = "2026-05-26T17:16:45.064064Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
 arthur-common = false
+arthur-client = false
 torch = false
 
 [[package]]
@@ -178,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "arthur-genai-engine"
-version = "2.1.573"
+version = "2.1.579"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Description

Adds the ability to filter transform attribute paths for lists using negative indexes to get the last items from a list and updates the demo task resources to have consistent naming as well as updating one of the transforms to use this new negative index functionality.

## Partner MR
- https://gitlab.com/ArthurAI/unify-frontend/-/merge_requests/1355