### PR TITLE
chore: upgrade arthur-client to 1.4.2228

### DIFF
--- a/genai-engine/pyproject.toml
+++ b/genai-engine/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
   "google-cloud-aiplatform>=1.38",
   "google-cloud-trace>=1.11.0,<2",
   "opentelemetry-semantic-conventions>=0.60b1,<0.61",
-  "arthur-client==1.4.2191",
+  "arthur-client==1.4.2228",
 ]
 
 [project.scripts]

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-23T14:19:53.248056Z"
+exclude-newer = "2026-06-23T15:08:40.257405Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -140,7 +140,7 @@ wheels = [
 
 [[package]]
 name = "arthur-client"
-version = "1.4.2191"
+version = "1.4.2228"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -152,9 +152,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b8/d4b55fe34508788e4fce47adc7f992d41e38a9284de13316ea0372216abc/arthur_client-1.4.2191.tar.gz", hash = "sha256:d909b9564ef2a3405ea06ad8fd6808bd4c6024eaab87e96855c963bd6c2f78e5", size = 397186, upload-time = "2026-06-09T22:13:22.008Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/77/a9c919e11c8fac67e70b01f4d6ad1d73c21cf0e16aeda24d0596a569e6d0/arthur_client-1.4.2228.tar.gz", hash = "sha256:dcc639d76eb871433761f8853d05a912b3c4e79327776efca2d894277966fcb7", size = 404102, upload-time = "2026-06-26T14:12:51.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/9e/08685f59ec078c7f8ca067d53660c48d53a299d87edff35e0f9d3ad7ab3d/arthur_client-1.4.2191-py3-none-any.whl", hash = "sha256:de287273f9e5c32585c2e44ba20e4c958751b881eeaeb801c2cc54bb834c38e1", size = 1459590, upload-time = "2026-06-09T22:13:20.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6f/7827f5cac061ca679bbd9defb4810e2dab563a3e02c5e82273592319b2a1/arthur_client-1.4.2228-py3-none-any.whl", hash = "sha256:1083524a9cf0bacf767193af16078ae5ed0083f6700137022e89d7830a4cf794", size = 1481882, upload-time = "2026-06-26T14:12:49.985Z" },
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "arthur-genai-engine"
-version = "2.1.664"
+version = "2.1.670"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -277,7 +277,7 @@ performance = [
 requires-dist = [
     { name = "alembic", specifier = "==1.17.2" },
     { name = "amplitude-analytics", specifier = ">=1.1.5,<2" },
-    { name = "arthur-client", specifier = "==1.4.2191" },
+    { name = "arthur-client", specifier = "==1.4.2228" },
     { name = "arthur-common", specifier = "==2.4.67" },
     { name = "authlib", specifier = "==1.6.12" },
     { name = "azure-storage-blob", specifier = "==12.27.1" },

--- a/ml-engine/pyproject.toml
+++ b/ml-engine/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "snowflake-sqlalchemy==1.10.0",
   "databricks-sqlalchemy>=2.0,<3",
   "databricks-sdk>=0.84.0,<1",
-  "arthur-client==1.4.2192",
+  "arthur-client==1.4.2228",
 ]
 
 [dependency-groups]

--- a/ml-engine/src/ml_engine/connectors/shield_connector.py
+++ b/ml-engine/src/ml_engine/connectors/shield_connector.py
@@ -17,7 +17,7 @@ from arthur_client.api_bindings import (
     Dataset,
     DatasetLocator,
     DatasetLocatorField,
-    LLMEval,
+    Eval,
     PutAvailableDataset,
     PutAvailableDatasets,
     TraceTransformResponse,
@@ -479,7 +479,7 @@ class ShieldBaseConnector(Connector, ABC):
         self,
         task_id: str,
         eval_name: str,
-    ) -> LLMEval:
+    ) -> Eval:
         """
         Reads the latest version of a specific LLM evaluation from the Shield API.
 
@@ -488,7 +488,7 @@ class ShieldBaseConnector(Connector, ABC):
             eval_name: Name of the eval to retrieve
 
         Returns:
-            LLMEval object for the latest version
+            Eval object for the latest version
         """
         resp = self._evals_client.get_llm_eval_api_v1_tasks_task_id_llm_evals_eval_name_versions_eval_version_get_with_http_info(
             task_id=task_id,
@@ -496,10 +496,12 @@ class ShieldBaseConnector(Connector, ABC):
             eval_version="latest",
         )
         data = json.loads(resp.raw_data)
-        return LLMEval.model_validate(data)
+        return Eval.model_validate(data)
 
     def list_trace_metadata(
-        self, task_ids: list[str], **kwargs: Any
+        self,
+        task_ids: list[str],
+        **kwargs: Any,
     ) -> TraceListResponse:
         """
         Lists trace metadata
@@ -517,7 +519,9 @@ class ShieldBaseConnector(Connector, ABC):
         return TraceListResponse.model_validate(data)
 
     def query_inferences(
-        self, task_ids: list[str], **kwargs: Any
+        self,
+        task_ids: list[str],
+        **kwargs: Any,
     ) -> QueryInferencesResponse:
         """
         Queries inferences

