### PR TITLE
fix(multitenancy): send valid signup body in tests for /tenant/signup

### DIFF
--- a/genai-engine/tests/clients/base_test_client.py
+++ b/genai-engine/tests/clients/base_test_client.py
@@ -526,7 +526,23 @@ class GenaiEngineTestClientBase(httpx.Client):
         )
 
     def signup_tenant(self) -> tuple[int, DemoTaskSignupResponse | None]:
-        resp = self.base_client.post("/api/v2/tenant/signup")
+        resp = self.base_client.post(
+            "/api/v2/tenant/signup",
+            json={
+                "form_variant": "linear",
+                "form_data": {
+                    "first_name": "Test",
+                    "last_name": "Tenant",
+                    "email": "test@example.com",
+                    "job_title": "Engineer",
+                    "company": "TestCo",
+                    "maturity": "exploring",
+                    "brings": "evals",
+                    "competitors": ["langsmith"],
+                    "attribution": "search",
+                },
+            },
+        )
 
         log_response(resp)
 

--- a/genai-engine/tests/multitenancy/test_isolation.py
+++ b/genai-engine/tests/multitenancy/test_isolation.py
@@ -27,6 +27,24 @@ from tests.multitenancy.conftest import TenantWorld
 SIGNUP_URL = "/api/v2/tenant/signup"
 ME_URL = "/users/me"
 
+# Minimal valid body for POST /api/v2/tenant/signup. These tests don't care
+# about the onboarding payload itself — they only need the request to clear
+# body validation so the demo-mode gate / signup logic can be exercised.
+_VALID_SIGNUP_BODY = {
+    "form_variant": "linear",
+    "form_data": {
+        "first_name": "Test",
+        "last_name": "Tenant",
+        "email": "test@example.com",
+        "job_title": "Engineer",
+        "company": "TestCo",
+        "maturity": "exploring",
+        "brings": "evals",
+        "competitors": ["langsmith"],
+        "attribution": "search",
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # Parametrized isolation cases (Patterns A, C, D).
@@ -847,11 +865,12 @@ def test_users_me_for_admin(tenant_world: TenantWorld):
 
 @pytest.mark.unit_tests
 def test_signup_flag_off_returns_404():
-    """Without GENAI_ENGINE_DEMO_MODE the route 404s for everyone."""
+    """Without GENAI_ENGINE_DEMO_MODE the route 404s for everyone — even for
+    well-formed requests."""
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("GENAI_ENGINE_DEMO_MODE", None)
         test_client = TestClient(app)
-        response = test_client.post(SIGNUP_URL)
+        response = test_client.post(SIGNUP_URL, json=_VALID_SIGNUP_BODY)
     assert response.status_code == 404
 
 
@@ -869,7 +888,7 @@ def test_signup_flag_on_returned_key_can_only_access_new_task(
     try:
         with patch.dict(os.environ, {"GENAI_ENGINE_DEMO_MODE": "ENABLED"}):
             test_client = TestClient(app)
-            sig = test_client.post(SIGNUP_URL).json()
+            sig = test_client.post(SIGNUP_URL, json=_VALID_SIGNUP_BODY).json()
         new_headers = {"Authorization": f"Bearer {sig['api_key']}"}
         # New tenant CANNOT see T1a
         cross = tenant_world.client.base_client.get(


### PR DESCRIPTION
## Summary
- The `POST /api/v2/tenant/signup` endpoint requires a `TenantSignupRequest` body — missing or invalid bodies should be rejected with 400. **That's expected behavior**, not a bug.
- 5 tests on `UP-4387-multitenancy` were POSTing without a body and asserting either 404 (demo-off) or 200 (success) — they hit FastAPI's validator (400) before reaching either branch.
- Fix the tests, not the route.

## What changed
- `tests/clients/base_test_client.py::signup_tenant()` — the shared helper used by demo-chatbot tests now POSTs a minimal valid onboarding payload.
- `tests/multitenancy/test_isolation.py` — adds module-level `_VALID_SIGNUP_BODY` and passes it to the two raw `POST(SIGNUP_URL)` calls. The flag-off 404 test now verifies the stronger property: a **well-formed** request still 404s when demo mode is disabled (the previous version only proved that an empty body 400s, which is uninteresting).
- **Route untouched** — `body: TenantSignupRequest` stays required.

## Note on rebase context
These 5 tests were already failing on the pre-rebase tip of `UP-4387-multitenancy` (commit `bc99a342`) — confirmed by inspection. The test commit `aea2f179` was authored *after* `d0983795` (which made `body` required), but didn't include a body in its POSTs. Likely never run in CI on this branch.

## Fixed tests
- `tests/multitenancy/test_isolation.py::test_signup_flag_off_returns_404`
- `tests/multitenancy/test_isolation.py::test_signup_flag_on_returned_key_can_only_access_new_task`
- `tests/unit/routes/tasks/test_demo_task_routes.py::test_stream_demo_chatbot_streams_response`
- `tests/unit/routes/tasks/test_demo_task_routes.py::test_stream_demo_chatbot_yields_error_when_stream_raises`
- `tests/unit/routes/tasks/test_demo_task_routes.py::test_demo_chatbot_emits_enriched_tool_events`

## Test plan
- [x] All 5 originally-failing tests pass locally
- [x] Broader scope: 76 passed across `tests/multitenancy/`, `tests/unit/routes/tasks/test_demo_task_routes.py`, `tests/unit/routes/test_tenant_signup.py`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)