### PR TITLE
fix(UP-4548): keep guided tour popover clear of docked checklist panel

### DIFF
--- a/genai-engine/ui/src/features/tour/react/primitives/PopoverAnchor.tsx
+++ b/genai-engine/ui/src/features/tour/react/primitives/PopoverAnchor.tsx
@@ -22,6 +22,16 @@ export interface PopoverAnchorProps {
   children: ReactNode;
 }
 
+// Width the docked checklist panel reserves on the right, published by
+// `TourSidePanel` and subtracted by MUI dialogs/drawers too (see `mui-theme.ts`).
+// 0 outside the tour, where the variable is unset.
+function readInsetRight(): number {
+  if (typeof window === "undefined") return 0;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue("--app-inset-right");
+  const value = parseFloat(raw);
+  return Number.isFinite(value) ? value : 0;
+}
+
 /**
  * Positions `children` relative to a live rect via floating-ui. Renders
  * nothing while `rect` is null.
@@ -35,6 +45,12 @@ export function PopoverAnchor({
   className,
   children,
 }: PopoverAnchorProps) {
+  // Trim the checklist panel's column off the right edge so the popover never
+  // lands on top of it (UP-4548). Re-read each render; the rect re-measures and
+  // re-renders us as the panel's collapse/expand animation reflows the page.
+  const insetRight = readInsetRight();
+  const padding = { top: viewportPadding, right: viewportPadding + insetRight, bottom: viewportPadding, left: viewportPadding };
+
   const { refs, floatingStyles } = useFloating<ReferenceType>({
     placement,
     strategy: "fixed",
@@ -45,7 +61,7 @@ export function PopoverAnchor({
       // side (e.g. top -> right) when neither the preferred side nor its
       // opposite fits — important for very tall targets like the evaluator
       // instructions panel or the full-height version drawer.
-      flip({ padding: viewportPadding, fallbackAxisSideDirection: "end" }),
+      flip({ padding, fallbackAxisSideDirection: "end" }),
       // `crossAxis: true` lets the popover slide along the placement's cross
       // axis too, so when the target nearly fills the viewport (e.g. the trace
       // drawer actions region) and no outside side fits, the popover is pulled
@@ -53,11 +69,11 @@ export function PopoverAnchor({
       // off-screen. The limiter still constrains the main axis (keeps the
       // popover attached to the target side) but leaves the cross axis free so
       // it can travel all the way inside when needed.
-      shift({ padding: viewportPadding, crossAxis: true, limiter: limitShift({ crossAxis: false }) }),
+      shift({ padding, crossAxis: true, limiter: limitShift({ crossAxis: false }) }),
       // Cap the popover to the space actually available in its final placement
       // so it never spills outside the viewport; long content scrolls inside.
       size({
-        padding: viewportPadding,
+        padding,
         apply({ availableWidth, availableHeight, elements }) {
           Object.assign(elements.floating.style, {
             maxWidth: `${Math.max(200, availableWidth)}px`,


### PR DESCRIPTION
The tour step popover is a fixed, viewport-anchored overlay rendered above the in-flow checklist panel, but floating-ui treated the panel's reserved column as free space and could flip/shift the popover on top of the checklist copy. Subtract the panel's `--app-inset-right` width from the right edge of the flip/shift/size padding, the same contract MUI dialogs/drawers already honor.