### PR TITLE
Stop unnecessary GenAI engine CI unit test runs

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -186,8 +186,21 @@ jobs:
             ui:
               - 'genai-engine/ui/**'
             backend:
-              - 'genai-engine/**'
-              - '!genai-engine/ui/**'
+              - 'genai-engine/src/**'
+              - 'genai-engine/tests/**'
+              - 'genai-engine/alembic/**'
+              - 'genai-engine/scripts/**'
+              - 'genai-engine/models/**'
+              - 'genai-engine/*.toml'
+              - 'genai-engine/*.cfg'
+              - 'genai-engine/*.ini'
+              - 'genai-engine/*.lock'
+              - 'genai-engine/*.txt'
+              - 'genai-engine/version'
+              - 'genai-engine/routes_security_check.py'
+              - 'genai-engine/changelog*'
+              - 'genai-engine/Dockerfile*'
+              - 'genai-engine/docker-compose.yml'
 
   run-genai-engine-ui-lint:
     needs: check-genai-engine-changes


### PR DESCRIPTION
We were running the 20 minute GenAI engine CI unit tests unnecessarily. As an example, a simple top level README.md file change was triggering the tests. This PR reduces unnecessary GenAI engine unit tests executions significantly to improve developer productivity.