### PR TITLE
feat(deploy): wire Amplitude and reCAPTCHA Enterprise env plumbing

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -400,6 +400,9 @@ jobs:
             METICULOUS_RECORDING_TOKEN=${{ secrets.METICULOUS_RECORDING_TOKEN }}
             METICULOUS_API_TOKEN=${{ secrets.METICULOUS_API_TOKEN }}
             GITLAB_UNIFY_FRONTEND_TOKEN=${{ secrets.GITLAB_UNIFY_FRONTEND_TOKEN }}
+            AMPLITUDE_API_KEY=${{ secrets.AMPLITUDE_API_KEY }}
+            VITE_AMPLITUDE_DEPLOYMENT_KEY=${{ secrets.AMPLITUDE_DEPLOYMENT_KEY }}
+            RECAPTCHA_ENTERPRISE_SITE_KEY=${{ secrets.RECAPTCHA_ENTERPRISE_SITE_KEY }}
           tags: |
             arthurplatform/genai-engine-${{ matrix.torch_device }}:${{ env.VERSION }}
             ${{ github.ref == 'refs/heads/main' && format('arthurplatform/genai-engine-{0}:latest', matrix.torch_device) || '' }}

--- a/deployment/cloudformation/genai-engine/arthur-genai-engine-ecs-task-definition-gpu.yml
+++ b/deployment/cloudformation/genai-engine/arthur-genai-engine-ecs-task-definition-gpu.yml
@@ -108,6 +108,19 @@ Parameters:
     Type: String
     Description: 'GenAI Engine secret store key ARN'
     NoEcho: true
+  RecaptchaEnterpriseProjectId:
+    Type: String
+    Description: 'Google Cloud project id hosting the reCAPTCHA Enterprise key. Leave blank to disable reCAPTCHA verification on the public tenant signup endpoint.'
+    Default: ''
+  RecaptchaEnterpriseSiteKey:
+    Type: String
+    Description: 'reCAPTCHA Enterprise site key used by the backend assessment call. Must match the site key baked into the UI build. Leave blank to disable reCAPTCHA verification.'
+    Default: ''
+  GenaiEngineSecretRecaptchaApiKeyARN:
+    Type: String
+    Description: 'ARN of the secret holding the reCAPTCHA Enterprise REST API key. Leave blank to disable reCAPTCHA verification.'
+    NoEcho: true
+    Default: ''
   GenaiEngineAPIOnlyModeEnabled:
     Type: String
     Description: 'Enable GenAI Engine API-only mode without the UI components'
@@ -229,6 +242,7 @@ Conditions:
   IsContainerRepositoryCredentialRequired: !Equals [ !Ref ContainerRepositoryCredentialRequired, 'true' ]
   ImportAuthServiceCertificate: !Not [ !Equals [ !Ref AuthLoadBalancerCertificateURL, '' ] ]
   ImportGenaiEngineSecretOpenAIEmbeddingModelNamesEndpointsKeysARN: !Not [ !Equals [ !Ref GenaiEngineSecretOpenAIEmbeddingModelNamesEndpointsKeysARN, '' ] ]
+  ImportGenaiEngineSecretRecaptchaApiKeyARN: !Not [ !Equals [ !Ref GenaiEngineSecretRecaptchaApiKeyARN, '' ] ]
   UseInternalModelRepository: !Not [ !Equals [ !Ref GenaiEngineModelRepositoryURL, '' ] ]
   IsAuditLogEnabled: !Equals [ !Ref AuditLogEnabled, 'true' ]
 
@@ -315,6 +329,10 @@ Resources:
               Value: !Ref GenaiEngineAPIOnlyModeEnabled
             - Name: 'GENAI_ENGINE_DEMO_MODE'
               Value: !Ref GenaiEngineDemoMode
+            - Name: 'RECAPTCHA_ENTERPRISE_PROJECT_ID'
+              Value: !Ref RecaptchaEnterpriseProjectId
+            - Name: 'RECAPTCHA_ENTERPRISE_SITE_KEY'
+              Value: !Ref RecaptchaEnterpriseSiteKey
             - Name: 'TRANSFER_ENCODING_MIDDLEWARE_ENABLED'
               Value: !Ref TransferEncodingMiddlewareEnabled
             - Name: 'GENAI_ENGINE_SENSITIVE_DATA_CHECK_MAX_TOKEN_LIMIT'
