### PR TITLE
feat: add platformVersion to engine Helm charts (UP-4313)

### DIFF
--- a/deployment/helm/arthur-engine/values.yaml.template
+++ b/deployment/helm/arthur-engine/values.yaml.template
@@ -2,8 +2,13 @@
 
 env:
   suffix: &suffix ""
+  # Set platformVersion once here to apply it to all Arthur-managed images in both sub-charts.
+  # Per-component version fields take precedence when platformVersion is empty.
+  # Example: set platformVersion to "0.0.15-lts" and both sub-charts will use that image tag.
+  platformVersion: &platformVersion ""
 
 arthur-genai-engine:
+  platformVersion: *platformVersion
   ###################################
   ## Minimum Required Configurations for Arthur GenAI Engine
   ###################################
@@ -145,6 +150,7 @@ arthur-genai-engine:
   genaiEngineSecretOpenAIGPTModelNamesEndpointsKeysName: "genai-engine-secret-open-ai-gpt-model-names-endpoints-keys"
 
 arthur-ml-engine:
+  platformVersion: *platformVersion
   ###################################
   ## Minimum Required Configurations for Arthur ML Engine
   ###################################

--- a/deployment/helm/genai-engine/templates/arthur-genai-engine-daemonset.yaml
+++ b/deployment/helm/genai-engine/templates/arthur-genai-engine-daemonset.yaml
@@ -48,7 +48,7 @@ spec:
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.genaiEngineContainerImageLocation }}:{{ .Values.genaiEngineVersion }}"
+          image: "{{ .Values.genaiEngineContainerImageLocation }}:{{ if .Values.platformVersion }}{{ .Values.platformVersion }}{{ else }}{{ .Values.genaiEngineVersion }}{{ end }}"
           ports:
             - containerPort: 3030
             - containerPort: {{ .Values.postgresBYOPort }}

--- a/deployment/helm/genai-engine/templates/arthur-genai-engine-deployment.yaml
+++ b/deployment/helm/genai-engine/templates/arthur-genai-engine-deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.genaiEngineContainerImageLocation }}:{{ .Values.genaiEngineVersion }}"
+          image: "{{ .Values.genaiEngineContainerImageLocation }}:{{ if .Values.platformVersion }}{{ .Values.platformVersion }}{{ else }}{{ .Values.genaiEngineVersion }}{{ end }}"
           ports:
             - containerPort: 3030
             - containerPort: {{ .Values.postgresBYOPort }}

--- a/deployment/helm/genai-engine/values.schema.json
+++ b/deployment/helm/genai-engine/values.schema.json
@@ -489,7 +489,13 @@
                     "description": "Name of the K8s secret containing the GCP service account JSON key"
                 }
             },
