### PR TITLE
fix(deps): bump form-data to 4.0.6 to patch CVE-2026-12143

### DIFF
--- a/genai-engine/ui/yarn.lock
+++ b/genai-engine/ui/yarn.lock
@@ -4869,15 +4869,15 @@ __metadata:
   linkType: hard
 
 "form-data@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
   languageName: node
   linkType: hard
 
@@ -5185,7 +5185,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hasown@npm:^2.0.2, hasown@npm:^2.0.3":
+"hasown@npm:^2.0.2, hasown@npm:^2.0.3, hasown@npm:^2.0.4":
   version: 2.0.4
   resolution: "hasown@npm:2.0.4"
   dependencies:
@@ -6733,7 +6733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12":
+"mime-types@npm:^2.1.35":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #932](https://github.com/arthur-ai/arthur-engine/security/dependabot/932) — `GHSA-hmw2-7cc7-3qxx` / `CVE-2026-12143` (high severity).

`form-data` < 4.0.6 is vulnerable to **CRLF injection** (CWE-93): field names and filenames passed to `FormData#append` are concatenated into the `Content-Disposition` header without escaping `\r`, `\n`, or `"`, allowing header/field injection when untrusted input is used as a field name or filename.

## Change

Bumps the transitive dependency `form-data` **4.0.5 → 4.0.6** in `genai-engine/ui/yarn.lock` (within the existing `^4.0.5` range). Also reflects 4.0.6's updated dependency ranges (`hasown@^2.0.4`, `mime-types@^2.1.35`), which resolve to already-present versions — no new packages added.

## Verification

- Lockfile regenerated by `yarn install`.
- `yarn install --immutable` passes cleanly (no lockfile drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)