@@ -413,6 +431,11 @@ Resources:
               ValueFrom: !Ref GenaiEngineAppSecretKeyARN
             - Name: 'GENAI_ENGINE_SECRET_STORE_KEY'
               ValueFrom: !Ref GenaiEngineSecretStoreKeyARN
+            - !If
+              - ImportGenaiEngineSecretRecaptchaApiKeyARN
+              - Name: 'RECAPTCHA_ENTERPRISE_API_KEY'
+                ValueFrom: !Ref GenaiEngineSecretRecaptchaApiKeyARN
+              - !Ref AWS::NoValue
             - !If
               - EnableAuthService
               - Name: 'AUTH_ADMIN_CONSOLE_PASSWORD'

--- a/deployment/cloudformation/genai-engine/arthur-genai-engine-ecs-task-definition.yml
+++ b/deployment/cloudformation/genai-engine/arthur-genai-engine-ecs-task-definition.yml
@@ -108,6 +108,19 @@ Parameters:
     Type: String
     Description: 'GenAI Engine secret store key ARN'
     NoEcho: true
+  RecaptchaEnterpriseProjectId:
+    Type: String
+    Description: 'Google Cloud project id hosting the reCAPTCHA Enterprise key. Leave blank to disable reCAPTCHA verification on the public tenant signup endpoint.'
+    Default: ''
+  RecaptchaEnterpriseSiteKey:
+    Type: String
+    Description: 'reCAPTCHA Enterprise site key used by the backend assessment call. Must match the site key baked into the UI build. Leave blank to disable reCAPTCHA verification.'
+    Default: ''
+  GenaiEngineSecretRecaptchaApiKeyARN:
+    Type: String
+    Description: 'ARN of the secret holding the reCAPTCHA Enterprise REST API key. Leave blank to disable reCAPTCHA verification.'
+    NoEcho: true
+    Default: ''
   GenaiEngineAPIOnlyModeEnabled:
     Type: String
     Description: 'Enable GenAI Engine API-only mode without the UI components'
@@ -225,6 +238,7 @@ Conditions:
   IsContainerRepositoryCredentialRequired: !Equals [ !Ref ContainerRepositoryCredentialRequired, 'true' ]
   ImportAuthServiceCertificate: !Not [ !Equals [ !Ref AuthLoadBalancerCertificateURL, '' ] ]
   ImportGenaiEngineSecretOpenAIEmbeddingModelNamesEndpointsKeysARN: !Not [ !Equals [ !Ref GenaiEngineSecretOpenAIEmbeddingModelNamesEndpointsKeysARN, '' ] ]
+  ImportGenaiEngineSecretRecaptchaApiKeyARN: !Not [ !Equals [ !Ref GenaiEngineSecretRecaptchaApiKeyARN, '' ] ]
   UseInternalModelRepository: !Not [ !Equals [ !Ref GenaiEngineModelRepositoryURL, '' ] ]
   IsAuditLogEnabled: !Equals [ !Ref AuditLogEnabled, 'true' ]
 
@@ -305,6 +319,10 @@ Resources:
               Value: !Ref GenaiEngineAPIOnlyModeEnabled
             - Name: 'GENAI_ENGINE_DEMO_MODE'
               Value: !Ref GenaiEngineDemoMode
+            - Name: 'RECAPTCHA_ENTERPRISE_PROJECT_ID'
+              Value: !Ref RecaptchaEnterpriseProjectId
+            - Name: 'RECAPTCHA_ENTERPRISE_SITE_KEY'
+              Value: !Ref RecaptchaEnterpriseSiteKey
             - Name: 'TRANSFER_ENCODING_MIDDLEWARE_ENABLED'
               Value: !Ref TransferEncodingMiddlewareEnabled
             - Name: 'GENAI_ENGINE_SENSITIVE_DATA_CHECK_MAX_TOKEN_LIMIT'
@@ -403,6 +421,11 @@ Resources:
               ValueFrom: !Ref GenaiEngineAppSecretKeyARN
             - Name: 'GENAI_ENGINE_SECRET_STORE_KEY'
               ValueFrom: !Ref GenaiEngineSecretStoreKeyARN
+            - !If
+              - ImportGenaiEngineSecretRecaptchaApiKeyARN
+              - Name: 'RECAPTCHA_ENTERPRISE_API_KEY'
+                ValueFrom: !Ref GenaiEngineSecretRecaptchaApiKeyARN
+              - !Ref AWS::NoValue
             - !If
               - EnableAuthService
               - Name: 'AUTH_ADMIN_CONSOLE_PASSWORD'