-            "required": ["isEnabled"]
+            "required": [
+                "isEnabled"
+            ]
+        },
+        "platformVersion": {
+            "type": "string",
+            "description": "Override the image tag for all Arthur-managed components. Takes precedence over genaiEngineVersion when set. Leave empty to use the per-component version."
         }
     },
     "required": [

--- a/deployment/helm/genai-engine/values.yaml.template
+++ b/deployment/helm/genai-engine/values.yaml.template
@@ -1,4 +1,13 @@
 ###################################
+## Platform Version
+###################################
+# Set this to override the image tag for all Arthur-managed components at once.
+# Per-component version fields (e.g. genaiEngineVersion) take precedence when
+# platformVersion is empty. Leave empty to use the chart's built-in AppVersion.
+# Example: helm install arthur-genai-engine ... --set platformVersion=0.0.15-lts
+platformVersion: ""
+
+###################################
 ## Minimum Required Configurations
 ###################################
 # postgres database URL

--- a/deployment/helm/ml-engine/templates/deployment.yaml
+++ b/deployment/helm/ml-engine/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
       containers:
         - name: arthur-ml-engine
-          image: "{{ .Values.containerRepository.imageLocation }}/{{ .Values.mlEngine.deployment.containerImageName }}:{{ .Values.mlEngine.deployment.containerImageVersion }}"
+          image: "{{ .Values.containerRepository.imageLocation }}/{{ .Values.mlEngine.deployment.containerImageName }}:{{ if .Values.platformVersion }}{{ .Values.platformVersion }}{{ else }}{{ .Values.mlEngine.deployment.containerImageVersion }}{{ end }}"
           imagePullPolicy: Always
           securityContext:
             runAsUser: 65532

--- a/deployment/helm/ml-engine/values.schema.json
+++ b/deployment/helm/ml-engine/values.schema.json
@@ -1,158 +1,162 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "ML Engine Helm Chart Values",
-    "type": "object",
-    "properties": {
-        "resourceNameSuffix": {
-            "type": "string",
-            "description": "Optional suffix for resource names."
-        },
-        "containerRepository": {
-            "type": "object",
-            "properties": {
-                "imageLocation": {
-                    "type": "string",
-                    "description": "The location of the container image repository."
-                },
-                "credentialsRequired": {
-                    "type": "boolean",
-                    "description": "Indicates if credentials are required to pull the image."
-                },
-                "imagePullSecretName": {
-                    "type": "string",
-                    "description": "The name of the secret containing image pull credentials."
-                }
-            },
-            "required": [
-                "imageLocation",
-                "credentialsRequired",
-                "imagePullSecretName"
-            ]
-        },
-        "mlEngine": {
-            "type": "object",
-            "properties": {
-                "deployment": {
-                    "type": "object",
-                    "properties": {
-                        "replicas": {
-                            "type": "integer",
-                            "description": "The number of replicas for the deployment."
-                        },
-                        "labels": {
-                            "type": "object",
-                            "description": "Custom labels for the deployment."
-                        },
-                        "annotations": {
-                            "type": "object",
-                            "description": "Custom annotations for the deployment."
-                        },
-                        "mlEnginePodLabels": {
-                            "type": "object",
-                            "description": "Labels for the ML Engine pods."
-                        },
-                        "mlEngineServiceAccount": {
-                            "type": "object",
-                            "properties": {
-                                "create": {
-                                    "type": "boolean"
-                                },
-                                "name": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "create",
-                                "name"
-                            ],
-                            "description": "Name of the service account used by the ML Engine pod"
-                        },
-                        "containerImageName": {
-                            "type": "string",
-                            "description": "The name of the container image."
-                        },
-                        "containerImageVersion": {
-                            "type": "string",
-                            "description": "The version of the container image."
-                        },
-                        "containerMemoryRequests": {
-                            "type": "string",
-                            "description": "The memory requests for the container."
-                        },
-                        "containerCPURequests": {
-                            "type": "string",
-                            "description": "The CPU requests for the container."
-                        },
-                        "containerMemoryLimits": {
-                            "type": "string",
-                            "description": "The memory limits for the container."
-                        },
-                        "containerCPULimits": {
-                            "type": "string",
-                            "description": "The CPU limits for the container."
-                        },
-                        "appPlaneUrl": {
-                            "type": "string",
-                            "description": "The URL of the application plane."
-                        },
-                        "mlEngineClientSecretName": {
-                            "type": "string",
-                            "description": "The name of the ML Engine client credentials secret."
-                        },
-                        "mlEnginePodNodeSelector": {
-                            "type": "object",
-                            "description": "Node selector for the ml engine pods."
-                        },
-                        "mlEnginePodAffinity": {
-                            "type": "object",
-                            "description": "Affinity settings for the ml engine pods."
-                        },
-                        "mlEnginePodTolerations": {
-                            "type": "object",
-                            "description": "Tolerations for the ml engine pods."
-                        },
-                        "genaiEngineInternalAPIKeySecretName": {
-                            "type": "string",
-                            "description": "The name of the secret containing the internal API key for GenAI Engine."
-                        },
-                        "genaiEngineInternalHost": {
-                            "type": "string",
-                            "description": "The internal host name for the GenAI Engine service."
-                        },
-                        "genaiEngineInternalIngressHost": {
-                            "type": "string",
-                            "description": "The internal ingress host addressfor GenAI Engine."
-                        },
-                        "fetchRawDataEnabled": {
-                            "type": "boolean",
-                            "description": "Whether to fetch raw data from the data plane."
-                        },
-                        "genaiEngineMaxPageSize": {
-                            "type": "integer",
-                            "description": "Max page size for fetching data from the GenAI Engine.",
-                            "default": 1500
-                        }
-                    },
-                    "required": [
-                        "replicas",
-                        "containerImageName",
-                        "containerImageVersion",
-                        "containerMemoryRequests",
-                        "containerCPURequests",
-                        "containerMemoryLimits",
-                        "containerCPULimits",
-                        "appPlaneUrl",
-                        "mlEngineClientSecretName",
-                        "genaiEngineInternalAPIKeySecretName",
-                        "genaiEngineInternalHost",
-                        "genaiEngineInternalIngressHost"
-                    ]
-                }
-            }
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ML Engine Helm Chart Values",
+  "type": "object",
+  "properties": {
+    "resourceNameSuffix": {
+      "type": "string",
+      "description": "Optional suffix for resource names."
     },
-    "required": [
-        "containerRepository",
-        "mlEngine"
-    ]
+    "containerRepository": {
+      "type": "object",
+      "properties": {
+        "imageLocation": {
+          "type": "string",
+          "description": "The location of the container image repository."
+        },
+        "credentialsRequired": {
+          "type": "boolean",
+          "description": "Indicates if credentials are required to pull the image."
+        },
+        "imagePullSecretName": {
+          "type": "string",
+          "description": "The name of the secret containing image pull credentials."
+        }
+      },
+      "required": [
+        "imageLocation",
+        "credentialsRequired",
+        "imagePullSecretName"
+      ]
+    },
+    "mlEngine": {
+      "type": "object",
+      "properties": {
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "replicas": {
+              "type": "integer",
+              "description": "The number of replicas for the deployment."
+            },
+            "labels": {
+              "type": "object",
+              "description": "Custom labels for the deployment."
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Custom annotations for the deployment."
+            },
+            "mlEnginePodLabels": {
+              "type": "object",
+              "description": "Labels for the ML Engine pods."
+            },
+            "mlEngineServiceAccount": {
+              "type": "object",
+              "properties": {
+                "create": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "create",
+                "name"
+              ],
+              "description": "Name of the service account used by the ML Engine pod"
+            },
+            "containerImageName": {
+              "type": "string",
+              "description": "The name of the container image."
+            },
+            "containerImageVersion": {
+              "type": "string",
+              "description": "The version of the container image."
+            },
+            "containerMemoryRequests": {
+              "type": "string",
+              "description": "The memory requests for the container."
+            },
+            "containerCPURequests": {
+              "type": "string",
+              "description": "The CPU requests for the container."
+            },
+            "containerMemoryLimits": {
+              "type": "string",
+              "description": "The memory limits for the container."
+            },
+            "containerCPULimits": {
+              "type": "string",
+              "description": "The CPU limits for the container."
+            },
+            "appPlaneUrl": {
+              "type": "string",
+              "description": "The URL of the application plane."
+            },
+            "mlEngineClientSecretName": {
+              "type": "string",
+              "description": "The name of the ML Engine client credentials secret."
+            },
+            "mlEnginePodNodeSelector": {
+              "type": "object",
+              "description": "Node selector for the ml engine pods."
+            },
+            "mlEnginePodAffinity": {
+              "type": "object",
+              "description": "Affinity settings for the ml engine pods."
+            },
+            "mlEnginePodTolerations": {
+              "type": "object",
+              "description": "Tolerations for the ml engine pods."
+            },
+            "genaiEngineInternalAPIKeySecretName": {
+              "type": "string",
+              "description": "The name of the secret containing the internal API key for GenAI Engine."
+            },
+            "genaiEngineInternalHost": {
+              "type": "string",
+              "description": "The internal host name for the GenAI Engine service."
+            },
+            "genaiEngineInternalIngressHost": {
+              "type": "string",
+              "description": "The internal ingress host addressfor GenAI Engine."
+            },
+            "fetchRawDataEnabled": {
+              "type": "boolean",
+              "description": "Whether to fetch raw data from the data plane."
+            },
+            "genaiEngineMaxPageSize": {
+              "type": "integer",
+              "description": "Max page size for fetching data from the GenAI Engine.",
+              "default": 1500
+            }
+          },
+          "required": [
+            "replicas",
+            "containerImageName",
+            "containerImageVersion",
+            "containerMemoryRequests",
+            "containerCPURequests",
+            "containerMemoryLimits",
+            "containerCPULimits",
+            "appPlaneUrl",
+            "mlEngineClientSecretName",
+            "genaiEngineInternalAPIKeySecretName",
+            "genaiEngineInternalHost",
+            "genaiEngineInternalIngressHost"
+          ]
+        }
+      }
+    },
+    "platformVersion": {
+      "type": "string",
+      "description": "Override the image tag for all Arthur-managed components. Takes precedence over mlEngine.deployment.containerImageVersion when set. Leave empty to use the per-component version."
+    }
+  },
+  "required": [
+    "containerRepository",
+    "mlEngine"
+  ]
 }

