### PR TITLE
Refine task tour copy for clarity and conciseness

### DIFF
--- a/genai-engine/ui/src/features/task-tour/content/00-intro.md
+++ b/genai-engine/ui/src/features/task-tour/content/00-intro.md
@@ -13,8 +13,8 @@ steps: []
 
 ## intro
 
-Arthur's **Agent Development Lifecycle** is how teams ship agents they can trust. Over the next few minutes, you'll walk through each stage — interact, measure, observe, refine, and deploy — using a real failure mode as your example.
+Arthur's **Agent Development Lifecycle** is a workflow for building agents you can actually trust before shipping them. Over the next few minutes you'll walk through each stage (interact, measure, observe, refine, deploy) using a real failure as your example.
 
 ## scenario
 
-The agent on this task answers general-knowledge questions from Wikipedia, but it never tells users where the information came from - so the **Source Attribution Eval**, which checks that answers cite their source, fails on every response. We'll use the ADLC to find the failure, fix the prompt so the agent cites Wikipedia, and prove the fix worked.
+The agent on this task answers general-knowledge questions from Wikipedia, but it never tells users where the information came from. That means the **Source Attribution Eval**, which checks whether answers cite their source, fails on every response. We'll use the ADLC to track down the failure, fix the prompt, and confirm the fix worked.

--- a/genai-engine/ui/src/features/task-tour/content/01-agent.md
+++ b/genai-engine/ui/src/features/task-tour/content/01-agent.md
@@ -16,16 +16,16 @@ steps:
 
 ## intro
 
-Start with the bundled Demo Agent: a Wikipedia-backed chatbot you can use to generate a realistic trace. Open it from the task sidebar, ask a question, and Arthur will record the run for the trace workflow we'll inspect together.
+Start with the bundled Demo Agent: a Wikipedia-backed chatbot you can use to generate a real trace. Open it from the task sidebar, ask a question, and Arthur will record the run so we can look at it in the next section.
 
 ## scenario
 
-First, open the Demo Agent from the sidebar. It answers general-knowledge questions by searching and fetching Wikipedia articles, which makes it a useful sandbox for seeing agent traces in Arthur.
+Open the Demo Agent from the sidebar. It answers general-knowledge questions by searching Wikipedia, which makes it a handy way to see what agent traces look like in Arthur.
 
 ## step: open-demo-agent
 
-Open **Demo Agent** in the sidebar. This takes you to the sandbox chatbot, where you can ask a general-knowledge question and create a trace for the next part of the tour.
+Open **Demo Agent** in the sidebar. This takes you to the sandbox chatbot where you can ask a general-knowledge question and generate a trace for the next part of the tour.
 
 ## step: send-message
 
-Send any general-knowledge question to the Demo Agent. It will search Wikipedia as needed, answer in the chat, and leave behind a trace for us to inspect next.
+Send any general-knowledge question to the Demo Agent. It will search Wikipedia, answer in the chat, and leave a trace we can look at next.

--- a/genai-engine/ui/src/features/task-tour/content/02-evals.md
+++ b/genai-engine/ui/src/features/task-tour/content/02-evals.md
@@ -26,38 +26,38 @@ steps:
 
 ## intro
 
-Evals are the **contract** you set with your agent. Before tuning prompts or swapping models you need to know how the agent is being measured — and against what bar — so any change can be judged objectively.
+Before tuning prompts or swapping models, you need to know how the agent is being measured and against what bar. That way any change has an objective before-and-after.
 
-Each eval reads a few **variables** — things like the agent's response, the user's question, or retrieved context. A **Transform** is what pulls those values out of a trace and hands them to the eval: the trace records everything the agent did, and the transform picks out just the fields this eval needs to score. For example, the **Source Attribution Eval** on this task uses a transform to extract the agent's response, then checks whether that response cites where its information came from.
+Each eval reads a few **variables**: the agent's response, the user's question, retrieved context, etc. A **Transform** is what pulls those values out of a trace and hands them to the eval. The trace records everything the agent did; the transform picks out just the fields this eval needs to score. The **Source Attribution Eval** on this task, for example, uses a transform to extract the agent's response and checks whether it cites a source.
 
 ## scenario
 
-Open Evaluate and inspect the first evaluator. Pay attention to the model that judges each trace and the variables a transform feeds into the eval — together with the threshold, they decide whether a trace passes or fails.
+Open Evaluate and look at the first evaluator. Pay attention to the model that judges each trace and the variables a transform feeds in. Together with the threshold, those are what determine whether a trace passes or fails.
 
 ## step: open-evaluate
 