--- a/deployment/cloudformation/genai-engine/arthur-genai-engine-secrets-manager.yml
+++ b/deployment/cloudformation/genai-engine/arthur-genai-engine-secrets-manager.yml
@@ -24,6 +24,11 @@ Parameters:
     Description: "Connection strings for OpenAI text-embedding-ada-002 embedding model endpoints. Must be in form \"DEPLOYMENT_NAME1::OPENAI_ENDPOINT1::SECRET_KEY1,DEPLOYMENT_NAME2::OPENAI_ENDPOINT2::SECRET_KEY2\"). The URLs must end with '/'. Many may be specified. Leave blank if Chat is disabled."
     Type: String
     NoEcho: true
+  RecaptchaEnterpriseApiKey:
+    Description: "reCAPTCHA Enterprise REST API key used to create assessments for the public tenant signup endpoint. Leave as 'none' to disable reCAPTCHA verification (the signup endpoint then fails open)."
+    Type: String
+    NoEcho: true
+    Default: 'none'
 Conditions:
   IsOpenAIEmbeddingModelNamesEndpointsAndKeysEmpty: !Equals [ !Ref OpenAIEmbeddingModelNamesEndpointsAndKeys, '' ]
 Resources:
@@ -69,6 +74,11 @@ Resources:
         ExcludePunctuation: true
         IncludeSpace: false
         PasswordLength: 32
+  GenaiEngineRecaptchaEnterpriseApiKeySecret:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Name: !Sub "${ArthurResourceNamespace}_genai_engine_recaptcha_enterprise_api_key${ArthurResourceNameSuffix}"
+      SecretString: !Ref RecaptchaEnterpriseApiKey
 Outputs:
   GenaiEngineOpenAIEmbeddingModelNamesEndpointsAndKeysSecretOutput:
     Description: 'Secret containing OpenAI embedding model connection strings'
@@ -88,3 +98,6 @@ Outputs:
   GenaiEngineSecretStoreKeySecretOutput:
     Description: 'Secret store key for GenAI Engine services'
     Value: !Ref GenaiEngineSecretStoreKeySecret
+  GenaiEngineRecaptchaEnterpriseApiKeySecretOutput:
+    Description: 'Secret containing the reCAPTCHA Enterprise REST API key'
+    Value: !Ref GenaiEngineRecaptchaEnterpriseApiKeySecret

--- a/deployment/cloudformation/root-arthur-engine-cpu.yml
+++ b/deployment/cloudformation/root-arthur-engine-cpu.yml
@@ -264,6 +264,19 @@ Parameters:
       - 'disabled'
     Default: 'disabled'
     Description: 'Enable GenAI Engine demo mode'
+  RecaptchaEnterpriseProjectId:
+    Type: String
+    Default: ''
+    Description: 'Google Cloud project id hosting the reCAPTCHA Enterprise key. Leave blank to disable reCAPTCHA on the public tenant signup endpoint.'
+  RecaptchaEnterpriseSiteKey:
+    Type: String
+    Default: ''
+    Description: 'reCAPTCHA Enterprise site key for the backend assessment call. Must match the site key baked into the UI build. Leave blank to disable reCAPTCHA.'
+  RecaptchaEnterpriseApiKey:
+    Type: String
+    NoEcho: true
+    Default: 'none'
+    Description: "reCAPTCHA Enterprise REST API key for creating assessments. Leave as 'none' to disable reCAPTCHA verification."
   GenaiEngineOpenAIProvider:
     Type: String
     AllowedValues:
@@ -714,6 +727,7 @@ Resources:
         ArthurResourceNameSuffix: !Ref ArthurResourceNameSuffix
         OpenAIEmbeddingModelNamesEndpointsAndKeys: 'none'
         OpenAIGPTModelNamesEndpointsAndKeys: !Ref OpenAIGPTModelNamesEndpointsAndKeys
+        RecaptchaEnterpriseApiKey: !Ref RecaptchaEnterpriseApiKey
       TemplateURL:  "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-secrets-manager.yml"
   MLEngineSecretsStack:
     Type: AWS::CloudFormation::Stack
@@ -741,6 +755,7 @@ Resources:
             - !GetAtt [ CoreSecretsStack, Outputs.ContainerRepositoryCredentialsSecretOutput ]
             - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAppKeySecretOutput ]
             - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineSecretStoreKeySecretOutput ]
+            - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineRecaptchaEnterpriseApiKeySecretOutput ]
         GenaiEngineUseInternalModelRepository: !Ref GenaiEngineUseInternalModelRepository
       TemplateURL:  "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-iam.yml"
   MLEngineIAMStack:
@@ -821,6 +836,7 @@ Resources:
         GenaiEngineSecretAPIKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAPIKeySecretOutput ]
         GenaiEngineAppSecretKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAppKeySecretOutput ]
         GenaiEngineSecretStoreKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineSecretStoreKeySecretOutput ]
+        GenaiEngineSecretRecaptchaApiKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineRecaptchaEnterpriseApiKeySecretOutput ]
         GenaiEngineSecretOpenAIGPTModelNamesEndpointsKeysARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineOpenAIGPTModelNamesEndpointsAndKeysSecretOutput ]
         GenaiEngineSecretOpenAIEmbeddingModelNamesEndpointsKeysARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineOpenAIEmbeddingModelNamesEndpointsAndKeysSecretOutput ]
         GenaiEngineSecretPostgresARN: !GetAtt [ CoreSecretsStack, Outputs.PostgresCredentialsSecretOutput ]
@@ -830,6 +846,8 @@ Resources:
         GenaiEngineToxicityCheckMaxTokenLimit: !Ref GenaiEngineToxicityCheckMaxTokenLimit
         GenaiEngineUsePIIModelV2: !Ref GenaiEngineUsePIIModelV2
         GenaiEngineDemoMode: !Ref GenaiEngineDemoMode
+        RecaptchaEnterpriseProjectId: !Ref RecaptchaEnterpriseProjectId
+        RecaptchaEnterpriseSiteKey: !Ref RecaptchaEnterpriseSiteKey
         GenaiEngineFargateTaskCPUValue: !Ref GenaiEngineFargateTaskCPUValue
         GenaiEngineFargateTaskMemoryValue: !Ref GenaiEngineFargateTaskMemoryValue
         GenaiEngineServerWorkerCount: !Ref GenaiEngineServerWorkerCount

--- a/deployment/cloudformation/root-arthur-engine-gpu.yml
+++ b/deployment/cloudformation/root-arthur-engine-gpu.yml
@@ -275,6 +275,19 @@ Parameters:
       - 'disabled'
     Default: 'disabled'
     Description: 'Enable GenAI Engine demo mode'
+  RecaptchaEnterpriseProjectId:
+    Type: String
+    Default: ''
+    Description: 'Google Cloud project id hosting the reCAPTCHA Enterprise key. Leave blank to disable reCAPTCHA on the public tenant signup endpoint.'
+  RecaptchaEnterpriseSiteKey:
+    Type: String
+    Default: ''
+    Description: 'reCAPTCHA Enterprise site key for the backend assessment call. Must match the site key baked into the UI build. Leave blank to disable reCAPTCHA.'
+  RecaptchaEnterpriseApiKey:
+    Type: String
+    NoEcho: true
+    Default: 'none'
+    Description: "reCAPTCHA Enterprise REST API key for creating assessments. Leave as 'none' to disable reCAPTCHA verification."
   GenaiEngineOpenAIProvider:
     Type: String
     AllowedValues:
@@ -898,6 +911,7 @@ Resources:
         ArthurResourceNameSuffix: !Ref ArthurResourceNameSuffix
         OpenAIEmbeddingModelNamesEndpointsAndKeys: 'none'
         OpenAIGPTModelNamesEndpointsAndKeys: !Ref OpenAIGPTModelNamesEndpointsAndKeys
+        RecaptchaEnterpriseApiKey: !Ref RecaptchaEnterpriseApiKey
       TemplateURL:  "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-secrets-manager.yml"
   MLEngineSecretsStack:
     Type: AWS::CloudFormation::Stack
@@ -925,6 +939,7 @@ Resources:
             - !GetAtt [ CoreSecretsStack, Outputs.ContainerRepositoryCredentialsSecretOutput ]
             - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAppKeySecretOutput ]
             - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineSecretStoreKeySecretOutput ]
+            - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineRecaptchaEnterpriseApiKeySecretOutput ]
         GenaiEngineUseInternalModelRepository: !Ref GenaiEngineUseInternalModelRepository
       TemplateURL:  "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-iam.yml"
   MLEngineIAMStack:
@@ -1005,6 +1020,7 @@ Resources:
         GenaiEngineSecretAPIKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAPIKeySecretOutput ]
         GenaiEngineAppSecretKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAppKeySecretOutput ]
         GenaiEngineSecretStoreKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineSecretStoreKeySecretOutput ]
+        GenaiEngineSecretRecaptchaApiKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineRecaptchaEnterpriseApiKeySecretOutput ]
         GenaiEngineSecretOpenAIGPTModelNamesEndpointsKeysARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineOpenAIGPTModelNamesEndpointsAndKeysSecretOutput ]
         GenaiEngineSecretPostgresARN: !GetAtt [ CoreSecretsStack, Outputs.PostgresCredentialsSecretOutput ]
         GenaiEngineSensitiveDataCheckMaxTokenLimit: !Ref GenaiEngineSensitiveDataCheckMaxTokenLimit
@@ -1012,6 +1028,8 @@ Resources:
         GenaiEngineToxicityCheckMaxTokenLimit: !Ref GenaiEngineToxicityCheckMaxTokenLimit
         GenaiEngineUsePIIModelV2: !Ref GenaiEngineUsePIIModelV2
         GenaiEngineDemoMode: !Ref GenaiEngineDemoMode
+        RecaptchaEnterpriseProjectId: !Ref RecaptchaEnterpriseProjectId
+        RecaptchaEnterpriseSiteKey: !Ref RecaptchaEnterpriseSiteKey
         GenaiEngineEC2TaskCPUValue: !Ref GenaiEngineEC2TaskCPUValue
         GenaiEngineEC2TaskGPUValue: !Ref GenaiEngineEC2TaskGPUValue
         GenaiEngineEC2TaskMemoryValue: !Ref GenaiEngineEC2TaskMemoryValue

--- a/deployment/cloudformation/root-arthur-genai-engine-cpu.yml
+++ b/deployment/cloudformation/root-arthur-genai-engine-cpu.yml
@@ -230,6 +230,19 @@ Parameters:
       - 'disabled'
     Default: 'disabled'
     Description: 'Enable GenAI Engine demo mode'
+  RecaptchaEnterpriseProjectId:
+    Type: String
+    Default: ''
+    Description: 'Google Cloud project id hosting the reCAPTCHA Enterprise key. Leave blank to disable reCAPTCHA on the public tenant signup endpoint.'
+  RecaptchaEnterpriseSiteKey:
+    Type: String
+    Default: ''
+    Description: 'reCAPTCHA Enterprise site key for the backend assessment call. Must match the site key baked into the UI build. Leave blank to disable reCAPTCHA.'
+  RecaptchaEnterpriseApiKey:
+    Type: String
+    NoEcho: true
+    Default: 'none'
+    Description: "reCAPTCHA Enterprise REST API key for creating assessments. Leave as 'none' to disable reCAPTCHA verification."
   GenaiEngineOpenAIProvider:
     Type: String
     AllowedValues:
@@ -552,6 +565,7 @@ Resources:
         ArthurResourceNameSuffix: !Ref ArthurResourceNameSuffix
         OpenAIEmbeddingModelNamesEndpointsAndKeys: 'none'
         OpenAIGPTModelNamesEndpointsAndKeys: !Ref OpenAIGPTModelNamesEndpointsAndKeys
+        RecaptchaEnterpriseApiKey: !Ref RecaptchaEnterpriseApiKey
       TemplateURL: !Sub "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-secrets-manager.yml"
   GenaiEngineIAMStack:
     Type: AWS::CloudFormation::Stack
@@ -570,6 +584,7 @@ Resources:
             - !GetAtt [ CoreSecretsStack, Outputs.ContainerRepositoryCredentialsSecretOutput ]
             - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAppKeySecretOutput ]
             - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineSecretStoreKeySecretOutput ]
+            - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineRecaptchaEnterpriseApiKeySecretOutput ]
         GenaiEngineUseInternalModelRepository: !Ref GenaiEngineUseInternalModelRepository
       TemplateURL: !Sub "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-iam.yml"
   GenaiEngineSecurityGroupStack:
@@ -626,6 +641,7 @@ Resources:
         GenaiEngineSecretAPIKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAPIKeySecretOutput ]
         GenaiEngineAppSecretKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAppKeySecretOutput ]
         GenaiEngineSecretStoreKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineSecretStoreKeySecretOutput ]
+        GenaiEngineSecretRecaptchaApiKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineRecaptchaEnterpriseApiKeySecretOutput ]
         GenaiEngineSecretOpenAIGPTModelNamesEndpointsKeysARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineOpenAIGPTModelNamesEndpointsAndKeysSecretOutput ]
         GenaiEngineSecretOpenAIEmbeddingModelNamesEndpointsKeysARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineOpenAIEmbeddingModelNamesEndpointsAndKeysSecretOutput ]
         GenaiEngineSecretPostgresARN: !GetAtt [ CoreSecretsStack, Outputs.PostgresCredentialsSecretOutput ]
@@ -635,6 +651,8 @@ Resources:
         GenaiEngineToxicityCheckMaxTokenLimit: !Ref GenaiEngineToxicityCheckMaxTokenLimit
         GenaiEngineUsePIIModelV2: !Ref GenaiEngineUsePIIModelV2
         GenaiEngineDemoMode: !Ref GenaiEngineDemoMode
+        RecaptchaEnterpriseProjectId: !Ref RecaptchaEnterpriseProjectId
+        RecaptchaEnterpriseSiteKey: !Ref RecaptchaEnterpriseSiteKey
         GenaiEngineFargateTaskCPUValue: !Ref GenaiEngineFargateTaskCPUValue
         GenaiEngineFargateTaskMemoryValue: !Ref GenaiEngineFargateTaskMemoryValue
         GenaiEngineServerWorkerCount: !Ref GenaiEngineServerWorkerCount

--- a/deployment/cloudformation/root-arthur-genai-engine-gpu.yml
+++ b/deployment/cloudformation/root-arthur-genai-engine-gpu.yml
@@ -241,6 +241,19 @@ Parameters:
       - 'disabled'
     Default: 'disabled'
     Description: 'Enable GenAI Engine demo mode'
+  RecaptchaEnterpriseProjectId:
+    Type: String
+    Default: ''
+    Description: 'Google Cloud project id hosting the reCAPTCHA Enterprise key. Leave blank to disable reCAPTCHA on the public tenant signup endpoint.'
+  RecaptchaEnterpriseSiteKey:
+    Type: String
+    Default: ''
+    Description: 'reCAPTCHA Enterprise site key for the backend assessment call. Must match the site key baked into the UI build. Leave blank to disable reCAPTCHA.'
+  RecaptchaEnterpriseApiKey:
+    Type: String
+    NoEcho: true
+    Default: 'none'
+    Description: "reCAPTCHA Enterprise REST API key for creating assessments. Leave as 'none' to disable reCAPTCHA verification."
   GenaiEngineOpenAIProvider:
     Type: String
     AllowedValues:
@@ -738,6 +751,7 @@ Resources:
         ArthurResourceNameSuffix: !Ref ArthurResourceNameSuffix
         OpenAIEmbeddingModelNamesEndpointsAndKeys: 'none'
         OpenAIGPTModelNamesEndpointsAndKeys: !Ref OpenAIGPTModelNamesEndpointsAndKeys
+        RecaptchaEnterpriseApiKey: !Ref RecaptchaEnterpriseApiKey
       TemplateURL: !Sub "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-secrets-manager.yml"
   GenaiEngineIAMStack:
     Type: AWS::CloudFormation::Stack
@@ -756,6 +770,7 @@ Resources:
             - !GetAtt [ CoreSecretsStack, Outputs.ContainerRepositoryCredentialsSecretOutput ]
             - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAppKeySecretOutput ]
             - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineSecretStoreKeySecretOutput ]
+            - !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineRecaptchaEnterpriseApiKeySecretOutput ]
         GenaiEngineUseInternalModelRepository: !Ref GenaiEngineUseInternalModelRepository
       TemplateURL: !Sub "https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/templates/REPLACE_ME_GENAI_ENGINE_VERSION/genai-engine/arthur-genai-engine-iam.yml"
   GenaiEngineSecurityGroupStack:
@@ -812,6 +827,7 @@ Resources:
         GenaiEngineSecretAPIKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAPIKeySecretOutput ]
         GenaiEngineAppSecretKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineAppKeySecretOutput ]
         GenaiEngineSecretStoreKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineSecretStoreKeySecretOutput ]
+        GenaiEngineSecretRecaptchaApiKeyARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineRecaptchaEnterpriseApiKeySecretOutput ]
         GenaiEngineSecretOpenAIGPTModelNamesEndpointsKeysARN: !GetAtt [ GenaiEngineSecretsStack, Outputs.GenaiEngineOpenAIGPTModelNamesEndpointsAndKeysSecretOutput ]
         GenaiEngineSecretPostgresARN: !GetAtt [ CoreSecretsStack, Outputs.PostgresCredentialsSecretOutput ]
         GenaiEngineSensitiveDataCheckMaxTokenLimit: !Ref GenaiEngineSensitiveDataCheckMaxTokenLimit