--- a/deployment/helm/ml-engine/values.schema.json
+++ b/deployment/helm/ml-engine/values.schema.json
@@ -1,162 +1,162 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ML Engine Helm Chart Values",
-  "type": "object",
-  "properties": {
-    "resourceNameSuffix": {
-      "type": "string",
-      "description": "Optional suffix for resource names."
-    },
-    "containerRepository": {
-      "type": "object",
-      "properties": {
-        "imageLocation": {
-          "type": "string",
-          "description": "The location of the container image repository."
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ML Engine Helm Chart Values",
+    "type": "object",
+    "properties": {
+        "platformVersion": {
+            "type": "string",
+            "description": "Override the image tag for all Arthur-managed components. Takes precedence over mlEngine.deployment.containerImageVersion when set. Leave empty to use the per-component version."
         },
-        "credentialsRequired": {
-          "type": "boolean",
-          "description": "Indicates if credentials are required to pull the image."
+        "resourceNameSuffix": {
+            "type": "string",
+            "description": "Optional suffix for resource names."
         },
-        "imagePullSecretName": {
-          "type": "string",
-          "description": "The name of the secret containing image pull credentials."
-        }
-      },
-      "required": [
-        "imageLocation",
-        "credentialsRequired",
-        "imagePullSecretName"
-      ]
-    },
-    "mlEngine": {
-      "type": "object",
-      "properties": {
-        "deployment": {
-          "type": "object",
-          "properties": {
-            "replicas": {
-              "type": "integer",
-              "description": "The number of replicas for the deployment."
-            },
-            "labels": {
-              "type": "object",
-              "description": "Custom labels for the deployment."
-            },
-            "annotations": {
-              "type": "object",
-              "description": "Custom annotations for the deployment."
-            },
-            "mlEnginePodLabels": {
-              "type": "object",
-              "description": "Labels for the ML Engine pods."
-            },
-            "mlEngineServiceAccount": {
-              "type": "object",
-              "properties": {
-                "create": {
-                  "type": "boolean"
+        "containerRepository": {
+            "type": "object",
+            "properties": {
+                "imageLocation": {
+                    "type": "string",
+                    "description": "The location of the container image repository."
                 },
-                "name": {
-                  "type": "string"
+                "credentialsRequired": {
+                    "type": "boolean",
+                    "description": "Indicates if credentials are required to pull the image."
+                },
+                "imagePullSecretName": {
+                    "type": "string",
+                    "description": "The name of the secret containing image pull credentials."
                 }
-              },
-              "required": [
-                "create",
-                "name"
-              ],
-              "description": "Name of the service account used by the ML Engine pod"
             },
-            "containerImageName": {
-              "type": "string",
-              "description": "The name of the container image."
-            },
-            "containerImageVersion": {
-              "type": "string",
-              "description": "The version of the container image."
-            },
-            "containerMemoryRequests": {
-              "type": "string",
-              "description": "The memory requests for the container."
-            },
-            "containerCPURequests": {
-              "type": "string",
-              "description": "The CPU requests for the container."
-            },
-            "containerMemoryLimits": {
-              "type": "string",
-              "description": "The memory limits for the container."
-            },
-            "containerCPULimits": {
-              "type": "string",
-              "description": "The CPU limits for the container."
-            },
-            "appPlaneUrl": {
-              "type": "string",
-              "description": "The URL of the application plane."
-            },
-            "mlEngineClientSecretName": {
-              "type": "string",
-              "description": "The name of the ML Engine client credentials secret."
-            },
-            "mlEnginePodNodeSelector": {
-              "type": "object",
-              "description": "Node selector for the ml engine pods."
-            },
-            "mlEnginePodAffinity": {
-              "type": "object",
-              "description": "Affinity settings for the ml engine pods."
-            },
-            "mlEnginePodTolerations": {
-              "type": "object",
-              "description": "Tolerations for the ml engine pods."
-            },
-            "genaiEngineInternalAPIKeySecretName": {
-              "type": "string",
-              "description": "The name of the secret containing the internal API key for GenAI Engine."
-            },
-            "genaiEngineInternalHost": {
-              "type": "string",
-              "description": "The internal host name for the GenAI Engine service."
-            },
-            "genaiEngineInternalIngressHost": {
-              "type": "string",
-              "description": "The internal ingress host addressfor GenAI Engine."
-            },
-            "fetchRawDataEnabled": {
-              "type": "boolean",
-              "description": "Whether to fetch raw data from the data plane."
-            },
-            "genaiEngineMaxPageSize": {
-              "type": "integer",
-              "description": "Max page size for fetching data from the GenAI Engine.",
-              "default": 1500
+            "required": [
+                "imageLocation",
+                "credentialsRequired",
+                "imagePullSecretName"
+            ]
+        },
+        "mlEngine": {
+            "type": "object",
+            "properties": {
+                "deployment": {
+                    "type": "object",
+                    "properties": {
+                        "replicas": {
+                            "type": "integer",
+                            "description": "The number of replicas for the deployment."
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Custom labels for the deployment."
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Custom annotations for the deployment."
+                        },
+                        "mlEnginePodLabels": {
+                            "type": "object",
+                            "description": "Labels for the ML Engine pods."
+                        },
+                        "mlEngineServiceAccount": {
+                            "type": "object",
+                            "properties": {
+                                "create": {
+                                    "type": "boolean"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "create",
+                                "name"
+                            ],
+                            "description": "Name of the service account used by the ML Engine pod"
+                        },
+                        "containerImageName": {
+                            "type": "string",
+                            "description": "The name of the container image."
+                        },
+                        "containerImageVersion": {
+                            "type": "string",
+                            "description": "The version of the container image."
+                        },
+                        "containerMemoryRequests": {
+                            "type": "string",
+                            "description": "The memory requests for the container."
+                        },
+                        "containerCPURequests": {
+                            "type": "string",
+                            "description": "The CPU requests for the container."
+                        },
+                        "containerMemoryLimits": {
+                            "type": "string",
+                            "description": "The memory limits for the container."
+                        },
+                        "containerCPULimits": {
+                            "type": "string",
+                            "description": "The CPU limits for the container."
+                        },
+                        "appPlaneUrl": {
+                            "type": "string",
+                            "description": "The URL of the application plane."
+                        },
+                        "mlEngineClientSecretName": {
+                            "type": "string",
+                            "description": "The name of the ML Engine client credentials secret."
+                        },
+                        "mlEnginePodNodeSelector": {
+                            "type": "object",
+                            "description": "Node selector for the ml engine pods."
+                        },
+                        "mlEnginePodAffinity": {
+                            "type": "object",
+                            "description": "Affinity settings for the ml engine pods."
+                        },
+                        "mlEnginePodTolerations": {
+                            "type": "object",
+                            "description": "Tolerations for the ml engine pods."
+                        },
+                        "genaiEngineInternalAPIKeySecretName": {
+                            "type": "string",
+                            "description": "The name of the secret containing the internal API key for GenAI Engine."
+                        },
+                        "genaiEngineInternalHost": {
+                            "type": "string",
+                            "description": "The internal host name for the GenAI Engine service."
+                        },
+                        "genaiEngineInternalIngressHost": {
+                            "type": "string",
+                            "description": "The internal ingress host addressfor GenAI Engine."
+                        },
+                        "fetchRawDataEnabled": {
+                            "type": "boolean",
+                            "description": "Whether to fetch raw data from the data plane."
+                        },
+                        "genaiEngineMaxPageSize": {
+                            "type": "integer",
+                            "description": "Max page size for fetching data from the GenAI Engine.",
+                            "default": 1500
+                        }
+                    },
+                    "required": [
+                        "replicas",
+                        "containerImageName",
+                        "containerImageVersion",
+                        "containerMemoryRequests",
+                        "containerCPURequests",
+                        "containerMemoryLimits",
+                        "containerCPULimits",
+                        "appPlaneUrl",
+                        "mlEngineClientSecretName",
+                        "genaiEngineInternalAPIKeySecretName",
+                        "genaiEngineInternalHost",
+                        "genaiEngineInternalIngressHost"
+                    ]
+                }
             }
-          },
-          "required": [
-            "replicas",
-            "containerImageName",
-            "containerImageVersion",
-            "containerMemoryRequests",
-            "containerCPURequests",
-            "containerMemoryLimits",
-            "containerCPULimits",
-            "appPlaneUrl",
-            "mlEngineClientSecretName",
-            "genaiEngineInternalAPIKeySecretName",
-            "genaiEngineInternalHost",
-            "genaiEngineInternalIngressHost"
-          ]
         }
-      }
     },
-    "platformVersion": {
-      "type": "string",
-      "description": "Override the image tag for all Arthur-managed components. Takes precedence over mlEngine.deployment.containerImageVersion when set. Leave empty to use the per-component version."
-    }
-  },
-  "required": [
-    "containerRepository",
-    "mlEngine"
-  ]
+    "required": [
+        "containerRepository",
+        "mlEngine"
+    ]
 }

--- a/deployment/helm/ml-engine/values.yaml.template
+++ b/deployment/helm/ml-engine/values.yaml.template
@@ -1,3 +1,9 @@
+# Set this to override the image tag for all Arthur-managed components at once.
+# Per-component version fields take precedence when platformVersion is empty.
+# Leave empty to use the chart's built-in AppVersion.
+# Example: helm install arthur-ml-engine ... --set platformVersion=0.0.15-lts
+platformVersion: ""
+
 containerRepository:
   imageLocation: "arthurplatform"
   credentialsRequired: false


### PR DESCRIPTION
## Summary

Adds a top-level `platformVersion` field to the `arthur-genai-engine` and `arthur-ml-engine` Helm chart values templates so operators can set a single value to control the image tag for all Arthur-managed components.

Companion to arthur-scope!... (UP-4302).

## Behavior

Priority order: `platformVersion` > per-component version field (`genaiEngineVersion` / `mlEngine.deployment.containerImageVersion`)

## Affected charts

| Chart | Template files |
|---|---|
| `genai-engine` | `arthur-genai-engine-deployment.yaml`, `arthur-genai-engine-daemonset.yaml` |
| `ml-engine` | `deployment.yaml` |
| `arthur-engine` (meta) | `values.yaml.template` only — YAML anchor wires `platformVersion` to both sub-charts |

## Usage

```bash
# Leaf chart
helm install arthur-genai-engine oci://ghcr.io/arthur-ai/arthur-engine/charts/arthur-genai-engine \
  --version 0.0.15-lts \
  --set platformVersion=0.0.15-lts \
  -f my-values.yaml

# Meta chart (values.yaml.template already wires via YAML anchor)
# Just set: platformVersion: &platformVersion "0.0.15-lts"
```

## Testing

```bash
# helm template smoke tests (both pass):
helm template test deployment/helm/genai-engine --set platformVersion=0.0.14-lts ...
# → arthurplatform/genai-engine-cpu:0.0.14-lts ✓

helm template test deployment/helm/ml-engine --set platformVersion=0.0.14-lts ...
# → arthurplatform/ml-engine:0.0.14-lts ✓

# Without platformVersion falls back to per-component version:
# → arthurplatform/genai-engine-cpu:2.1.579 ✓
# → arthurplatform/ml-engine:2.1.579 ✓
```

Note: the `ml-engine` chart has a pre-existing schema lint failure (`genaiEngineInternalHost` required in schema but absent from `values.yaml.template`) that is unrelated to this PR.

Closes UP-4313

🤖 Generated with [Claude Code](https://claude.com/claude-code)