### PR TITLE
fix(UP-4541): delay section-complete until async results land in tour…

### DIFF
--- a/genai-engine/ui/src/components/prompt-experiments/ExperimentDetailView.tsx
+++ b/genai-engine/ui/src/components/prompt-experiments/ExperimentDetailView.tsx
@@ -30,6 +30,7 @@ import { PromptVersionDrawer } from "./PromptVersionDrawer";
 
 import { getContentHeight } from "@/constants/layout";
 import { useDisplaySettings } from "@/contexts/DisplaySettingsContext";
+import { TOUR_IDS } from "@/features/task-tour/selectors";
 import { useCreateNotebookMutation, useAttachExperimentToNotebookMutation, useSetNotebookStateMutation } from "@/hooks/useNotebooks";
 import { usePromptExperiment, useDeleteExperiment } from "@/hooks/usePromptExperiments";
 import { formatDateInTimezone, formatTimestampDuration, formatCurrency } from "@/utils/formatters";
@@ -213,7 +214,7 @@ export const ExperimentDetailView: React.FC = () => {
   }
 
   return (
-    <Box className="w-full overflow-auto" style={{ height: getContentHeight() }}>
+    <Box className="w-full overflow-auto" style={{ height: getContentHeight() }} data-tour-id={TOUR_IDS.promptExperimentDetail}>
       <Box className="p-6">
         {/* Breadcrumb / Back Button */}
         <Box className="mb-4">

--- a/genai-engine/ui/src/features/task-tour/__tests__/tourConfig.test.ts
+++ b/genai-engine/ui/src/features/task-tour/__tests__/tourConfig.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { TASK_TOUR_QUERY_HOOKS } from "../content/wiring";
+import { TASK_TOUR_PREPARATIONS, TASK_TOUR_QUERY_HOOKS } from "../content/wiring";
 import { tourSelector, TOUR_IDS } from "../selectors";
 import { buildTourConfig } from "../tour-config";
 import { TASK_TOUR_ACTIONS } from "../tourActions";
@@ -11,6 +11,7 @@ describe("task tour config", () => {
     const agentSection = config.sections.find((section) => section.id === "agent");
     const openDemoAgentStep = agentSection?.steps.find((step) => step.id === "open-demo-agent");
     const sendMessageStep = agentSection?.steps.find((step) => step.id === "send-message");
+    const reviewResponseStep = agentSection?.steps.find((step) => step.id === "review-agent-response");
 
     expect(openDemoAgentStep).toMatchObject({
       route: {
@@ -29,6 +30,18 @@ describe("task tour config", () => {
         value: "What is an AI Agent?",
       },
       advanceOn: [{ type: "action", name: TASK_TOUR_ACTIONS.demoAgentMessageSent }],
+    });
+    // The closing beat holds the section open while the response streams in:
+    // it spotlights the chat window and advances only on an explicit Next, so
+    // the section-complete dialog can't appear before the answer arrives.
+    expect(reviewResponseStep).toMatchObject({
+      route: {
+        path: "/tasks/:taskId/chatbot",
+        params: { taskId: "task-id" },
+      },
+      target: { kind: "selector", selector: tourSelector(TOUR_IDS.chatWindow) },
+      advanceOn: [{ type: "manual" }],
+      popover: { showNext: true, nextLabel: "Next" },
     });
   });
 
@@ -261,6 +274,7 @@ describe("task tour config", () => {
     const promptMappingStep = promptsSection?.steps.find((step) => step.id === "complete-prompt-mapping");
     const explainEvalMappingStep = promptsSection?.steps.find((step) => step.id === "explain-eval-mapping");
     const createExperimentStep = promptsSection?.steps.find((step) => step.id === "create-experiment");
+    const reviewExperimentStep = promptsSection?.steps.find((step) => step.id === "review-experiment");
 
     expect(openCreateStep).toMatchObject({
       route: {
@@ -343,6 +357,19 @@ describe("task tour config", () => {
     });
     expect(createExperimentStep?.skipWhen).toBeDefined();
 
+    // Creating the run redirects to its detail page, so this beat is route-less
+    // (a static route would strip the dynamic /prompt-experiments/:id URL back
+    // to the list) and spotlights that auto-refreshing page, waiting for an
+    // explicit Next so the section-complete dialog can't appear mid-run. The
+    // `experimentDetailOpened` prep re-navigates on an out-of-order jump.
+    expect(reviewExperimentStep).toMatchObject({
+      target: { kind: "selector", selector: tourSelector(TOUR_IDS.promptExperimentDetail) },
+      advanceOn: [{ type: "manual" }],
+      popover: { showNext: true, nextLabel: "Next" },
+      prepare: { key: TASK_TOUR_PREPARATIONS.experimentDetailOpened },
+    });
+    expect(reviewExperimentStep?.route).toBeUndefined();
+
     // Modal beats encode their internal step as the `experimentStep` search
     // param so PromptExperimentsView opens the modal at the right step on a
     // jump (open-create-experiment stays param-less — it teaches the button).
@@ -385,6 +412,7 @@ describe("task tour config", () => {
     const reviewVerificationMessageStep = deploySection?.steps.find((step) => step.id === "review-verification-message");
     const verifyEvalStep = deploySection?.steps.find((step) => step.id === "verify-eval-passes");
     const reviewLatestTraceStep = deploySection?.steps.find((step) => step.id === "review-latest-trace");
+    const reviewEvalResultStep = deploySection?.steps.find((step) => step.id === "review-eval-result");
 
     expect(stepIds).toEqual([
       "open-production-prompt",
@@ -394,6 +422,7 @@ describe("task tour config", () => {
       "review-verification-message",
       "verify-eval-passes",
       "review-latest-trace",
+      "review-eval-result",
     ]);
     expect(reopenDemoAgentStep).toMatchObject({
       route: {
@@ -438,6 +467,19 @@ describe("task tour config", () => {
       },
       target: { kind: "queryHook", hookId: TASK_TOUR_QUERY_HOOKS.tracesFirstRow },
       advanceOn: expect.arrayContaining([{ type: "action", name: TASK_TOUR_ACTIONS.traceOpened }]),
+    });
+    // Closing beat: keep the trace drawer open (traceOpened prep) and wait on an
+    // explicit Next so the tour-complete dialog can't fire before the Source
+    // Attribution Eval finishes running on the fresh trace.
+    expect(reviewEvalResultStep).toMatchObject({
+      route: {
+        path: "/tasks/:taskId/traces",
+        params: { taskId: "task-id" },
+      },
+      target: { kind: "queryHook", hookId: TASK_TOUR_QUERY_HOOKS.traceDrawerEvals },
+      advanceOn: [{ type: "manual" }],
+      popover: { showNext: true, nextLabel: "Next" },
+      prepare: { key: TASK_TOUR_PREPARATIONS.traceOpened },
     });
   });
 });

--- a/genai-engine/ui/src/features/task-tour/content/01-agent.md
+++ b/genai-engine/ui/src/features/task-tour/content/01-agent.md
@@ -12,6 +12,8 @@ steps:
     title: Open the Demo Agent
   - id: send-message
     title: Send a message
+  - id: review-agent-response
+    title: Review the response
 ---
 
 ## intro
@@ -29,3 +31,7 @@ Open **Demo Agent** in the sidebar. This takes you to the sandbox chatbot where 
 ## step: send-message
 
 Send any general-knowledge question to the Demo Agent. It will search Wikipedia, answer in the chat, and leave a trace we can look at next.
+
+## step: review-agent-response
+
+Wait for the Demo Agent to finish responding — it searches Wikipedia before it answers, so give it a moment. Once you've read the reply, click **Next** to continue.

--- a/genai-engine/ui/src/features/task-tour/content/05-prompts.md
+++ b/genai-engine/ui/src/features/task-tour/content/05-prompts.md
@@ -48,6 +48,8 @@ steps:
     title: Map evaluator variables
   - id: create-experiment
     title: Create the experiment
+  - id: review-experiment
+    title: Watch the experiment run
 ---
 
 ## intro
@@ -137,3 +139,7 @@ Each evaluator reads its variables from a source you choose. Map the agent's **r
 ## step: create-experiment
 
 Final check. Make sure every eval variable has the right source, with response variables mapped to **Experiment Output**. Then click **Create Experiment** to start the run.
+
+## step: review-experiment
+
+You're now on the experiment's results page. It's running against the dataset and evals, and the page updates as each row finishes — give it a moment to complete, then compare how your prompt versions scored. Click **Next** when you're ready to move on.

--- a/genai-engine/ui/src/features/task-tour/content/06-deploy.md
+++ b/genai-engine/ui/src/features/task-tour/content/06-deploy.md
@@ -22,6 +22,8 @@ steps:
     title: Verify the eval passes
   - id: review-latest-trace
     title: Check the latest trace
+  - id: review-eval-result
+    title: Confirm the eval passes
 ---
 
 ## intro
@@ -59,3 +61,7 @@ Open **Observe** from the sidebar to see the traces from your verification messa
 ## step: review-latest-trace
 
 Open the latest trace (the one from the message you just sent) and check the evals. The **Source Attribution Eval** should be green now that the agent cites its source. That passing eval is your confirmation the fix worked.
+
+## step: review-eval-result
+
+Evals run as soon as the trace lands, so give the **Source Attribution Eval** a moment to finish. Once it turns green, you've verified the fix end to end — click **Next** to wrap up the tour.

--- a/genai-engine/ui/src/features/task-tour/content/wiring.ts
+++ b/genai-engine/ui/src/features/task-tour/content/wiring.ts
@@ -137,6 +137,7 @@ export const TASK_TOUR_PREPARATIONS = {
   datasetDetailOpened: "task-tour.prep.datasetDetailOpened",
   promptDetailOpened: "task-tour.prep.promptDetailOpened",
   playgroundOpened: "task-tour.prep.playgroundOpened",
+  experimentDetailOpened: "task-tour.prep.experimentDetailOpened",
 } as const;
 
 /**
@@ -187,6 +188,19 @@ export const TASK_TOUR_WIRING: Record<string, SectionWiring> = {
           targetId: TOUR_IDS.chatSendPlaceholder,
           value: "What is an AI Agent?",
         },
+      },
+      // `demoAgentMessageSent` fires the instant the message is sent, while the
+      // response is still streaming — without this beat the section-complete
+      // dialog popped before any answer appeared. Spotlight the chat window and
+      // wait for an explicit Next so the user can read the streamed reply.
+      // Mirrors `deploy.review-verification-message`. `actionName` is required
+      // but inert under manual advance, so it reuses `demoAgentMessageSent`.
+      "review-agent-response": {
+        targetId: TOUR_IDS.chatWindow,
+        actionName: TASK_TOUR_ACTIONS.demoAgentMessageSent,
+        route: "chatbot",
+        advance: "manual",
+        popover: { showNext: true, nextLabel: "Next", placement: "top" },
       },
     },
   },
@@ -620,6 +634,22 @@ export const TASK_TOUR_WIRING: Record<string, SectionWiring> = {
         skipWhenEmptyKey: TASK_TOUR_SKIP_WHEN.noEvaluators,
         popover: { placement: "left" },
       }),
+      // `createExperimentCreated` fires the moment the run is created, while it
+      // is still queued/running — without this beat the section-complete dialog
+      // popped before any results existed. Creating an experiment redirects to
+      // its detail view (`/prompt-experiments/:id`, see create-experiment-modal),
+      // which auto-refreshes while the run is in flight, so spotlight that page
+      // and wait for an explicit Next. Route-less so the redirect's dynamic URL
+      // isn't stripped back to the list; `experimentDetailOpened` re-navigates to
+      // the latest experiment on an out-of-order jump (mirrors the evaluator /
+      // dataset / prompt detail beats). `actionName` is inert under manual.
+      "review-experiment": {
+        targetId: TOUR_IDS.promptExperimentDetail,
+        actionName: TASK_TOUR_ACTIONS.createExperimentCreated,
+        advance: "manual",
+        prepareKey: TASK_TOUR_PREPARATIONS.experimentDetailOpened,
+        popover: { showNext: true, nextLabel: "Next", placement: "top" },
+      },
     },
   },
   deploy: {
@@ -678,6 +708,21 @@ export const TASK_TOUR_WIRING: Record<string, SectionWiring> = {
         targetHookId: TASK_TOUR_QUERY_HOOKS.tracesFirstRow,
         route: "traces",
         actionName: TASK_TOUR_ACTIONS.traceOpened,
+      },
+      // `traceOpened` fires when the drawer opens, but the Source Attribution
+      // eval may still be running on the fresh trace — without this beat the
+      // tour-complete dialog popped before the eval turned green. Keep the
+      // drawer open (`traceOpened` prep) and spotlight the eval annotations,
+      // waiting for an explicit Next. Mirrors `traces.review-annotations`;
+      // `actionName` is inert under manual advance.
+      "review-eval-result": {
+        targetId: TOUR_IDS.traceDrawerEvals,
+        targetHookId: TASK_TOUR_QUERY_HOOKS.traceDrawerEvals,
+        route: "traces",
+        actionName: TASK_TOUR_ACTIONS.traceOpened,
+        advance: "manual",
+        prepareKey: TASK_TOUR_PREPARATIONS.traceOpened,
+        popover: { showNext: true, nextLabel: "Next", placement: "left" },
       },
     },
   },

--- a/genai-engine/ui/src/features/task-tour/prep/useDetailRouteTourPrep.ts
+++ b/genai-engine/ui/src/features/task-tour/prep/useDetailRouteTourPrep.ts
@@ -97,8 +97,25 @@ export function useDetailRouteTourPrep({ taskId }: UseDetailRouteTourPrepOptions
     return { ready: true };
   }, []);
 
+  // Experiment detail — /tasks/:taskId/prompt-experiments/:experimentId
+  const experimentHook = useCallback<PreparationHook>(async () => {
+    if (/\/prompt-experiments\/[^/]+/.test(pathnameRef.current)) return { ready: true };
+    const tid = taskIdRef.current;
+    let experimentId: string | null = null;
+    try {
+      const response = await apiRef.current?.api.listPromptExperimentsApiV1TasksTaskIdPromptExperimentsGet({ taskId: tid, page: 0, page_size: 1 });
+      experimentId = response?.data.data?.[0]?.id ?? null;
+    } catch {
+      // fall through to the not-ready hint
+    }
+    if (!experimentId) return { ready: false };
+    navigateRef.current(`/tasks/${tid}/prompt-experiments/${experimentId}`);
+    return { ready: true };
+  }, []);
+
   useRegisterPreparation(TASK_TOUR_PREPARATIONS.evaluatorDetailOpened, evaluatorHook);
   useRegisterPreparation(TASK_TOUR_PREPARATIONS.datasetDetailOpened, datasetHook);
   useRegisterPreparation(TASK_TOUR_PREPARATIONS.promptDetailOpened, promptHook);
   useRegisterPreparation(TASK_TOUR_PREPARATIONS.playgroundOpened, playgroundHook);
+  useRegisterPreparation(TASK_TOUR_PREPARATIONS.experimentDetailOpened, experimentHook);
 }

--- a/genai-engine/ui/src/features/task-tour/selectors.ts
+++ b/genai-engine/ui/src/features/task-tour/selectors.ts
@@ -123,6 +123,12 @@ export const TOUR_IDS = {
   createExperimentEvalMappingsList: "task-tour-create-experiment-eval-mappings-list",
   /** Final Create Experiment action in the dialog. */
   createExperimentSubmit: "task-tour-create-experiment-submit",
+  /**
+   * Root of the experiment detail view (`/prompt-experiments/:id`). Creating an
+   * experiment redirects here, so it's spotlighted as the closing beat — the
+   * user watches the run finish before the section-complete dialog appears.
+   */
+  promptExperimentDetail: "task-tour-prompt-experiment-detail",
 } as const;
 
 export type TourId = (typeof TOUR_IDS)[keyof typeof TOUR_IDS];

--- a/genai-engine/ui/src/features/task-tour/tour-config.ts
+++ b/genai-engine/ui/src/features/task-tour/tour-config.ts
@@ -74,7 +74,8 @@ function buildStep(taskId: string, item: TaskTourItem, opts: BuildTourConfigOpti
     item.prepareKey === TASK_TOUR_PREPARATIONS.evaluatorDetailOpened ||
     item.prepareKey === TASK_TOUR_PREPARATIONS.datasetDetailOpened ||
     item.prepareKey === TASK_TOUR_PREPARATIONS.promptDetailOpened ||
-    item.prepareKey === TASK_TOUR_PREPARATIONS.playgroundOpened;
+    item.prepareKey === TASK_TOUR_PREPARATIONS.playgroundOpened ||
+    item.prepareKey === TASK_TOUR_PREPARATIONS.experimentDetailOpened;
   const skipWhen = item.skipWhenEmptyKey ? (ctx: StepContext) => Promise.resolve(opts.isEmpty?.(item.skipWhenEmptyKey!, ctx) ?? false) : undefined;
   const surfaces = surfacesFor(item);
   return {

--- a/genai-engine/ui/src/features/task-tour/tourActions.ts
+++ b/genai-engine/ui/src/features/task-tour/tourActions.ts
@@ -108,6 +108,9 @@ export function refreshTaskTourTarget(): void {
 
 /** Keys are `${sectionId}.${stepId}` — shown under the active checklist row when the spotlight target is missing. */
 export const TASK_TOUR_TARGET_LOST_HINTS: Partial<Record<string, string>> = {
+  "agent.review-agent-response": "Stay on the Demo Agent until the response finishes streaming, then continue.",
+  "prompts.review-experiment": "Open your experiment's results page to watch the run finish, then continue.",
+  "deploy.review-eval-result": "Open the latest trace and scroll to the eval annotations to confirm the Source Attribution Eval passes.",
   "traces.open-trace": "Click a trace row, or mark this step complete to open the top trace automatically.",
   "traces.review-spans": "Open a trace first — the highlight appears once the drawer is visible.",
   "traces.review-annotations": "Open a trace and scroll to the eval annotations to continue.",


### PR DESCRIPTION
… steps 2, 6, 7

The "Section complete" dialog fired the instant the last step of a section completed, even when the work that step kicked off was still in flight, so users were yanked away before there was anything to look at:

- agent (§2): send-message advanced on demoAgentMessageSent (dispatched the moment the message is sent) while the reply was still streaming.
- prompts (§6): create-experiment advanced on createExperimentCreated, fired on creation while the run was still queued/running.
- deploy (§7): review-latest-trace advanced on traceOpened, before the Source Attribution eval finished on the fresh trace.

Add a manual "review" beat as the new last step of each section, following the existing deploy.review-verification-message / evals.review-result-details precedent. Because section-complete only fires after the final step, the review beat becomes the gate and the user controls the pacing:

- agent.review-agent-response spotlights the chat window.
- prompts.review-experiment spotlights the experiment detail view. Creating a run redirects to /prompt-experiments/:id, so the beat is route-less (a static route would strip the dynamic URL back to the list) and is made jump-safe with a new experimentDetailOpened prep that re-navigates to the latest experiment, mirroring the evaluator/dataset/prompt detail beats.
- deploy.review-eval-result keeps the trace drawer open and spotlights the eval annotations.