@@ -819,6 +835,8 @@ Resources:
         GenaiEngineToxicityCheckMaxTokenLimit: !Ref GenaiEngineToxicityCheckMaxTokenLimit
         GenaiEngineUsePIIModelV2: !Ref GenaiEngineUsePIIModelV2
         GenaiEngineDemoMode: !Ref GenaiEngineDemoMode
+        RecaptchaEnterpriseProjectId: !Ref RecaptchaEnterpriseProjectId
+        RecaptchaEnterpriseSiteKey: !Ref RecaptchaEnterpriseSiteKey
         GenaiEngineEC2TaskCPUValue: !Ref GenaiEngineEC2TaskCPUValue
         GenaiEngineEC2TaskGPUValue: !Ref GenaiEngineEC2TaskGPUValue
         GenaiEngineEC2TaskMemoryValue: !Ref GenaiEngineEC2TaskMemoryValue

--- a/deployment/helm/genai-engine/templates/arthur-genai-engine-daemonset.yaml
+++ b/deployment/helm/genai-engine/templates/arthur-genai-engine-daemonset.yaml
@@ -117,6 +117,21 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.genaiEngineSecretStoreKeyName }}
                   key: key
+            {{- if .Values.recaptchaEnterpriseProjectId }}
+            - name: RECAPTCHA_ENTERPRISE_PROJECT_ID
+              value: {{ .Values.recaptchaEnterpriseProjectId | quote }}
+            {{- end }}
+            {{- if .Values.recaptchaEnterpriseSiteKey }}
+            - name: RECAPTCHA_ENTERPRISE_SITE_KEY
+              value: {{ .Values.recaptchaEnterpriseSiteKey | quote }}
+            {{- end }}
+            {{- if .Values.genaiEngineSecretRecaptchaApiKeyName }}
+            - name: RECAPTCHA_ENTERPRISE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.genaiEngineSecretRecaptchaApiKeyName }}
+                  key: key
+            {{- end }}
             - name: NVIDIA_DRIVER_CAPABILITIES
               value: "compute,utility"
             - name: NVIDIA_VISIBLE_DEVICES

--- a/deployment/helm/genai-engine/templates/arthur-genai-engine-deployment.yaml
+++ b/deployment/helm/genai-engine/templates/arthur-genai-engine-deployment.yaml
@@ -115,6 +115,21 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.genaiEngineSecretStoreKeyName }}
                   key: key
+            {{- if .Values.recaptchaEnterpriseProjectId }}
+            - name: RECAPTCHA_ENTERPRISE_PROJECT_ID
+              value: {{ .Values.recaptchaEnterpriseProjectId | quote }}
+            {{- end }}
+            {{- if .Values.recaptchaEnterpriseSiteKey }}
+            - name: RECAPTCHA_ENTERPRISE_SITE_KEY
+              value: {{ .Values.recaptchaEnterpriseSiteKey | quote }}
+            {{- end }}
+            {{- if .Values.genaiEngineSecretRecaptchaApiKeyName }}
+            - name: RECAPTCHA_ENTERPRISE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.genaiEngineSecretRecaptchaApiKeyName }}
+                  key: key
+            {{- end }}
             {{- if .Values.gpuEnabled }}
             - name: NVIDIA_DRIVER_CAPABILITIES
               value: "compute,utility"

--- a/deployment/helm/genai-engine/values.schema.json
+++ b/deployment/helm/genai-engine/values.schema.json
@@ -457,6 +457,18 @@
             "type": "string",
             "description": "(Optional) Custom URL for the model repository (e.g. a private Hugging Face mirror). If not specified, the default Hugging Face endpoint will be used."
         },
