### PR TITLE
fix(docker): patch base-image OS CVEs (libssl3, libc6, python3.11)

### DIFF
--- a/genai-engine/dockerfile
+++ b/genai-engine/dockerfile
@@ -30,8 +30,11 @@ RUN uv export --frozen \
     --index-strategy unsafe-best-match \
     -r /tmp/requirements.txt
 
-# install lsof for healthchecks
-RUN apt-get update && apt-get install -y lsof && apt-get clean && rm -rf /var/lib/apt/lists/*
+# Upgrade OS packages to pick up Debian security fixes (libssl3, libc6,
+# libexpat1, ...) and install lsof for healthchecks. These libraries live in
+# /usr/lib and are copied into the distroless final image below, so upgrading
+# here patches the shared objects that actually ship.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y lsof && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 
 # GPU Install: Install PyTorch for GPU
@@ -163,6 +166,24 @@ COPY --from=install /etc/ld.so.cache /etc/ld.so.cache
 COPY --from=install --chown=nonroot:nonroot /app/ /home/nonroot/app/
 COPY --from=install --chown=nonroot:nonroot /home/nonroot/models /home/nonroot/models
 COPY --from=install --chown=nonroot:nonroot /home/nonroot/tiktoken /home/nonroot/tiktoken
+
+# Remove the unused Python 3.11 runtime inherited from the distroless base.
+# The app runs on Python 3.12 (from /usr/local); the distroless base ships a
+# separate, never-executed Python 3.11 that image scanners keep flagging
+# (e.g. CVE-2025-8194, CVE-2025-13836). Delete the files and their dpkg
+# metadata so neither the runtime nor the SBOM advertise it. distroless has no
+# `rm`, so copy it from the build stage and delete it again in the same layer.
+USER root
+COPY --from=install /usr/bin/rm /usr/bin/rm
+RUN /usr/bin/rm -rf \
+      /usr/lib/python3.11 \
+      /usr/bin/python3.11 \
+      /usr/lib/*-linux-gnu/libpython3.11.so* \
+      /var/lib/dpkg/status.d/python3.11-minimal \
+      /var/lib/dpkg/status.d/libpython3.11-minimal \
+      /var/lib/dpkg/status.d/libpython3.11-stdlib \
+    && /usr/bin/rm /usr/bin/rm
+USER nonroot
 
 ENV PATH="/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
 ENV PYTHONPATH="/home/nonroot/app/src"

--- a/ml-engine/Dockerfile
+++ b/ml-engine/Dockerfile
@@ -1,8 +1,12 @@
 FROM --platform=linux/amd64 python:3.13-slim-bookworm AS install
 
-# install uv and wget
+# install uv and wget; upgrade OS packages for Debian security fixes
+# (libssl3, libc6, libexpat1, ...). These libraries live in /usr/lib and are
+# copied into the distroless final image below, so upgrading here patches the
+# shared objects that actually ship.
 RUN pip install uv==0.11.7 && \
     apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y wget curl gnupg apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
 
@@ -98,6 +102,25 @@ COPY --from=install /opt/microsoft/msodbcsql18 /opt/microsoft/msodbcsql18
 COPY --from=install /opt/microsoft/msodbcsql17 /opt/microsoft/msodbcsql17
 COPY --from=install /etc/odbcinst.ini /etc/odbcinst.ini
 COPY --from=install --chown=nonroot:nonroot /app/ /home/nonroot/app/
+
+# Remove the unused Python 3.11 runtime inherited from the distroless base.
+# The app runs on Python 3.13 (from /usr/local); the distroless base ships a
+# separate, never-executed Python 3.11 that image scanners keep flagging
+# (e.g. CVE-2025-8194, CVE-2025-13836). Delete the files and their dpkg
+# metadata so neither the runtime nor the SBOM advertise it. distroless has no
+# `rm`, so copy it from the build stage and delete it again in the same layer.
+USER root
+COPY --from=install /usr/bin/rm /usr/bin/rm
+RUN /usr/bin/rm -rf \
+      /usr/lib/python3.11 \
+      /usr/bin/python3.11 \
+      /usr/lib/*-linux-gnu/libpython3.11.so* \
+      /var/lib/dpkg/status.d/python3.11-minimal \
+      /var/lib/dpkg/status.d/libpython3.11-minimal \
+      /var/lib/dpkg/status.d/libpython3.11-stdlib \
+    && /usr/bin/rm /usr/bin/rm
+USER nonroot
+
 ENV PATH="/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
 ENV PYTHONPATH="$PYTHONPATH:/home/nonroot/app/src"
 ENV LD_LIBRARY_PATH="/opt/microsoft/msodbcsql18/lib64:/opt/microsoft/msodbcsql17/lib64:/opt/oracle/instantclient:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
## Summary

Addresses vulnerability-scan findings that originate from the **base images**, not application code. Both `genai-engine` and `ml-engine` build on `*-slim-bookworm` and ship via `gcr.io/distroless/python3-debian12:nonroot`, copying `/usr/lib` from the build stage into the distroless final image.

Changes (Dockerfile-only — no API or dependency changes):
- **`apt-get upgrade -y`** added to both build stages so the `libssl3` / `libc6` / `libexpat1` shared objects copied into the final image carry the latest Debian security fixes.
- **Removed the unused Python 3.11 runtime** inherited from the distroless base (files + dpkg metadata). The apps run on Python 3.12 / 3.13 from `/usr/local`; the distroless 3.11 is never executed but is repeatedly flagged. `distroless` has no `rm`, so it is copied from the build stage and deleted again in the same layer, and the stage drops back to `USER nonroot`.

## Verification

Empirically validated on an amd64 repro of the final stage:
- `python3.11` files **and** dpkg `status.d` entries removed; the copied `rm` self-deletes.
- Python **3.12 still runs** (`3.12.13`); `python3` resolves to 3.12 (not the removed 3.11).
- SSL reports the patched **OpenSSL 3.0.20** (vs. distroless base's 3.0.19).
- Both Dockerfiles pass `docker build --check` (only pre-existing, unrelated warnings).

## CVE status (after rebuild + rescan)

| CVE(s) | Package | Status |
|---|---|---|
| CVE-2026-40217 | litellm | ✅ Already fixed in both engines (≥1.83.10); original scan hit was a false positive |
| 6× incl. CRITICAL CVE-2026-34182 | libssl3 | ✅ Patched binary (OpenSSL 3.0.20) |
| 5× (CVE-2026-4437, -4046, -0915, -0861, -15281) | libc6 | ✅ Patched binary (glibc u14) |
| CVE-2025-8194, CVE-2025-13836 | python3.11 | ✅ Fully removed (files + metadata) |
| CVE-2026-45186 | libexpat1 | ⚠️ No Debian bookworm fix exists yet; `apt-get upgrade` picks it up when released |

### Notes
- **libssl3 / libc6**: the *shipped binaries* are patched, but their dpkg metadata is inherited from the (currently stale) distroless base, so a metadata-based scanner may still report old versions as false positives until `distroless/python3-debian12:nonroot` is refreshed upstream. Metadata was intentionally **not** deleted (the libraries are genuinely present and patched — deleting it would make the SBOM falsely claim they're absent).
- **Not included:** an `ml-engine` `arthur-common` 2.4.66→2.4.67 bump — `2.4.67` requires `pandas>=3.0.3`, conflicting with the pinned `pandas==2.3.3`. Since ml-engine's litellm is already past the fix, the bump was cosmetic and was dropped to avoid a pandas 2→3 migration.
- `deployment/model-upload/Dockerfile` shares the same distroless base and carries the same latent python3.11 finding (out of scope for this scan); can apply the identical fix in a follow-up if desired.

These take effect on the next image build — rebuild and rescan to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)