### PR TITLE
fix(UP-4505): stop red target-lost hint flashing in task tour Step 3

### DIFF
--- a/genai-engine/ui/src/features/task-tour/hooks/useChecklistController.ts
+++ b/genai-engine/ui/src/features/task-tour/hooks/useChecklistController.ts
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, type ReactNode } from "react";
+import { useDebouncer } from "@tanstack/react-pacer";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { TASK_TOUR_SECTIONS, type TaskTourItem } from "../data";
 import { dismissOverlay } from "../dismissOverlay";
@@ -14,6 +15,41 @@ import {
   type StepRenderContext,
   type TourStatePlugin,
 } from "@/features/tour";
+
+/**
+ * Grace period before a missing target surfaces its "target lost" hint. Clicks
+ * inside an active step routinely detach and re-attach the highlighted node for
+ * a frame or two (list re-renders, drawer swaps), which momentarily resolves the
+ * target to null. Without this delay the red hint copy flashes on every such
+ * click (UP-4505). A genuinely missing target stays null past the window and the
+ * hint still appears.
+ */
+const TARGET_LOST_HINT_DELAY_MS = 200;
+
+/**
+ * Returns true only after `active` has stayed true continuously for `delayMs`.
+ * Flips back to false immediately when `active` becomes false, so the hint
+ * disappears the instant the target re-resolves — only the lost→shown edge is
+ * debounced (via TanStack Pacer), never shown→cleared.
+ */
+export function useDelayedFlag(active: boolean, delayMs: number): boolean {
+  const [flag, setFlag] = useState(false);
+  // Pacer debounces the trailing edge of `maybeExecute`, so a transient `active`
+  // blip shorter than `delayMs` is cancelled before it can flip the flag.
+  const showDebouncer = useDebouncer(setFlag, { wait: delayMs });
+
+  useEffect(() => {
+    if (active) {
+      showDebouncer.maybeExecute(true);
+    } else {
+      // Drop any pending show and clear immediately — no delay on this edge.
+      showDebouncer.cancel();
+      setFlag(false);
+    }
+  }, [active, showDebouncer]);
+
+  return flag;
+}
 
 export interface ChecklistController {
   /**
@@ -134,7 +170,10 @@ export function useChecklistController(statePlugin: TourStatePlugin): ChecklistC
   }, [activeStep, actions, engine.config.id]);
 
   const activeStepKey = state.status === "step" ? `${state.sectionId}.${state.stepId}` : null;
-  const targetLostHint = activeStepKey && !activeTarget ? (TASK_TOUR_TARGET_LOST_HINTS[activeStepKey] ?? null) : null;
+  // Debounce the lost→shown edge so a transient target swap on click doesn't
+  // flash the hint; see {@link useDelayedFlag} / UP-4505.
+  const targetMissing = useDelayedFlag(activeStepKey != null && !activeTarget, TARGET_LOST_HINT_DELAY_MS);
+  const targetLostHint = activeStepKey && targetMissing ? (TASK_TOUR_TARGET_LOST_HINTS[activeStepKey] ?? null) : null;
   // Occlusion is mutually exclusive with target-lost at the source (occlusion
   // only fires when an element resolved; target-lost only when none did).
   const occlusionHint = activeStepKey && occlusion ? (TASK_TOUR_OCCLUSION_HINTS[activeStepKey] ?? DEFAULT_OCCLUSION_HINT) : null;

--- a/genai-engine/ui/src/features/task-tour/hooks/useDelayedFlag.test.tsx
+++ b/genai-engine/ui/src/features/task-tour/hooks/useDelayedFlag.test.tsx
@@ -1,0 +1,63 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDelayedFlag } from "./useChecklistController";
+
+const DELAY = 200;
+
+describe("useDelayedFlag", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays false while inactive", () => {
+    const { result } = renderHook(() => useDelayedFlag(false, DELAY));
+    expect(result.current).toBe(false);
+    act(() => vi.advanceTimersByTime(DELAY * 2));
+    expect(result.current).toBe(false);
+  });
+
+  it("does NOT flip on a transient activation shorter than the delay (the UP-4505 flash)", () => {
+    const { result, rerender } = renderHook(({ active }) => useDelayedFlag(active, DELAY), {
+      initialProps: { active: false },
+    });
+
+    // Target lost for a single frame, then re-resolved before the window elapses.
+    rerender({ active: true });
+    act(() => vi.advanceTimersByTime(DELAY - 50));
+    expect(result.current).toBe(false);
+    rerender({ active: false });
+
+    // Even after plenty of time, the cancelled timer must not surface the flag.
+    act(() => vi.advanceTimersByTime(DELAY * 2));
+    expect(result.current).toBe(false);
+  });
+
+  it("flips true once active stays continuously past the delay", () => {
+    const { result, rerender } = renderHook(({ active }) => useDelayedFlag(active, DELAY), {
+      initialProps: { active: false },
+    });
+
+    rerender({ active: true });
+    expect(result.current).toBe(false);
+    act(() => vi.advanceTimersByTime(DELAY - 1));
+    expect(result.current).toBe(false);
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current).toBe(true);
+  });
+
+  it("clears immediately when active goes false (no delay on the shown→cleared edge)", () => {
+    const { result, rerender } = renderHook(({ active }) => useDelayedFlag(active, DELAY), {
+      initialProps: { active: true },
+    });
+
+    act(() => vi.advanceTimersByTime(DELAY));
+    expect(result.current).toBe(true);
+
+    rerender({ active: false });
+    expect(result.current).toBe(false);
+  });
+});


### PR DESCRIPTION
Clicks inside an active tour step briefly detach/re-attach the highlighted node (list re-renders, drawer swaps), which momentarily resolves the target to null and emits target:lost. The checklist panel rendered the red "target lost" hint on that transient state, so the copy flashed on nearly every click in the evals section (Step 3).

Gate the hint behind useDelayedFlag, a TanStack Pacer-backed hook that debounces the lost->shown edge (~200ms) while clearing instantly when the target re-resolves, so transient blips never surface the hint but a genuinely missing target still does.