+        "recaptchaEnterpriseProjectId": {
+            "type": "string",
+            "description": "(Optional) Google Cloud project id hosting the reCAPTCHA Enterprise key. Leave unset to disable reCAPTCHA verification on the public tenant signup endpoint."
+        },
+        "recaptchaEnterpriseSiteKey": {
+            "type": "string",
+            "description": "(Optional) reCAPTCHA Enterprise site key used by the backend assessment call. Must match the site key baked into the UI build. Leave unset to disable reCAPTCHA verification."
+        },
+        "genaiEngineSecretRecaptchaApiKeyName": {
+            "type": "string",
+            "description": "(Optional) Name of the secret holding the reCAPTCHA Enterprise REST API key (expecting value for key 'key'). Leave unset to disable reCAPTCHA verification."
+        },
         "gcpDiscoveryConfig": {
             "type": "object",
             "properties": {

--- a/deployment/helm/genai-engine/values.yaml.template
+++ b/deployment/helm/genai-engine/values.yaml.template
@@ -129,6 +129,10 @@ arthurGenaiEngineService:
 genaiEngineAllowAdminKeyGeneralAccess: "enabled"
 # (Optional) Custom URL for the model repository (e.g. a private Hugging Face mirror). If not specified, the default Hugging Face endpoint will be used.
 # modelRepositoryURL: ""
+# (Optional) reCAPTCHA Enterprise — gates the public tenant signup endpoint. All three of project id, site key, and the API-key secret
+# must be set for verification to run; otherwise the signup endpoint fails open. The site key must match the one baked into the UI build.
+# recaptchaEnterpriseProjectId: ""
+# recaptchaEnterpriseSiteKey: ""
 
 ###################################
 ## Advanced - Secrets name customization
@@ -145,6 +149,8 @@ genaiEngineSecretAdminKeyName: "genai-engine-secret-admin-key"
 genaiEngineSecretOpenAIGPTModelNamesEndpointsKeysName: "genai-engine-secret-open-ai-gpt-model-names-endpoints-keys"
 # GenAI Engine secret store key name (expecting value for key 'key' - should be a base64-encoded 32-byte Fernet key)
 genaiEngineSecretStoreKeyName: "genai-engine-secret-store-key"
+# (Optional) Name of the secret holding the reCAPTCHA Enterprise REST API key (expecting value for key 'key'). Leave unset to disable reCAPTCHA verification.
+# genaiEngineSecretRecaptchaApiKeyName: "genai-engine-secret-recaptcha-api-key"
 
 ###################################
 ## Advanced - GCP Service Account

--- a/genai-engine/dockerfile
+++ b/genai-engine/dockerfile
@@ -53,6 +53,14 @@ ARG METICULOUS_API_TOKEN
 # Accept GitLab Unify Frontend token as build argument
 ARG GITLAB_UNIFY_FRONTEND_TOKEN
 
+# Accept client-side analytics / anti-abuse keys as build arguments. These are
+# baked into the static bundle at `yarn build` time (Vite inlines them), so they
+# must be present here rather than as ECS runtime env vars. All are optional;
+# when blank the corresponding feature stays disabled in the UI.
+ARG AMPLITUDE_API_KEY
+ARG VITE_AMPLITUDE_DEPLOYMENT_KEY
+ARG RECAPTCHA_ENTERPRISE_SITE_KEY
+
 WORKDIR /app/ui
 
 # Copy UI source code
@@ -70,6 +78,9 @@ RUN if [ -z "${GITLAB_UNIFY_FRONTEND_TOKEN}" ]; then \
 # Build the UI as static files
 ENV METICULOUS_RECORDING_TOKEN=${METICULOUS_RECORDING_TOKEN}
 ENV METICULOUS_API_TOKEN=${METICULOUS_API_TOKEN}
+ENV AMPLITUDE_API_KEY=${AMPLITUDE_API_KEY}
+ENV VITE_AMPLITUDE_DEPLOYMENT_KEY=${VITE_AMPLITUDE_DEPLOYMENT_KEY}
+ENV RECAPTCHA_ENTERPRISE_SITE_KEY=${RECAPTCHA_ENTERPRISE_SITE_KEY}
 RUN yarn build
 
 # Copy the built static files


### PR DESCRIPTION
Bake the client-side Amplitude keys and reCAPTCHA Enterprise site key into the UI build (Dockerfile build args + CI build-args), and surface the reCAPTCHA Enterprise backend config to the GenAI Engine container:
- CloudFormation: new optional RecaptchaEnterprise* params across both ECS task definitions and all four root templates; the REST API key flows through Secrets Manager (new secret + IAM read grant), project id and site key as plain env.
- Helm: same env wired into the Deployment and DaemonSet, with optional values + schema entries (API key via a BYO secretKeyRef).

All values are optional and fail open: leaving them unset keeps reCAPTCHA disabled and changes no existing deployment behavior. Excludes the tracked .env files so the live reCAPTCHA API key stays out of the repo.