-Click Evaluate in the sidebar to see the evaluators currently running on this task.
+Click Evaluate in the sidebar to see the evaluators running on this task.
 
 ## step: review-evaluator
 
-Click the **maximize** icon on the first evaluator to open its full details. Each evaluator runs a model against a set of variables pulled from every trace, then scores the result against a threshold — that's how Arthur decides whether the agent is meeting the bar.
+Click the **maximize** icon on the first evaluator to open its full details. Each evaluator runs a model against a set of variables pulled from every trace, then scores the result against a threshold. That score is how Arthur decides whether a trace passes.
 
 ## step: review-evaluator-versions
 
-Evaluators are **versioned**. The drawer on the left lists every version with its model and creation date, so you can track how the eval evolved and roll back if a change regresses.
+Evaluators are versioned. The drawer on the left lists every version with its model and creation date, so you can see how the eval has changed and roll back if needed.
 
 ## step: review-evaluator-instructions
 
-The **instructions** are the prompt sent to the judge model. They define exactly what the model is asked to score — the clearer the instructions, the more reliable the evaluation.
+The **instructions** are the prompt sent to the judge model. They define what the model is being asked to score.
 
 ## step: review-evaluator-model
 
-This is the **model** that judges each trace. Picking the right model — and keeping it consistent across versions — is what makes scores comparable over time.
+This is the judge model for this evaluator. Keeping it consistent across versions is what makes scores comparable over time.
 
 ## step: open-results-tab
 
-Click the **Results** tab to see how those evaluator rules have scored recent traces.
+Click the **Results** tab to see how recent traces scored against this evaluator.
 
 ## step: review-result-details
 
-Click the first result row and review the details modal. The row-level view shows the trace, score, explanation, and rerun controls for understanding why an eval passed or failed.
+Click the first result row to open the details. You'll see the trace, the score, the explanation, and controls to rerun it if you want to dig into why it passed or failed.

--- a/genai-engine/ui/src/features/task-tour/content/03-traces.md
+++ b/genai-engine/ui/src/features/task-tour/content/03-traces.md
@@ -22,28 +22,28 @@ steps:
 
 ## intro
 
-A trace is the timeline of everything the agent did to produce one answer — retrieval calls, model invocations, post-processing, evals. Continuous Evals run on every trace automatically, so you can spot failure patterns the moment they happen.
+A trace is a timeline of everything the agent did to produce one answer: retrieval calls, model invocations, post-processing, evals. Continuous Evals attach to every trace automatically, so you can see failures as soon as they show up.
 
 ## scenario
 
-Open Observe, drill into a trace, walk through the spans, read the eval annotations, and leave manual feedback. We'll specifically call out where the **Source Attribution Eval** is failing — the agent answered without citing where the information came from — that's the signal you'll fix later in this tour.
+Open Observe, drill into a trace, walk through the spans, read the eval annotations, and leave some manual feedback. We'll point out where the **Source Attribution Eval** is failing (the agent answered without citing its source). That's the problem you'll fix later in the tour.
 
 ## step: open-observe
 
-Open the Observe view to see the trail of requests this agent has generated. Click **Observe** in the sidebar.
+Click **Observe** in the sidebar to see the requests this agent has generated.
 
 ## step: open-trace
 
-Open one of the traces to see what's actually inside — any trace works. Click the top row, or mark this step complete and we'll open the first trace for you.
+Open one of the traces to see what's inside. Any trace works. Click the top row, or mark this step complete and we'll open the first trace for you.
 
 ## step: review-spans
 
-A **trace** is the full request; each **span** is one step the agent took (retrieval, model call, post-processing). Look at latency, cost, and tokens to see where time and money are going. (Mark complete when done.)
+A **trace** is the full request; each **span** is one step the agent took (retrieval, model call, post-processing). Check latency, cost, and tokens to see where time and money are going. (Mark complete when done.)
 
 ## step: review-annotations
 
-**Continuous Evals** attach automatically to every trace — they measure quality on every request so you catch regressions early. For the evals on this trace, notice the **Source Attribution Eval** is failing because the answer doesn't cite its source — that's the live signal we'll fix in the prompt playground. (Mark complete when done.)
+**Continuous Evals** run on every trace automatically. Notice the **Source Attribution Eval** is failing here because the answer doesn't cite its source. That's the live signal we'll address in the prompt playground. (Mark complete when done.)
 
 ## step: add-feedback
 
