### PR TITLE
fix(UP-4510): lift Variables panel above playground input labels

### DIFF
--- a/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
+++ b/genai-engine/ui/src/components/prompts-playground/PlaygroundHeader.tsx
@@ -166,7 +166,7 @@ export default function PlaygroundHeader({
               </Popover.Trigger>
             </Badge>
             <Popover.Portal>
-              <Popover.Positioner side="bottom" align="start" sideOffset={6}>
+              <Popover.Positioner side="bottom" align="start" sideOffset={6} className="z-50">
                 <Popover.Popup
                   data-tour-id={TOUR_IDS.playgroundVariablesPanel}
                   render={<Paper className="outline-none" sx={{ width: 400, maxHeight: 500, overflow: "auto" }} />}


### PR DESCRIPTION
The Variables panel is a Base UI Popover portaled to <body> without a z-index, so it lands in the base positioned layer and the playground's stacking contexts (the z-10 resize splitter, prompt-card transforms) paint their floating input labels over it. Add z-50 to the Positioner, matching SpanSelector, so the panel sits above page content.