### PR TITLE
add image support for s3

### DIFF
--- a/ml-engine/src/ml_engine/tools/image_tools.py
+++ b/ml-engine/src/ml_engine/tools/image_tools.py
@@ -7,6 +7,7 @@ from arthur_common.models.schema_definitions import (
 
 IMAGE_CONNECTOR_PREFIX_TO_TYPE = {
     "gs://": ConnectorType.GCS,
+    "s3://": ConnectorType.S3,
 }
 IMAGE_CONNECTOR_PREFIX_TUPLE = tuple(IMAGE_CONNECTOR_PREFIX_TO_TYPE.keys())
 

--- a/ml-engine/tests/unit/tools/test_image_tools.py
+++ b/ml-engine/tests/unit/tools/test_image_tools.py
@@ -17,7 +17,11 @@ from tools.image_tools import (
 
 
 def test_is_supported_image_uri() -> None:
+    # assert supported
     assert is_supported_image_uri("gs://bucket/path/image.png")
+    assert is_supported_image_uri("s3://bucket/path/image.png")
+
+    # assert not supported
     assert not is_supported_image_uri("unsupported_uri://bucket/path/image.png")
     assert not is_supported_image_uri("data:image/png;base64,abc")
     assert not is_supported_image_uri("just a string")
@@ -25,13 +29,21 @@ def test_is_supported_image_uri() -> None:
 
 def test_get_connector_type_for_image_uri() -> None:
     assert get_connector_type_for_image_uri("gs://b/i.png") == ConnectorType.GCS
+    assert get_connector_type_for_image_uri("s3://b/i.png") == ConnectorType.S3
     assert get_connector_type_for_image_uri("unsupported_uri://b/i.png") is None
     assert get_connector_type_for_image_uri("not a uri") is None
 
 
 def test_get_bucket_from_uri() -> None:
+    # GCS
     assert get_bucket_from_uri("gs://my-bucket/path/image.png") == "my-bucket"
     assert get_bucket_from_uri("gs://my-bucket") == "my-bucket"
+
+    # S3
+    assert get_bucket_from_uri("s3://my-bucket/path/image.png") == "my-bucket"
+    assert get_bucket_from_uri("s3://my-bucket") == "my-bucket"
+
+    # No scheme
     assert get_bucket_from_uri("no-scheme") is None
     assert get_bucket_from_uri("gs://") is None
 

--- a/ml-engine/uv.lock
+++ b/ml-engine/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-15T17:47:09.31376Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1413,7 +1413,7 @@ wheels = [
 
 [[package]]
 name = "ml-engine"
-version = "2.1.646"
+version = "2.1.648"
 source = { editable = "." }
 dependencies = [
     { name = "adlfs" },


### PR DESCRIPTION
## Description

Adds similar support for s3 images as implemented for gcs in this PR: https://github.com/arthur-ai/arthur-engine/pull/1785/changes

### Example Raw Dataset
<img width="584" height="240" alt="Screenshot 2026-06-18 at 1 59 34 PM" src="https://github.com/user-attachments/assets/fd3525f7-0af2-4a07-bd14-bf22fc004c11" />

 ### Example Dataset on Platform
<img width="843" height="612" alt="Screenshot 2026-06-18 at 2 02 14 PM" src="https://github.com/user-attachments/assets/c787429b-16af-49cc-a164-04d8e856576f" />

## Jira Ticket
- https://arthurai.atlassian.net/browse/UP-4581