-**Manual feedback** is how humans (or your own app, via the API) tell Arthur something an automated eval can't capture. Leave a quick note about this answer — developers use it to triage, and production apps can post it programmatically. (Mark complete when done.)
+**Manual feedback** is how you (or your app, via the API) flag something an automated eval can't catch. Leave a quick note on this trace. Developers use it to triage, and production apps can post it programmatically. (Mark complete when done.)

--- a/genai-engine/ui/src/features/task-tour/content/04-datasets.md
+++ b/genai-engine/ui/src/features/task-tour/content/04-datasets.md
@@ -40,43 +40,43 @@ steps:
 
 ## intro
 
-Datasets are the test cases your agent has to pass before every release. Promote real traces — including the citation failure you just annotated — into a dataset, then enrich it with synthetic examples so future regressions get caught automatically.
+Datasets hold the test cases you run before each release. You can pull real traces into a dataset and add synthetic examples to fill in gaps. In this section you'll capture the citation failure from Observe as a test case so future prompt versions have to pass it.
 
 ## scenario
 
-Open the pre-loaded dataset and look at how a test suite is built, then add the failing trace from Observe into it, return to the dataset to see the new row land, and (optional) generate a few synthetic rows to broaden coverage.
+Open the pre-loaded dataset to see how a test suite is structured, then go back to Observe, add the failing trace to the dataset, and (optionally) generate a few synthetic rows to widen coverage.
 
 ## step: open-datasets
 
-Click Dataset in the sidebar to see the test sets available on this task.
+Click **Dataset** in the sidebar to see the test sets on this task.
 
 ## step: open-preloaded-dataset
 
-Click the top dataset row. This is the test suite developers use to make sure the agent doesn't regress on cases we already know matter.
+Click the top dataset row. This is the suite developers run to check the agent doesn't break on cases they already know about.
 
 ## step: review-dataset-rows
 
-Each row is a test case — the inputs your agent receives plus the expected output it should reproduce. This pre-loaded suite is what every release has to pass.
+Each row is a test case: the inputs your agent receives and the expected output it should produce. This pre-loaded suite is what you'd run before each release.
 
 ## step: review-dataset-columns
 
-Columns define the fields of each case. **Configure Columns** is where you add or rename the input and expected-output fields.
+Columns define the fields in each case. **Configure Columns** is where you add or rename input and expected-output fields.
 
 ## step: review-dataset-grow
 
-Three ways to add cases: **Add Row** by hand, **Import** a CSV in bulk, or **Generate** synthetic rows with AI — we'll generate some at the end of this section.
+There are three ways to add cases: **Add Row** manually, **Import** a CSV, or **Generate** synthetic rows. We'll try generating some at the end of this section.
 
 ## step: review-dataset-versions
 
-Datasets are versioned. Every save creates a new version, and experiments pin a specific one so results stay reproducible.
+Datasets are versioned. Each save creates a new version, and experiments pin a specific one so results stay reproducible.
 
 ## step: review-dataset-experiments
 
-**Experiments** replay your prompt candidates against this dataset and score them with your evals — that's how you prove a fix before shipping. We'll set one up in the Prompts section.
+**Experiments** run your prompt candidates against this dataset and score them with your evals. We'll set one up in the Prompts section.
 
 ## step: open-traces-for-dataset
 
-Head back to Observe so you can capture the real failing trace as a regression case.
+Head back to Observe to capture the failing trace as a regression case.
 
 ## step: open-trace-for-dataset
 
@@ -92,16 +92,16 @@ Open **Trace Actions**, then choose **Add to Dataset** to start capturing this t
 
 ## step: save-trace-to-dataset
 
-Fill out the drawer to capture this trace as a permanent regression check:
+Fill out the drawer to save this trace as a test case:
 
 1. **Select a dataset** to add the row to.
-2. Map columns to the trace — use **Fill from object**, or pick a span and drill into its keys (a transform can do this automatically).
-3. Once at least one column has a value, click **Add Row** to save.
+2. Map columns to the trace. Use **Fill from object**, or pick a span and drill into its keys (a transform can handle this automatically).
+3. Once at least one column has a value, click **Add Row**.
 
 ## step: verify-new-row
 
