### PR TITLE
fix(docker): build UI stage on native platform to avoid QEMU SIGILL

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -407,9 +407,9 @@ jobs:
           version-prefix: "genai-engine-"
       - name: Set up QEMU
         if: matrix.torch_device == 'cpu'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
+        uses: docker/setup-buildx-action@v4.1.0
       - name: Log in to Docker Hub
         uses: docker/login-action@v3.6.0
         with:

--- a/.github/workflows/build-ecs-model-upload.yml
+++ b/.github/workflows/build-ecs-model-upload.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install dependencies
         run: pip install huggingface_hub
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
+        uses: docker/setup-buildx-action@v4.1.0
       - name: Log in to Docker Hub
         if: inputs.push
         uses: docker/login-action@v3.6.0

--- a/.github/workflows/build-fs-model-upload.yml
+++ b/.github/workflows/build-fs-model-upload.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install dependencies
         run: pip install huggingface_hub
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
+        uses: docker/setup-buildx-action@v4.1.0
       - name: Log in to Docker Hub
         if: inputs.push
         uses: docker/login-action@v3.6.0

--- a/.github/workflows/build-gcp-model-upload.yml
+++ b/.github/workflows/build-gcp-model-upload.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install dependencies
         run: pip install huggingface_hub
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
+        uses: docker/setup-buildx-action@v4.1.0
       - name: Log in to Docker Hub
         if: inputs.push
         uses: docker/login-action@v3.6.0

--- a/genai-engine/dockerfile
+++ b/genai-engine/dockerfile
@@ -47,7 +47,10 @@ RUN uv pip install --system --no-cache --reinstall -r /tmp/requirements-torch.tx
 FROM preinstall AS cpu-install
 
 # UI Build Stage: Build the React SPA
-FROM node:20-alpine AS ui-build
+# Pinned to the build platform: `yarn build` emits architecture-independent
+# static assets (copied into both arch images below), so it must NOT run under
+# QEMU. Emulated arm64 Node crashes `yarn install` with SIGILL (exit 132).
+FROM --platform=$BUILDPLATFORM node:20-alpine AS ui-build
 
 # Accept Meticulous tokens as build arguments
 ARG METICULOUS_RECORDING_TOKEN


### PR DESCRIPTION
## Problem

The cpu Docker image build has been failing intermittently (e.g. [run 28267045251](https://github.com/arthur-ai/arthur-engine/actions/runs/28267045251/job/83775236972)) at the **Build and push docker image** step:

```
ERROR: failed to solve: process "/bin/sh -c ... yarn install --immutable ..."
did not complete successfully: exit code: 132
```

Exit **132 = 128 + 4 = SIGILL** (illegal instruction). The QEMU/Buildx *setup* steps succeed — the failure is inside the build.

### Root cause

- The cpu matrix builds `linux/amd64,linux/arm64` on an amd64 `ubuntu-latest` runner (`arthur-engine-workflow.yml:438`), so the **arm64 leg runs under QEMU emulation**.
- The `ui-build` stage (`FROM node:20-alpine`) had no `--platform` pin, so `yarn install` ran **arm64 Node under QEMU**, which crashes with SIGILL — the textbook Node-under-QEMU failure.

## Fix

Pin the `ui-build` stage to the native build platform:

```dockerfile
FROM --platform=$BUILDPLATFORM node:20-alpine AS ui-build
```

`yarn build` emits **architecture-independent** static assets that are copied into both arch images via `COPY --from=ui-build`, so building once natively (amd64) is correct for both arches — and faster. This removes Node-under-emulation entirely, which is exactly where the crash was. QEMU is still used for the arm64 Python/runtime stages (`pip install`, `apt`), which produce arch-specific output and were not failing.

### Also

Bumped the Docker setup actions to latest stable (clears the Node 20 runtime deprecation warnings; not the cause of the crash):
- `docker/setup-buildx-action` `v3.11.1` → `v4.1.0` (×4 workflows)
- `docker/setup-qemu-action` `v3` → `v4.1.0`

All affected workflows run on `ubuntu-latest`, which satisfies v4's Actions Runner ≥ v2.327.1 / Node 24 requirement.

## Alternative considered

Building arm64 on a native `ubuntu-24.04-arm` runner would drop QEMU entirely (and speed up the heavy torch install), but requires a two-runner + manifest-merge workflow. The `$BUILDPLATFORM` pin is the minimal fix for the immediate breakage; the native-runner split can follow if remaining emulation cost/flakiness warrants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)