### PR TITLE
chore(renovate): enable lockFileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,10 @@
     "**/docker-compose*.yaml"
   ],
   "osvVulnerabilityAlerts": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["* 0-4 * * 1"]
+  },
   "dockerfile": {
     "managerFilePatterns": ["(^|/)[Dd]ockerfile$", "(^|/)Dockerfile_[a-zA-Z]+$"]
   },


### PR DESCRIPTION
## What

Enables Renovate's `lockFileMaintenance` and schedules it weekly (Mondays) inside the existing `00:00–04:00 America/New_York` window:

```json
"lockFileMaintenance": {
  "enabled": true,
  "schedule": ["* 0-4 * * 1"]
}
```

## Why

The `pep621` and `npm` managers only bump **direct** dependencies declared in `pyproject.toml` / `package.json`. Vulnerable **transitive** dependencies pinned in `uv.lock` / `yarn.lock` never receive a fix PR on their own.

Concrete example from the current container scan: `cryptography 48.0.0 → 48.0.1` (GHSA-537c-gmf6-5ccf, HIGH) is a transitive dependency, so neither manager will propose it. `lockFileMaintenance` regenerates the lockfiles on a cadence, pulling patched transitive packages in automatically.

## Behavior notes

- **Weekly cadence** (Monday) to avoid daily full-lockfile churn; runs only in the repo's existing nightly window.
- Applies to all lockfiles in `includePaths` (the `uv.lock` files + `genai-engine/ui/yarn.lock`), so expect one maintenance PR per lockfile when updates are available.
- **Not auto-merged**: the existing `automerge` rule matches `minor`/`patch` only; `lockFileMaintenance` updates fall outside that and will require review/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)