-Reopen Datasets and click the same dataset — the trace you just added should be a new row, ready to be replayed against future prompt versions. (Mark complete when done.)
+Reopen Datasets and click the same dataset. The trace you just added should appear as a new row. (Mark complete when done.)
 
 ## step: generate-synthetic
 
-Click Generate to enrich the dataset with 5–10 synthetic rows based on the examples already captured. Synthetic data broadens test coverage without waiting for real users to hit edge cases. You can also cancel the modal to skip this optional step and keep moving.
+Click **Generate** to add 5–10 synthetic rows based on the examples already in the dataset. This fills in edge cases without waiting for real users to hit them. You can cancel the modal to skip this step if you'd rather move on.

--- a/genai-engine/ui/src/features/task-tour/content/05-prompts.md
+++ b/genai-engine/ui/src/features/task-tour/content/05-prompts.md
@@ -52,15 +52,15 @@ steps:
 
 ## intro
 
-A prompt is a collection of messages, variables, and a model — change any of them and you've got a candidate fix. The playground lets you try variations side-by-side, and Experiments run those candidates against your dataset and evals so you can ship with confidence.
+A prompt is a bundle of messages, variables, and a model. Change any of them and you have a candidate fix. The playground lets you try variants side-by-side, and Experiments run those candidates against your dataset and evals so you have data before you commit to a change.
 
 ## scenario
 
-Inspect the existing prompt, open it in the playground, draft 2–3 variants that fix the citation failure — prompting the agent to tell users its answers come from Wikipedia — then run an experiment against the dataset and evals to see which variant wins.
+Inspect the current prompt, open it in the playground, and draft a variant that fixes the citation failure (instruct the agent to tell users its answers come from Wikipedia). Then run an experiment against the dataset and evals to see which version performs better.
 
 ## step: open-prompts
 
-Click Prompt in the sidebar to see the prompts powering this agent.
+Click **Prompt** in the sidebar to see the prompts powering this agent.
 
 ## step: open-prompts-tab
 
@@ -68,35 +68,35 @@ Click the **Prompts** tab to see the prompt library for this task.
 
 ## step: inspect-prompt
 
-Click the highlighted prompt in the list. Each prompt is a bundle of messages, variables, and a model — change any of those and you've got a new version worth comparing.
+Click the highlighted prompt in the list. Each prompt is a bundle of messages, variables, and a model. Changing any of those produces a new version you can compare.
 
 ## step: open-in-playground
 
-Click **Open in Playground** from the prompt detail view. This creates or reuses a notebook seeded with the prompt so you can iterate without losing the production version.
+Click **Open in Playground** from the prompt detail view. This creates or reuses a notebook seeded with the prompt so you can iterate without touching the production version.
 
 ## step: duplicate-prompt-in-playground
 
-Click **Duplicate Prompt** to copy the seeded prompt into a side-by-side variant. Start from a copy so you can make targeted edits without losing the original baseline.
+Click **Duplicate Prompt** to copy the prompt into a side-by-side variant. Working from a copy keeps the original baseline intact while you make edits.
 
 ## step: review-playground-prompt
 
-Use this duplicated prompt card to edit the system prompt so the agent cites its source — e.g. instruct it to tell the user the answer comes from Wikipedia. Edit the messages or try a different model — anything that makes the agent attribute its answers.
+Edit the system prompt in this duplicated card so the agent cites its source. For example, instruct it to tell users the answer comes from Wikipedia. You can change the messages or swap the model.
 
 ## step: open-variables
 
-Click **Variables** to open the panel where you fill in the values your prompts run against.
+Click **Variables** to open the panel where you set the values your prompts run against.
 
 ## step: review-playground-controls
 
-This is the variables panel. The values here control what data your prompts run against — review or fill them in so the experiment compares the same scenario fairly, then close the panel to continue.
+This is the variables panel. The values here control what data your prompts run against. Review or fill them in so the experiment compares the same scenario across variants, then close the panel to continue.
 
 ## step: save-prompt-version
 
-Click the **Save** icon on this prompt card to store it as a new prompt version. Save at least one prompt before moving on — each saved version is a candidate you can pit against the others in an experiment.
+Click the **Save** icon on this prompt card to store it as a new version. Save at least one prompt before moving on. Each saved version is a candidate you can include in an experiment.
 
 ## step: review-notebook
 
