### PR TITLE
Fix race in model-upload "Commit updated manifest" step

### DIFF
--- a/.github/workflows/build-ecs-model-upload.yml
+++ b/.github/workflows/build-ecs-model-upload.yml
@@ -93,7 +93,26 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add deployment/model-upload/models-manifest.json
           export GH_TOKEN=${{ steps.generate-token.outputs.token }}
-          git diff --staged --quiet || git commit --no-verify -m "Update models manifest [skip ci]"
-          git push origin ${{ github.ref_name }}
+          git add deployment/model-upload/models-manifest.json
+          # Nothing to do if another job already committed the same update.
+          if git diff --staged --quiet; then
+            echo "No manifest changes to commit."
+            exit 0
+          fi
+          # Commit BEFORE pulling so the working tree is clean and `pull --rebase` won't abort
+          # with "cannot pull with rebase: You have unstaged changes".
+          git commit --no-verify -m "Update models manifest [skip ci]"
+          # dev is a shared branch; rebase our commit onto any concurrent pushes, then push.
+          # Retry because the branch can advance again between the pull and the push.
+          for attempt in 1 2 3 4 5; do
+            if git pull --rebase origin "${{ github.ref_name }}" \
+               && git push origin "${{ github.ref_name }}"; then
+              echo "Manifest pushed (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Push attempt ${attempt} failed (branch advanced?); retrying in 5s..."
+            sleep 5
+          done
+          echo "Failed to push manifest after retries." >&2
+          exit 1

--- a/.github/workflows/build-fs-model-upload.yml
+++ b/.github/workflows/build-fs-model-upload.yml
@@ -93,12 +93,26 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          # Pull latest changes in case ECS job already committed
           export GH_TOKEN=${{ steps.generate-token.outputs.token }}
-          git pull --rebase origin ${{ github.ref_name }} || true
           git add deployment/model-upload/models-manifest.json
-          # Commit only if there are changes (handles case where another job already committed)
-          if ! git diff --staged --quiet; then
-            git commit --no-verify -m "Update models manifest [skip ci]"
-            git push origin ${{ github.ref_name }}
+          # Nothing to do if another job already committed the same update.
+          if git diff --staged --quiet; then
+            echo "No manifest changes to commit."
+            exit 0
           fi
+          # Commit BEFORE pulling so the working tree is clean and `pull --rebase` won't abort
+          # with "cannot pull with rebase: You have unstaged changes".
+          git commit --no-verify -m "Update models manifest [skip ci]"
+          # dev is a shared branch; rebase our commit onto any concurrent pushes, then push.
+          # Retry because the branch can advance again between the pull and the push.
+          for attempt in 1 2 3 4 5; do
+            if git pull --rebase origin "${{ github.ref_name }}" \
+               && git push origin "${{ github.ref_name }}"; then
+              echo "Manifest pushed (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Push attempt ${attempt} failed (branch advanced?); retrying in 5s..."
+            sleep 5
+          done
+          echo "Failed to push manifest after retries." >&2
+          exit 1

--- a/.github/workflows/build-gcp-model-upload.yml
+++ b/.github/workflows/build-gcp-model-upload.yml
@@ -93,12 +93,26 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          # Pull latest changes in case ECS or K8s job already committed
           export GH_TOKEN=${{ steps.generate-token.outputs.token }}
-          git pull --rebase origin ${{ github.ref_name }} || true
           git add deployment/model-upload/models-manifest.json
-          # Commit only if there are changes (handles case where another job already committed)
-          if ! git diff --staged --quiet; then
-            git commit --no-verify -m "Update models manifest [skip ci]"
-            git push origin ${{ github.ref_name }}
+          # Nothing to do if another job already committed the same update.
+          if git diff --staged --quiet; then
+            echo "No manifest changes to commit."
+            exit 0
           fi
+          # Commit BEFORE pulling so the working tree is clean and `pull --rebase` won't abort
+          # with "cannot pull with rebase: You have unstaged changes".
+          git commit --no-verify -m "Update models manifest [skip ci]"
+          # dev is a shared branch; rebase our commit onto any concurrent pushes, then push.
+          # Retry because the branch can advance again between the pull and the push.
+          for attempt in 1 2 3 4 5; do
+            if git pull --rebase origin "${{ github.ref_name }}" \
+               && git push origin "${{ github.ref_name }}"; then
+              echo "Manifest pushed (attempt ${attempt})."
+              exit 0
+            fi
+            echo "Push attempt ${attempt} failed (branch advanced?); retrying in 5s..."
+            sleep 5
+          done
+          echo "Failed to push manifest after retries." >&2
+          exit 1


### PR DESCRIPTION
## Problem
The `Commit updated manifest` step in the model-upload builds pushes the `models-manifest.json` update to a **shared branch (`dev`)**, but wasn't resilient to concurrent pushes. It failed in [run 29031121187](https://github.com/arthur-ai/arthur-engine/actions/runs/29031121187/job/86163927915) (`build-gcp-model-upload`):

```
error: cannot pull with rebase: You have unstaged changes.
 ! [rejected]          dev -> dev (fetch first)
error: failed to push some refs to 'https://github.com/arthur-ai/arthur-engine'
```

### Root cause
The three workflows had diverged and none was actually race-safe:

- **s3 (`build-ecs`)** — no sync at all; `git push` fails on non-fast-forward whenever `dev` moved during the build.
- **fs / gcs** — ran `git pull --rebase origin dev || true` **before** `git add`, i.e. while `models-manifest.json` was already modified-unstaged by the preceding `check_model_updates.py --update`. `git pull --rebase` refuses to run with unstaged changes, so it aborted; `|| true` swallowed the error; local stayed behind remote; and the subsequent `git push` was rejected as non-fast-forward.

## Fix
Applied **identically to all three** (`build-ecs`, `build-fs`, `build-gcp`):

1. **Stage + commit first** so the working tree is clean — then `git pull --rebase` actually works instead of aborting on unstaged changes.
2. **`pull --rebase` + `push` in a retry loop** (5 attempts, 5s apart) to absorb the branch advancing again between our pull and push.
3. **Skip cleanly** (`exit 0`) when there's nothing to commit (another job already pushed the same update).
4. **Fail loudly** (`exit 1`) if all retries are exhausted, instead of masking the failure with `|| true`.

## Notes
- Independent of the SBOM work (#1897 / #1898); this only touches the `Commit updated manifest` step, not the image builds.
- Someone appears to have been mid-migration on this step (s3 still had the old logic, fs/gcs the half-fixed logic) — this unifies all three.
- Immediate unblock for the failed run: the gcs **image was built and pushed fine**; only the manifest bookkeeping commit failed, so re-running that job is safe.

## Test plan
- [ ] Release build with model updates → each model job commits & pushes the manifest without non-fast-forward errors.
- [ ] Concurrent/racing pushes to `dev` during a build → retry loop rebases and succeeds (or fails loudly after 5 attempts).
- [ ] No manifest change → step logs "No manifest changes to commit." and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)