### PR TITLE
fix(docker): patch base-image OS CVEs in model-upload images

### DIFF
--- a/deployment/model-upload/Dockerfile
+++ b/deployment/model-upload/Dockerfile
@@ -7,13 +7,18 @@
 #   docker build --build-arg BACKEND=s3  --target runtime-s3  -t <image> .
 #   docker build --build-arg BACKEND=gcs --target runtime-gcs -t <image> .
 #   docker build --build-arg BACKEND=fs  --target runtime-fs  -t <image> .
+#
+# Runtime is Python 3.12 (per requires-python) on Debian bookworm. The distroless
+# runtimes (s3, fs) copy the apt-upgraded Python 3.12 runtime + patched system
+# libraries from the builder stage over the distroless base (whose own python3 is
+# the unused, vulnerable 3.11, which is removed). Images are linux/amd64 only.
 
 ARG BACKEND=s3
 
 # =============================================================================
 # Stage 1: Download models (shared across all backends)
 # =============================================================================
-FROM python:3.14-slim AS downloader
+FROM python:3.12-slim-bookworm AS downloader
 ARG BACKEND
 
 WORKDIR /app
@@ -28,13 +33,21 @@ COPY download_models.py .
 RUN python download_models.py --output-dir /models --workers 4
 
 # =============================================================================
-# Stage 2: Install backend-specific runtime deps
+# Stage 2: Install backend-specific runtime deps + apply Debian security fixes
 #   - s3:  boto3
 #   - gcs: google-cloud-storage
-#   - pvc: nothing (stdlib only)
+#   - fs:  nothing (stdlib only)
+#
+# `apt-get upgrade` patches base-image OS CVEs (libssl3, libc6, ...). The upgraded
+# shared objects in /usr/lib and the Python 3.12 runtime in /usr/local are copied
+# into the distroless runtime images below, so the binaries that actually ship
+# contain the fixes (the distroless base's dpkg metadata, which scanners read,
+# stays stale — see security/vex/openvex.json).
 # =============================================================================
-FROM python:3.14-slim AS builder
+FROM python:3.12-slim-bookworm AS builder
 ARG BACKEND
+
+RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 RUN pip install --no-cache-dir uv==0.11.7
@@ -52,17 +65,40 @@ RUN if [ "$BACKEND" != "fs" ]; then \
 # =============================================================================
 FROM gcr.io/distroless/python3-debian12:nonroot AS runtime-s3
 
+# Bring the apt-upgraded Python 3.12 runtime and patched system libraries from the
+# builder over the distroless base (whose own python3 is the unused, vulnerable 3.11).
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /usr/local/lib/ /usr/local/lib/
+COPY --from=builder /usr/lib /usr/lib
+COPY --from=builder /etc/ld.so.cache /etc/ld.so.cache
+
+# Remove the unused Python 3.11 runtime inherited from the distroless base so it
+# neither ships nor trips scanners (CVE-2025-8194, CVE-2025-13836). The job runs on
+# Python 3.12 from /usr/local. distroless has no shell, so use exec-form rm with
+# explicit amd64 paths (these images are linux/amd64 only); rm deletes itself last.
+USER root
+COPY --from=builder /usr/bin/rm /usr/bin/rm
+RUN ["/usr/bin/rm", "-rf", \
+     "/usr/lib/python3.11", \
+     "/usr/bin/python3.11", \
+     "/usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0", \
+     "/var/lib/dpkg/status.d/python3.11-minimal", \
+     "/var/lib/dpkg/status.d/libpython3.11-minimal", \
+     "/var/lib/dpkg/status.d/libpython3.11-stdlib", \
+     "/usr/bin/rm"]
+USER nonroot
+
 WORKDIR /app
 COPY --from=builder /app/site-packages /app/site-packages
 COPY --from=downloader /models /models
 COPY --chown=nonroot:nonroot upload_models.py /app/
 
 ENV BACKEND=s3 \
+    PATH="/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin" \
     PYTHONPATH=/app/site-packages \
     MODELS_DIR=/models \
     LOG_LEVEL=INFO
 