-This is your notebook — prompts, variables, and config all live together here so you can iterate side-by-side. Take one last look. When you're ready to prove which variant actually wins, continue to set up an experiment.
+This is your notebook. Prompts, variables, and config all live here so you can compare variants in one place. When you're ready to run the experiment, continue.
 
 ## step: open-create-experiment
 
@@ -104,36 +104,36 @@ Open the Experiment menu and choose **Create New**. The tour will stay with you 
 
 ## step: experiment-info-name
 
-Start by naming the run — a clear name (and an optional description) makes it easy to find later when you're comparing results. Click **Next** when you're done.
+Give the run a name. A clear name (and optional description) makes it easier to find later when you're looking back at results. Click **Next** when you're done.
 
 ## step: experiment-info-versions
 
-Choose the candidate prompt versions you want to pit against each other. These are the saved variants from your notebook — pick the ones worth comparing, then click **Next**.
+Choose the prompt versions you want to compare. These are the saved variants from your notebook. Pick the ones worth testing, then click **Next**.
 
 ## step: experiment-info-dataset
 
-Select the dataset and version that holds the captured failure. This is the data every prompt version will run against, so the comparison stays fair. Click **Next** to continue.
+Select the dataset and version that holds the captured failure. Every prompt version will run against the same data, so the comparison is fair. Click **Next** to continue.
 
 ## step: experiment-info-evaluators
 
-Add the evals that should judge each result — these decide which variant actually wins. Once your evaluators are in, click **Next**.
+Add the evals that will judge each result. Once your evaluators are in, click **Next**.
 
 ## step: review-experiment-info
 
-Here's the full setup for the run — name, prompt versions, dataset, and evals. Give it a once-over, and when it looks right, click **Configure Prompts** to wire up the variables.
+This is the full setup: name, prompt versions, dataset, and evals. Look it over, and when it looks right, click **Configure Prompts** to wire up the variables.
 
 ## step: explain-prompt-mapping
 
-Variable mappings tell each prompt version where to read its inputs. Map every prompt variable to the dataset column that feeds it — exact name matches are pre-filled as a starting point, but check each one and fill any left empty. The run can't start until every variable is mapped, so don't just click through. Click **Next** when they're all set.
+Variable mappings tell each prompt version where to read its inputs. Map every prompt variable to the dataset column that feeds it. Exact name matches are pre-filled, but check each one and fill any that are empty. The run won't start until every variable is mapped. Click **Next** when they're all set.
 
 ## step: complete-prompt-mapping
 
-That's your prompt-to-data wiring — every variable should now point at a column. Once they're all mapped, click **Configure Evals** to set up the judges (or **Create Experiment** if you skipped evals).
+Each prompt variable should now point at a column. Click **Configure Evals** to set up the judges, or **Create Experiment** if you skipped evals.
 
 ## step: explain-eval-mapping
 
-Each evaluator reads its variables from a source you set. Map the agent's **response** — and any other value the prompt generates — to **Experiment Output** so the eval scores what your new prompt actually produced, not a stored value. Map input variables like the user's question to the **Dataset Column** that holds them; exact name matches are pre-filled. Every variable starts on **Dataset Column**, so switch your response variables to **Experiment Output** before clicking **Next**.
+Each evaluator reads its variables from a source you choose. Map the agent's **response** (and any other value the prompt generates) to **Experiment Output** so the eval scores what your new prompt actually produced, not a stored value. Map input variables like the user's question to the **Dataset Column** that holds them. Exact name matches are pre-filled, but every variable defaults to **Dataset Column**, so switch your response variables to **Experiment Output** before clicking **Next**.
 
 ## step: create-experiment
 
-Final review. Double-check every eval variable has the right source — response variables mapped to **Experiment Output** — then click **Create Experiment** to launch the run.
+Final check. Make sure every eval variable has the right source, with response variables mapped to **Experiment Output**. Then click **Create Experiment** to start the run.

--- a/genai-engine/ui/src/features/task-tour/content/06-deploy.md
+++ b/genai-engine/ui/src/features/task-tour/content/06-deploy.md
@@ -26,36 +26,36 @@ steps:
 
 ## intro
 
-Reopen the winning prompt, tag it as production, then re-run the Demo Agent and confirm the **Source Attribution Eval** is green on fresh traces. That's the loop closing — the failure you found in Observe is the failure you just shipped a fix for.
+Take the winning prompt from your experiment, tag it as production, then send another Demo Agent message and check that the **Source Attribution Eval** passes on the new trace. That's the point of the whole workflow: the failure you found in Observe gets a fix you can verify before it ships.
 
 ## scenario
 
