### PR TITLE
fix(ci): install latest Trivy via setup-trivy action

### DIFF
--- a/.github/workflows/composite-actions/vuln-report/action.yml
+++ b/.github/workflows/composite-actions/vuln-report/action.yml
@@ -17,10 +17,6 @@ inputs:
     description: "Platform to scan for multi-arch images"
     required: false
     default: "linux/amd64"
-  trivy-version:
-    description: "Trivy CLI version to install"
-    required: false
-    default: "0.58.1"
 
 runs:
   using: composite
@@ -50,16 +46,13 @@ runs:
         image: ${{ inputs.image }}
         platform: ${{ inputs.platform }}
 
-    # --- Install Trivy CLI (deterministic; no action-tag guessing) ---
+    # --- Install Trivy CLI (official action; always latest) ---
+    # Unpinned: GitHub only retains release assets for recent versions, so pinned tags eventually 404.
     - name: Install Trivy
-      shell: bash
-      run: |
-        set -euo pipefail
-        VER="${{ inputs.trivy-version }}"
-        curl -sfL "https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh" \
-          | sh -s -- -b "${RUNNER_TEMP}/bin" "v${VER}"
-        echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
-        "${RUNNER_TEMP}/bin/trivy" --version
+      uses: aquasecurity/setup-trivy@v0.3.1
+      with:
+        version: latest
+        token: ${{ github.token }}
 
     # --- Trivy: single scan -> JSON, then convert to SARIF (advisory) ---
     - name: Trivy scan (advisory)


### PR DESCRIPTION
## Problem

The scheduled `image-vuln-scan` job ([failing run](https://github.com/arthur-ai/arthur-engine/actions/runs/28255693091/job/83718065331)) fails at **Install Trivy** with `exit code 1`.

Root cause: the `vuln-report` composite action pinned Trivy **0.58.1** and installed it via `curl | sh`. GitHub only retains release assets for the most recent Trivy versions, so 0.58.1's tarball/checksum now **404**. The install resolves the version (`found version: 0.58.1`) then dies on the download.

Verified directly against the release-download host:

| Version | tarball | checksum |
|---|---|---|
| `v0.58.1` (was pinned) | **404** | **404** |
| `v0.70.0`+ / `v0.71.2` | 200 | 200 |

(Everything ≤ `v0.68.0` is pruned; not a rate-limit — clean deterministic 404.)

> The Docker Scout `recommendations` panic in the same log is a separate, harmless issue — that step is `continue-on-error: true` and does not fail the job.

## Fix

- Replace the manual `curl | sh` install with the official **`aquasecurity/setup-trivy`** action.
- Always install **`latest`** (unpinned) — avoids the asset-pruning 404 entirely and gives the newest CVE DB for this advisory scan.
- Drop the now-unused `trivy-version` input (no caller overrode it).

Flag compatibility confirmed against current Trivy: `--vex <file>`, `--show-suppressed`, `--scanners`, `convert`, `--format cyclonedx` all still supported.

This composite action is also used by `arthur-engine-workflow.yml` (build/release image scans); all call sites inherit the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)