### PR TITLE
Rename KEYCLOAK_SSL_VERIFY to an approrpriate name

### DIFF
--- a/ml-engine/src/ml_engine/config/config.py
+++ b/ml-engine/src/ml_engine/config/config.py
@@ -16,16 +16,23 @@ class Config:
     settings = settings
 
     @classmethod
-    def get_bool(cls, key: str, default: bool = False) -> bool:
+    def get_bool(
+        cls,
+        key: str,
+        default: bool = False,
+        fallback_keys: list[str] | None = None,
+    ) -> bool:
         settings_dict = cls.settings.as_dict()
-        value = settings_dict.get(key)
-        if isinstance(value, bool):
-            return value
-        if value is None:
-            return default
-        if isinstance(value, str):
-            return value.lower() in ["true", "1", "yes"]
-        raise ValueError(f"Invalid value for {key}: {value}")
+        for k in [key, *(fallback_keys or [])]:
+            value = settings_dict.get(k)
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, str):
+                return value.lower() in ["true", "1", "yes"]
+            raise ValueError(f"Invalid value for {k}: {value}")
+        return default
 
     @staticmethod
     def segmentation_col_count_limit() -> int:

--- a/ml-engine/src/ml_engine/config/settings.yaml
+++ b/ml-engine/src/ml_engine/config/settings.yaml
@@ -23,4 +23,4 @@ SEGMENTATION_COL_UNIQUE_VALUE_LIMIT: 100
 # Timeout increased to 10 minutes to allow for larger datasets and more complex aggregations
 ML_ENGINE_AGGREGATION_TIMEOUT: 600
 ###############################################
-KEYCLOAK_SSL_VERIFY: true
+ARTHUR_API_HOST_SSL_VERIFY: true

--- a/ml-engine/src/ml_engine/config/settings.yaml
+++ b/ml-engine/src/ml_engine/config/settings.yaml
@@ -23,4 +23,8 @@ SEGMENTATION_COL_UNIQUE_VALUE_LIMIT: 100
 # Timeout increased to 10 minutes to allow for larger datasets and more complex aggregations
 ML_ENGINE_AGGREGATION_TIMEOUT: 600
 ###############################################
-ARTHUR_API_HOST_SSL_VERIFY: true
+# SSL verification for connections to ARTHUR_API_HOST. Defaults to true (see the
+# Config.get_bool default at the call sites). The legacy KEYCLOAK_SSL_VERIFY env
+# var is honored as a fallback for backward compatibility. Left unset here so an
+# explicit KEYCLOAK_SSL_VERIFY override is not shadowed by a value from this file.
+# ARTHUR_API_HOST_SSL_VERIFY: true

--- a/ml-engine/src/ml_engine/job_agent.py
+++ b/ml-engine/src/ml_engine/job_agent.py
@@ -45,7 +45,7 @@ class RunningJob:
 
 class JobAgent:
     def __init__(self, shutdown_grace_period_seconds: int = 15) -> None:
-        ssl_verify = Config.get_bool("KEYCLOAK_SSL_VERIFY", True)
+        ssl_verify = Config.get_bool("ARTHUR_API_HOST_SSL_VERIFY", True)
         sess = ArthurClientCredentialsAPISession(
             client_id=Config.settings.ARTHUR_CLIENT_ID,
             client_secret=Config.settings.ARTHUR_CLIENT_SECRET,

--- a/ml-engine/src/ml_engine/job_agent.py
+++ b/ml-engine/src/ml_engine/job_agent.py
@@ -45,7 +45,11 @@ class RunningJob:
 
 class JobAgent:
     def __init__(self, shutdown_grace_period_seconds: int = 15) -> None:
-        ssl_verify = Config.get_bool("ARTHUR_API_HOST_SSL_VERIFY", True)
+        ssl_verify = Config.get_bool(
+            "ARTHUR_API_HOST_SSL_VERIFY",
+            True,
+            fallback_keys=["KEYCLOAK_SSL_VERIFY"],
+        )
         sess = ArthurClientCredentialsAPISession(
             client_id=Config.settings.ARTHUR_CLIENT_ID,
             client_secret=Config.settings.ARTHUR_CLIENT_SECRET,

--- a/ml-engine/src/ml_engine/job_executor.py
+++ b/ml-engine/src/ml_engine/job_executor.py
@@ -110,7 +110,7 @@ class JobSpecRawParser:
 
 class JobExecutor:
     def __init__(self) -> None:
-        ssl_verify = Config.get_bool("KEYCLOAK_SSL_VERIFY", True)
+        ssl_verify = Config.get_bool("ARTHUR_API_HOST_SSL_VERIFY", True)
         sess = ArthurClientCredentialsAPISession(
             client_id=Config.settings.ARTHUR_CLIENT_ID,
             client_secret=Config.settings.ARTHUR_CLIENT_SECRET,
@@ -376,7 +376,7 @@ class JobExecutor:
                         if not genai_engine_url or not genai_engine_api_key:
                             self.logger.error(
                                 "GenAI Engine configuration missing. "
-                                "GENAI_ENGINE_INTERNAL_HOST and GENAI_ENGINE_INTERNAL_API_KEY must be set."
+                                "GENAI_ENGINE_INTERNAL_HOST and GENAI_ENGINE_INTERNAL_API_KEY must be set.",
                             )
                             raise ValueError("GenAI Engine configuration missing")
 

--- a/ml-engine/src/ml_engine/job_executor.py
+++ b/ml-engine/src/ml_engine/job_executor.py
@@ -110,7 +110,11 @@ class JobSpecRawParser:
 
 class JobExecutor:
     def __init__(self) -> None:
-        ssl_verify = Config.get_bool("ARTHUR_API_HOST_SSL_VERIFY", True)
+        ssl_verify = Config.get_bool(
+            "ARTHUR_API_HOST_SSL_VERIFY",
+            True,
+            fallback_keys=["KEYCLOAK_SSL_VERIFY"],
+        )
         sess = ArthurClientCredentialsAPISession(
             client_id=Config.settings.ARTHUR_CLIENT_ID,
             client_secret=Config.settings.ARTHUR_CLIENT_SECRET,

--- a/ml-engine/tests/unit/configuration/test_config.py
+++ b/ml-engine/tests/unit/configuration/test_config.py
@@ -24,6 +24,47 @@ def test_get_bool():
             Config.get_bool("FETCH_RAW_DATA_ENABLED", default=True)
 
 
+def test_get_bool_fallback_keys():
+    # primary key set -> primary wins over legacy fallback
+    with patch("config.Config.settings") as mock_settings:
+        mock_settings.as_dict.return_value = {
+            "ARTHUR_API_HOST_SSL_VERIFY": "false",
+            "KEYCLOAK_SSL_VERIFY": "true",
+        }
+        assert (
+            Config.get_bool(
+                "ARTHUR_API_HOST_SSL_VERIFY",
+                default=True,
+                fallback_keys=["KEYCLOAK_SSL_VERIFY"],
+            )
+            is False
+        )
+
+    # primary key unset -> legacy KEYCLOAK_SSL_VERIFY is honored (backward compat)
+    with patch("config.Config.settings") as mock_settings:
+        mock_settings.as_dict.return_value = {"KEYCLOAK_SSL_VERIFY": "false"}
+        assert (
+            Config.get_bool(
+                "ARTHUR_API_HOST_SSL_VERIFY",
+                default=True,
+                fallback_keys=["KEYCLOAK_SSL_VERIFY"],
+            )
+            is False
+        )
+
+    # neither set -> default
+    with patch("config.Config.settings") as mock_settings:
+        mock_settings.as_dict.return_value = {}
+        assert (
+            Config.get_bool(
+                "ARTHUR_API_HOST_SSL_VERIFY",
+                default=True,
+                fallback_keys=["KEYCLOAK_SSL_VERIFY"],
+            )
+            is True
+        )
+
+
 def test_genai_engine_max_page_size():
     with patch("config.config.settings") as mock_settings:
         mock_settings.GENAI_ENGINE_MAX_PAGE_SIZE = 500


### PR DESCRIPTION
The SSL is for the platform connection.