-Return to the prompt detail view, promote the best experiment candidate to production, send another Demo Agent message, then return to Observe and verify the new trace clears the **Source Attribution Eval** — the agent now cites its source.
+Go back to the prompt detail view, promote the best experiment candidate to production, send another Demo Agent message, then check the new trace in Observe. The **Source Attribution Eval** should be green now that the agent cites its source.
 
 ## step: open-production-prompt
 
-Open the prompt you want to ship. The production tag is applied from the prompt detail view, so this brings you back to the version metadata before you promote it.
+Open the prompt you want to ship. You tag it as production from the prompt detail view, so this takes you back to the version metadata before you promote it.
 
 ## step: tag-production
 
-Open the prompt detail view, click the tag icon next to the version chips, and mark this version as production. Whichever version you tag becomes the one production traffic uses. (Mark complete when done.)
+In the prompt detail view, click the tag icon next to the version chips and mark this version as production. Whichever version you tag is the one production traffic will use. (Mark complete when done.)
 
 ## step: reopen-demo-agent
 
-Open **Demo Agent** again from the sidebar. Now that the winning prompt is tagged as production, the next chat run will use that promoted version.
+Open **Demo Agent** again from the sidebar. The next chat run will use the production version you just tagged.
 
 ## step: send-verification-message
 
-Send another general-knowledge question to create a fresh trace with the production prompt. Use the same question as before if you want an easy before-and-after comparison.
+Send another general-knowledge question to generate a fresh trace with the production prompt. Using the same question as before makes for an easy before-and-after comparison.
 
 ## step: review-verification-message
 
-Wait for the Demo Agent to finish responding. When the reply is complete, click **Next** so you can check the evals on the new trace.
+Wait for the Demo Agent to finish responding, then click **Next** to check the evals on the new trace.
 
 ## step: verify-eval-passes
 
-Open **Observe** from the sidebar to see the traces your verification message produced.
+Open **Observe** from the sidebar to see the traces from your verification message.
 
 ## step: review-latest-trace
 
-This is the latest trace — the one from the message you just sent. Open it to check the evals: the **Source Attribution Eval** should now be green now that the agent cites its source. That passing eval is your proof the fix held, closing the loop you started back in Observe.
+Open the latest trace (the one from the message you just sent) and check the evals. The **Source Attribution Eval** should be green now that the agent cites its source. That passing eval is your confirmation the fix worked.


### PR DESCRIPTION
## Summary
Updated instructional copy across the Agent Development Lifecycle (ADLC) task tour to improve clarity, reduce verbosity, and enhance user guidance. Changes focus on simplifying language, removing redundancy, and making instructions more direct and actionable.

## Key Changes

**01-agent.md**
- Simplified intro and scenario descriptions
- Made instructions more direct (e.g., "Open **Demo Agent**" instead of longer preamble)
- Reduced wordiness while maintaining meaning

**02-evals.md**
- Clarified the relationship between evals, transforms, and traces
- Simplified explanations of evaluator versioning and scoring
- Made instructions more concise without losing technical accuracy

**03-traces.md**
- Streamlined intro to focus on key concepts (timeline, automatic evals, failure detection)
- Simplified span/annotation explanations
- Made feedback instructions more direct

**04-datasets.md**
- Clarified dataset purpose and versioning
- Simplified row/column/generation explanations
- Made instructions more action-oriented
- Improved clarity around synthetic data generation

**05-prompts.md**
- Changed "collection" to "bundle" for consistency
- Simplified variant/version terminology
- Made playground and experiment setup instructions clearer
- Reduced redundancy in variable mapping and eval configuration steps
- Improved tone from prescriptive to explanatory

**06-deploy.md**
- Clarified the feedback loop from Observe → fix → verification
- Simplified production tagging and verification steps
- Made success criteria clearer

## Notable Implementation Details
- Maintained all technical accuracy while improving readability
- Consistent terminology across all sections (e.g., "bundle" for prompts, "variant" for versions)
- Removed unnecessary qualifiers and hedging language
- Improved parallel structure in multi-step instructions
- Enhanced emphasis using bold formatting for UI elements and key terms

https://claude.ai/code/session_01Vt1XXC15EXg62fRgbN5LgD