### PR TITLE
Fix Dependabot alerts #649 (python-multipart) and #472 (black)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         fail_fast: true
         exclude: ^arthur-observability-sdk/python/src/arthur_genai_client/
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.3.1
     hooks:
       - id: black
         language_version: python3.12

--- a/arthur-observability-sdk/python/uv.lock
+++ b/arthur-observability-sdk/python/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-08T22:00:56.586421Z"
+exclude-newer = "2026-06-09T01:33:28.701889Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "arthur-observability-sdk"
-version = "2.1.631"
+version = "2.1.632"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -2822,11 +2822,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]

--- a/genai-engine/pyproject.toml
+++ b/genai-engine/pyproject.toml
@@ -92,7 +92,7 @@ performance = [
   "locust==2.43.3",
 ]
 linters = [
-  "black==25.12.0",
+  "black==26.3.1",
   "mypy>=1.13.0,<2",
   "isort>=7.0.0",
   "autoflake>=2.3.1,<3",

--- a/genai-engine/src/scorer/metrics/relevance/prompt_templates.py
+++ b/genai-engine/src/scorer/metrics/relevance/prompt_templates.py
@@ -41,16 +41,14 @@ Evaluate if the user query is relevant to the system prompt. Provide a response 
 
 # Legacy prompt templates (with format_instructions)
 RESPONSE_RELEVANCE_NON_STRUCTURED_PROMPT_TEMPLATE = (
-    RESPONSE_RELEVANCE_STRUCTURED_PROMPT_TEMPLATE
-    + """
+    RESPONSE_RELEVANCE_STRUCTURED_PROMPT_TEMPLATE + """
 ---
 {format_instructions}
 ---"""
 )
 
 USER_QUERY_RELEVANCE_NON_STRUCTURED_PROMPT_TEMPLATE = (
-    USER_QUERY_RELEVANCE_STRUCTURED_PROMPT_TEMPLATE
-    + """
+    USER_QUERY_RELEVANCE_STRUCTURED_PROMPT_TEMPLATE + """
 ---
 {format_instructions}
 ---"""

--- a/genai-engine/src/scorer/metrics/tool_selection/prompt_templates.py
+++ b/genai-engine/src/scorer/metrics/tool_selection/prompt_templates.py
@@ -83,20 +83,16 @@ Now evaluate the following:
 
 # Legacy prompt templates (with format_instructions)
 TOOL_SELECTION_NON_STRUCTURED_PROMPT_TEMPLATE = (
-    TOOL_SELECTION_STRUCTURED_PROMPT_TEMPLATE
-    + """
+    TOOL_SELECTION_STRUCTURED_PROMPT_TEMPLATE + """
 
     ---
     {format_instructions}
     ---"""
 )
 
-TOOL_USAGE_NON_STRUCTURED_PROMPT_TEMPLATE = (
-    TOOL_USAGE_STRUCTURED_PROMPT_TEMPLATE
-    + """
+TOOL_USAGE_NON_STRUCTURED_PROMPT_TEMPLATE = TOOL_USAGE_STRUCTURED_PROMPT_TEMPLATE + """
 
     ---
     {format_instructions}
 
     ---"""
-)

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-08T20:17:49.468813Z"
+exclude-newer = "2026-06-09T01:36:01.005306Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "arthur-genai-engine"
-version = "2.1.630"
+version = "2.1.632"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -348,7 +348,7 @@ dev = [
 ]
 linters = [
     { name = "autoflake", specifier = ">=2.3.1,<3" },
-    { name = "black", specifier = "==25.12.0" },
+    { name = "black", specifier = "==26.3.1" },
     { name = "isort", specifier = ">=7.0.0" },
     { name = "mypy", specifier = ">=1.13.0,<2" },
 ]
@@ -500,7 +500,7 @@ wheels = [
 
 [[package]]
 name = "black"
-version = "25.12.0"
+version = "26.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -510,14 +510,14 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/d9/07b458a3f1c525ac392b5edc6b191ff140b596f9d77092429417a54e249d/black-25.12.0.tar.gz", hash = "sha256:8d3dd9cea14bff7ddc0eb243c811cdb1a011ebb4800a5f0335a01a68654796a7", size = 659264, upload-time = "2025-12-08T01:40:52.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/bd/26083f805115db17fda9877b3c7321d08c647df39d0df4c4ca8f8450593e/black-25.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:31f96b7c98c1ddaeb07dc0f56c652e25bdedaac76d5b68a059d998b57c55594a", size = 1924178, upload-time = "2025-12-08T01:49:51.048Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6b/ea00d6651561e2bdd9231c4177f4f2ae19cc13a0b0574f47602a7519b6ca/black-25.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:05dd459a19e218078a1f98178c13f861fe6a9a5f88fc969ca4d9b49eb1809783", size = 1742643, upload-time = "2025-12-08T01:49:59.09Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/f3/360fa4182e36e9875fabcf3a9717db9d27a8d11870f21cff97725c54f35b/black-25.12.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1f68c5eff61f226934be6b5b80296cf6939e5d2f0c2f7d543ea08b204bfaf59", size = 1800158, upload-time = "2025-12-08T01:44:27.301Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/08/2c64830cb6616278067e040acca21d4f79727b23077633953081c9445d61/black-25.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:274f940c147ddab4442d316b27f9e332ca586d39c85ecf59ebdea82cc9ee8892", size = 1426197, upload-time = "2025-12-08T01:45:51.198Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/60/a93f55fd9b9816b7432cf6842f0e3000fdd5b7869492a04b9011a133ee37/black-25.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:169506ba91ef21e2e0591563deda7f00030cb466e747c4b09cb0a9dae5db2f43", size = 1237266, upload-time = "2025-12-08T01:45:10.556Z" },
-    { url = "https://files.pythonhosted.org/packages/68/11/21331aed19145a952ad28fca2756a1433ee9308079bd03bd898e903a2e53/black-25.12.0-py3-none-any.whl", hash = "sha256:48ceb36c16dbc84062740049eef990bb2ce07598272e673c17d1a7720c71c828", size = 206191, upload-time = "2025-12-08T01:40:50.963Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Resolves two high-severity Dependabot alerts.

### [Alert #649](https://github.com/arthur-ai/arthur-engine/security/dependabot/649) — python-multipart DoS
`python-multipart < 0.0.27` has a high-severity (CVSS 7.5) denial-of-service vulnerability — **CVE-2026-42561** / GHSA-pp6c-gr5w-3c5g — where `MultipartParser` enforces no limit on the number or size of multipart part headers, allowing CPU exhaustion from attacker-controlled `multipart/form-data`. It is a **transitive** dependency in `arthur-observability-sdk/python/uv.lock`, pulled in via `mcp` (`openinference-instrumentation-mcp`).

- Bump locked `python-multipart` `0.0.22` → `0.0.32` (≥ `0.0.27`, first patched release).

### [Alert #472](https://github.com/arthur-ai/arthur-engine/security/dependabot/472) — black path traversal
`black < 26.3.1` has a high-severity (CVSS 8.7) path-traversal vulnerability — **CVE-2026-32274** / GHSA-3936-cmfr-pm3m — where the `--python-cell-magics` value was placed into the cache filename without sanitization, allowing arbitrary file writes. `black` is a **direct dev** dependency pinned in `genai-engine/pyproject.toml`.

- Bump pin `black==25.12.0` → `black==26.3.1` (first patched release) and re-lock.

## Notes
- Each lock diff is isolated to the target package (plus per-package version-line self-corrections to `2.1.632` matching the `pyproject.toml` versions).
- Other lockfiles were checked: `genai-engine/uv.lock` already had patched `python-multipart` `0.0.27`; `ml-engine` and `arthur-observability-sdk` already had patched `black` (`26.5.1` / `26.3.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)