### PR TITLE
UP-4632 revert postgres upgrade to pg16 and prevent renovate from upgrading further

### DIFF
--- a/deployment/docker-compose/arthur-engine/docker-compose.yml
+++ b/deployment/docker-compose/arthur-engine/docker-compose.yml
@@ -1,7 +1,7 @@
 name: arthur-engine
 services:
   db:
-    image: postgres:18
+    image: postgres:16
     shm_size: 128mb
     ports:
       - "5435:5432"

--- a/deployment/docker-compose/genai-engine/docker-compose.yml
+++ b/deployment/docker-compose/genai-engine/docker-compose.yml
@@ -1,7 +1,7 @@
 name: arthur-genai-engine
 services:
   db:
-    image: postgres:18
+    image: postgres:16
     shm_size: 128mb
     environment:
       - POSTGRES_PASSWORD=changeme_pg_password

--- a/genai-engine/docker-compose.yml
+++ b/genai-engine/docker-compose.yml
@@ -1,7 +1,7 @@
 name: genai-engine-dev
 services:
   db:
-    image: postgres:18
+    image: postgres:16
     ports:
       - "${GENAI_DB_PORT:-5432}:5432"
     environment:

--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,11 @@
       "enabled": false
     },
     {
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchPackageNames": ["postgres"],
+      "allowedVersions": "<17"
+    },
+    {
       "matchManagers": ["npm"],
       "reviewers": ["TheLukaszNs-Blazity", "xV3rt", "martin-arthur-ai"],
       "reviewersSampleSize": 1


### PR DESCRIPTION
Renovate bot updated Postgres to 18, which breaks the data volume mounts for previously running engines. Reverting to pg16 and limiting renovate bot to prevent it from upgrading further

https://github.com/arthur-ai/arthur-engine/commit/79706ade865a4cce0f6bc660ac37d3bd71475784