--- a/ml-engine/src/ml_engine/job_executors/task_management_job_executors.py
+++ b/ml-engine/src/ml_engine/job_executors/task_management_job_executors.py
@@ -11,7 +11,7 @@ from arthur_client.api_bindings import (
     DatasetLocator,
     DatasetLocatorField,
     DatasetsV1Api,
-    LLMEval,
+    Eval,
     Model,
     ModelProblemType,
     ModelsV1Api,
@@ -209,7 +209,7 @@ class TaskManagementJobExecutor:
         self,
         connector: ShieldBaseConnector,
         task_id: str,
-    ) -> list[LLMEval]:
+    ) -> list[Eval]:
         """
         Retrieves LLM evals with their latest versions for a task.
 
@@ -228,9 +228,9 @@ class TaskManagementJobExecutor:
             )
 
             # For each eval, get the latest version
-            llm_evals_with_versions: list[LLMEval] = []
+            llm_evals_with_versions: list[Eval] = []
             self.logger.info(
-                f"Retrieved {len(llm_evals_response.llm_metadata)} LLM eval definitions"
+                f"Retrieved {len(llm_evals_response.llm_metadata)} LLM eval definitions",
             )
 
             for eval_metadata in llm_evals_response.llm_metadata:
@@ -238,7 +238,7 @@ class TaskManagementJobExecutor:
                     self.logger.info(
                         f"Fetching latest version for eval: {eval_metadata.name}",
                     )
-                    latest_version: LLMEval = connector.read_llm_eval_latest_version(
+                    latest_version: Eval = connector.read_llm_eval_latest_version(
                         task_id=task_id,
                         eval_name=eval_metadata.name,
                     )

--- a/ml-engine/uv.lock
+++ b/ml-engine/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = "==3.13.*"
 
 [options]
-exclude-newer = "2026-06-22T22:42:27.678428Z"
+exclude-newer = "2026-06-23T15:08:44.733665Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -141,7 +141,7 @@ wheels = [
 
 [[package]]
 name = "arthur-client"
-version = "1.4.2192"
+version = "1.4.2228"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -153,9 +153,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/f3/692eff90fb78f29d31437bd43e9dc44d51ac4cabb06967f21a0d3beac4ca/arthur_client-1.4.2192.tar.gz", hash = "sha256:5ad64347779888fc5b4b5058f0ba5e2085bbdae27921e300a4bed4de9088d288", size = 401184, upload-time = "2026-06-10T15:19:45.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/77/a9c919e11c8fac67e70b01f4d6ad1d73c21cf0e16aeda24d0596a569e6d0/arthur_client-1.4.2228.tar.gz", hash = "sha256:dcc639d76eb871433761f8853d05a912b3c4e79327776efca2d894277966fcb7", size = 404102, upload-time = "2026-06-26T14:12:51.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/73/423dc7d4d9e96dfd8b538807d69f53a1e32cec41e5c7b9f86267ec98a26c/arthur_client-1.4.2192-py3-none-any.whl", hash = "sha256:999a93cdee8fcce689458f078c311272433349fe616ad69eb9ee897dc474e8f2", size = 1475341, upload-time = "2026-06-10T15:19:43.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6f/7827f5cac061ca679bbd9defb4810e2dab563a3e02c5e82273592319b2a1/arthur_client-1.4.2228-py3-none-any.whl", hash = "sha256:1083524a9cf0bacf767193af16078ae5ed0083f6700137022e89d7830a4cf794", size = 1481882, upload-time = "2026-06-26T14:12:49.985Z" },
 ]
 
 [[package]]
@@ -1413,7 +1413,7 @@ wheels = [
 
 [[package]]
 name = "ml-engine"
-version = "2.1.663"
+version = "2.1.670"
 source = { editable = "." }
 dependencies = [
     { name = "adlfs" },
@@ -1472,7 +1472,7 @@ linters = [
 [package.metadata]
 requires-dist = [
     { name = "adlfs", specifier = "==2025.8.0" },
-    { name = "arthur-client", specifier = "==1.4.2192" },
+    { name = "arthur-client", specifier = "==1.4.2228" },
     { name = "arthur-common", specifier = "==2.4.66" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "databricks-sdk", specifier = ">=0.84.0,<1" },


### PR DESCRIPTION
## Summary
Upgrades `arthur-client` to the latest version `1.4.2228` across both backend components.

- **genai-engine**: `1.4.2191` → `1.4.2228`
- **ml-engine**: `1.4.2192` → `1.4.2228`

Both `uv.lock` files were re-resolved to pick up the new version.

## Test plan
- [ ] CI lint/type-check/unit tests pass for genai-engine and ml-engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)