-USER nonroot
 ENTRYPOINT ["python", "/app/upload_models.py"]
 
 # =============================================================================
@@ -72,23 +108,46 @@ ENTRYPOINT ["python", "/app/upload_models.py"]
 # =============================================================================
 FROM gcr.io/distroless/python3-debian12:nonroot AS runtime-fs
 
+# Bring the apt-upgraded Python 3.12 runtime and patched system libraries from the
+# builder over the distroless base (whose own python3 is the unused, vulnerable 3.11).
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /usr/local/lib/ /usr/local/lib/
+COPY --from=builder /usr/lib /usr/lib
+COPY --from=builder /etc/ld.so.cache /etc/ld.so.cache
+
+# Remove the unused Python 3.11 runtime inherited from the distroless base (see s3 stage).
+USER root
+COPY --from=builder /usr/bin/rm /usr/bin/rm
+RUN ["/usr/bin/rm", "-rf", \
+     "/usr/lib/python3.11", \
+     "/usr/bin/python3.11", \
+     "/usr/lib/x86_64-linux-gnu/libpython3.11.so.1.0", \
+     "/var/lib/dpkg/status.d/python3.11-minimal", \
+     "/var/lib/dpkg/status.d/libpython3.11-minimal", \
+     "/var/lib/dpkg/status.d/libpython3.11-stdlib", \
+     "/usr/bin/rm"]
+USER nonroot
+
 WORKDIR /app
 COPY --from=downloader /models /models
 COPY --chown=nonroot:nonroot upload_models.py /app/
 
 ENV BACKEND=fs \
+    PATH="/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin" \
     MODELS_DIR=/models \
     TARGET_DIR=/models-output \
     LOG_LEVEL=INFO
 
-USER nonroot
 ENTRYPOINT ["python", "/app/upload_models.py"]
 
 # =============================================================================
 # Runtime: GCP / GCS  (slim — google-auth requires libffi)
+# apt-get upgrade patches base OS CVEs here directly (the slim image's dpkg
+# metadata is updated too, so scanners see the fixed versions).
 # =============================================================================
-FROM python:3.14-slim AS runtime-gcs
+FROM python:3.12-slim-bookworm AS runtime-gcs
 
+RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN useradd --uid 65532 --no-create-home nonroot
 
 WORKDIR /app


### PR DESCRIPTION
## What

Hardens the `genai-engine-models-*` (model-upload) images so container scans no longer report **fixable** HIGH/CRITICAL base-OS CVEs (`libssl3`, `libc6`, the inherited Python 3.11). Brings them to parity with `genai-engine`/`ml-engine` (PR #1851).

## Changes (`deployment/model-upload/Dockerfile`)

- Pin all stages to **`python:3.12-slim-bookworm`** (was `3.14-slim`, which also violated `requires-python = ">=3.12,<3.13"`).
- `apt-get upgrade -y` in the `builder` stage. The distroless **`runtime-s3`/`runtime-fs`** now copy the apt-upgraded `/usr/lib` (patched `libssl3`/`libc6`) **and** the Python 3.12 runtime from `/usr/local` over the distroless base, and **delete the unused Python 3.11** (files + dpkg metadata).
- **`runtime-gcs`** (slim) runs `apt-get upgrade` directly, so its dpkg metadata reflects the fixed versions too.

Before this, `runtime-s3`/`runtime-fs` actually executed the distroless base's **Python 3.11** (no interpreter was copied from the 3.14 builder) and never patched the OS libs.

## Why split from the VEX PR

The VEX justifications for the models images in **#1852** assume this hardening (libssl3/libc6 shipped binary patched; Python 3.11 removed). **Merge this PR together with / before #1852** so those statements are accurate.

## Testing notes

- Images are **linux/amd64 only**, so the Python 3.11 removal uses an exec-form `rm` with explicit amd64 paths (no shell in distroless).
- Build targets/args (`runtime-s3`/`-fs`/`-gcs`, `BACKEND=...`) are unchanged — the build workflows need no edits.
- ⚠️ Not build-tested locally (large bases + private token). Please confirm via the model-upload build workflows; the key thing to verify is that `python` resolves to the copied 3.12 in the distroless runtimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)