### PR TITLE
fix(ci): pull scan image once with authenticated Docker Hub creds

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -443,6 +443,8 @@ jobs:
         with:
           image: arthurplatform/genai-engine-${{ matrix.torch_device }}:${{ env.VERSION }}
           slug: genai-${{ matrix.torch_device }}
+          dockerhub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   build-ml-engine-docker-images:
     environment: shared-protected-branch-secrets
@@ -494,6 +496,8 @@ jobs:
         with:
           image: arthurplatform/ml-engine:${{ env.VERSION }}
           slug: ml-engine
+          dockerhub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Login to Artifactory
         run: |
           docker logout

--- a/.github/workflows/composite-actions/vuln-report/action.yml
+++ b/.github/workflows/composite-actions/vuln-report/action.yml
@@ -2,9 +2,10 @@ name: "Vulnerability scan & justification report"
 description: >
   Advisory container vulnerability scan (Docker Scout + Trivy) for a single image. Uploads SARIF
   to the GitHub Security tab and generates an SBOM + a VEX-applied HIGH/CRITICAL justification
-  report, uploaded as a workflow artifact. Never fails the build (advisory). Requires the caller
-  to have already `docker login`'d and to have checked out the repo (for security/vex + renderer).
-  The caller job needs `permissions: { security-events: write }`.
+  report, uploaded as a workflow artifact. Never fails the build (advisory). Pass
+  dockerhub-username/dockerhub-token for authenticated pulls (otherwise the caller must already be
+  `docker login`'d). The caller must also have checked out the repo (for security/vex + renderer)
+  and the job needs `permissions: { security-events: write }`.
 
 inputs:
   image:
@@ -17,10 +18,36 @@ inputs:
     description: "Platform to scan for multi-arch images"
     required: false
     default: "linux/amd64"
+  dockerhub-username:
+    description: "Docker Hub username for authenticated image pulls (raises the pull rate limit)"
+    required: false
+    default: ""
+  dockerhub-token:
+    description: "Docker Hub access token (or password) for authenticated image pulls"
+    required: false
+    default: ""
 
 runs:
   using: composite
   steps:
+    # --- Pull the image ONCE (authenticated) so Docker Scout and Trivy both scan the local
+    #     copy instead of each pulling it from the registry. Halves registry pulls per job and,
+    #     with the Docker Hub credentials, uses the authenticated (higher) rate limit — avoids the
+    #     TOOMANYREQUESTS errors that surface as "unable to find the specified image". ---
+    - name: Authenticate to Docker Hub & pull image
+      shell: bash
+      env:
+        DOCKERHUB_USERNAME: ${{ inputs.dockerhub-username }}
+        DOCKERHUB_TOKEN: ${{ inputs.dockerhub-token }}
+        IMAGE: ${{ inputs.image }}
+        PLATFORM: ${{ inputs.platform }}
+      run: |
+        set -euo pipefail
+        if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+          echo "${DOCKERHUB_TOKEN}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
+        fi
+        docker pull --platform "${PLATFORM}" "${IMAGE}"
+
     # --- Docker Scout: CVEs -> SARIF (advisory) ---
     - name: Docker Scout CVE scan (advisory)
       uses: docker/scout-action@v1

--- a/.github/workflows/image-vuln-scan.yml
+++ b/.github/workflows/image-vuln-scan.yml
@@ -55,13 +55,10 @@ jobs:
           TAG="${OVERRIDE:-${{ env.VERSION }}}"
           echo "Scanning tag: ${TAG}"
           echo "value=${TAG}" >> "$GITHUB_OUTPUT"
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3.6.0
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Scan image & generate justification docs
         uses: ./.github/workflows/composite-actions/vuln-report
         with:
           image: ${{ matrix.image }}:${{ steps.tag.outputs.value }}
           slug: ${{ matrix.slug }}
+          dockerhub-username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}


### PR DESCRIPTION
## Problem

The `image-vuln-scan` job ([failing run](https://github.com/arthur-ai/arthur-engine/actions/runs/28257715220/job/83724926970)) fails with `unable to find the specified image "***/genai-engine-cpu:2.1.673-dev"`. That message is misleading — the image exists. The real error is the `remote` sub-error:

```
TOOMANYREQUESTS: You have reached your pull rate limit as '***'
```

Trivy tries four image sources (local docker daemon → containerd → podman → remote registry); the image was never pulled into the local daemon, the others are unavailable, and the **remote pull is rate-limited by Docker Hub**. After all four fail, Trivy prints the generic "unable to find" message.

**Why the limit gets hit:** the composite action never pulled the image locally, so **Docker Scout and Trivy each pulled it from the registry** — two pulls per job across a **6-image matrix**, which trips Docker Hub's rate limit.

## Fix

- **Pull the image once, authenticated, at the start of the composite action.** Both Docker Scout and Trivy then scan the **local** copy — no duplicate remote pulls (registry pulls per job halved).
- **Authenticate with the Docker Hub secrets** (`DOCKER_HUB_USERNAME` / `DOCKER_HUB_ACCESS_TOKEN`), threaded through as new `dockerhub-username` / `dockerhub-token` inputs from all three call sites, so the pull uses the higher authenticated rate limit.
- Drop the now-redundant standalone `docker login` step in `image-vuln-scan.yml` (the composite logs in before Scout runs). The two `arthur-engine-workflow.yml` call sites keep their existing login (needed for build+push) and just pass the secrets through.

Credential inputs are optional (default `""`); if omitted the composite falls back to the caller's existing `docker login`, preserving backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)