### PR TITLE
Publish per-release CycloneDX SBOMs to the arthur-cft S3 bucket

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -718,6 +718,106 @@ jobs:
           aws s3 sync ./deployment/cloudformation/ s3://${{ env.BUCKET_NAME }}/${{ env.TEMPLATES_DIRECTORY }}/templates/${{ env.VERSION }} --acl public-read
           aws s3 sync ./deployment/cloudformation/ s3://${{ env.BUCKET_NAME }}/${{ env.TEMPLATES_DIRECTORY }}/templates/latest --acl public-read
 
+  # Publish a CycloneDX SBOM per published image to the public arthur-cft bucket, giving stable
+  # download URLs (versioned + `latest`). Modeled on push-all-cfts (same OIDC role + s3 sync).
+  # SBOMs are generated fresh here with Trivy so coverage is uniform across all six images
+  # regardless of whether a model image was freshly built or retagged (the retag path builds
+  # nothing, so there is no artifact to reuse), and independent of the build jobs' internals.
+  push-all-sboms:
+    needs:
+      - build-genai-engine-docker-images
+      - build-ml-engine-docker-images
+      - build-genai-engine-models-docker-image
+      - tag-genai-engine-models-docker-image
+      - build-genai-engine-models-fs-docker-image
+      - tag-genai-engine-models-fs-docker-image
+      - build-gcp-model-upload-docker-image
+    environment: shared-protected-branch-secrets
+    # `needs` on a skipped model build/tag job still enforces ordering (a skipped job counts as
+    # complete), so whichever of each build/tag pair ran will have published the <VERSION> tag.
+    # `!cancelled()` lets this run when the unused half of each pair is skipped; we only require
+    # the two engine builds to have succeeded.
+    if: |
+      !cancelled() &&
+      needs.build-genai-engine-docker-images.result == 'success' &&
+      needs.build-ml-engine-docker-images.result == 'success' &&
+      contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION: us-east-2
+      BUCKET_NAME: arthur-cft
+    steps:
+      - uses: mathio/gha-cleanup@v1
+        with:
+          remove-browsers: true
+          verbose: true
+      - uses: actions/checkout@v5
+      - uses: ./.github/workflows/composite-actions/setup-git
+      - uses: ./.github/workflows/composite-actions/set-version
+      # Enterprise creds = higher pull-rate limit (same account vuln-report uses for pulls).
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_ENTERPRISE_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ENTERPRISE_TOKEN }}
+      # Unpinned latest: GitHub only retains recent release assets, so pinned tags eventually 404
+      # (matches composite-actions/vuln-report).
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.3.1
+        with:
+          version: latest
+          token: ${{ github.token }}
+      - name: Generate CycloneDX SBOMs
+        run: |
+          set -uo pipefail
+          mkdir -p sbom-out
+          # image repo (under arthurplatform/) -> output filename stem
+          IMAGES="
+          genai-engine-cpu
+          genai-engine-gpu
+          ml-engine
+          genai-engine-models-s3
+          genai-engine-models-fs
+          genai-engine-models-gcs
+          "
+          for repo in $IMAGES; do
+            ref="arthurplatform/${repo}:${VERSION}"
+            echo "::group::SBOM for ${ref}"
+            # Advisory: a single missing/failed image must not block publishing the rest.
+            if trivy image --format cyclonedx --output "sbom-out/sbom-${repo}.cdx.json" "${ref}"; then
+              echo "Generated sbom-${repo}.cdx.json"
+            else
+              echo "::warning::Failed to generate SBOM for ${ref}; skipping"
+              rm -f "sbom-out/sbom-${repo}.cdx.json"
+            fi
+            # Clear trivy's image analysis cache between images to bound peak disk (model images
+            # bundle large HF weights). Keeps the vuln/java DBs so they don't re-download.
+            trivy clean --scan-cache >/dev/null 2>&1 || true
+            echo "::endgroup::"
+          done
+          echo "SBOMs produced:"
+          ls -la sbom-out
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@5ebd15afc69e5abcd499614d3ced5d65dc34087f
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_ROLE_ARN }}
+          role-session-name: ${{ secrets.AWS_S3_ROLE_SESSION_NAME }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Publish SBOMs to S3
+        run: |
+          set -euo pipefail
+          echo "Publishing SBOMs for ${VERSION}"
+          aws s3 sync ./sbom-out s3://${BUCKET_NAME}/arthur-engine/sbom/${VERSION} --acl public-read
+          # `latest` tracks the newest production release only: dev increments continuously, so
+          # pointing the public `latest` SBOM at a dev build would be misleading.
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            aws s3 sync ./sbom-out s3://${BUCKET_NAME}/arthur-engine/sbom/latest --acl public-read
+          fi
+
   push-all-helm-charts:
     needs: [build-genai-engine-docker-images, build-ml-engine-docker-images]
     environment: shared-protected-branch-secrets

--- a/security/README.md
+++ b/security/README.md
@@ -40,6 +40,24 @@ one is triaged to a documented position (fix it, or justify it via VEX). Two vie
 Generated artifacts (SBOM, per-image reports) are **not** committed; they are produced by CI and
 uploaded as workflow artifacts (and re-generated daily by `.github/workflows/image-vuln-scan.yml`).
 
+## Downloading a released SBOM
+
+Per release, a CycloneDX SBOM for every published image is also published to the public `arthur-cft`
+S3 bucket (by the `push-all-sboms` job in `.github/workflows/arthur-engine-workflow.yml`), giving
+stable download URLs. `latest/` tracks the newest **production** (main) release only:
+
+```
+https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/sbom/<VERSION>/sbom-<image>.cdx.json
+https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/sbom/latest/sbom-<image>.cdx.json
+```
+
+where `<image>` is one of `genai-engine-cpu`, `genai-engine-gpu`, `ml-engine`,
+`genai-engine-models-s3`, `genai-engine-models-fs`, `genai-engine-models-gcs`. Example:
+
+```bash
+curl -O https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/sbom/latest/sbom-genai-engine-cpu.cdx.json
+```
+
 ## Where the scanning runs
 
 - **Per release build** — `.github/workflows/arthur-engine-workflow.yml` calls the


### PR DESCRIPTION
## Context

Today the CycloneDX SBOMs for Arthur Engine images are hard to reach:

- **Image attestations** (`sbom: true` in `docker/build-push-action`) require Docker tooling and the exact image tag to extract (`docker buildx imagetools inspect ... --format '{{ json .SBOM }}'`), and are BuildKit/SPDX — not the CycloneDX format consumers expect.
- **Trivy CycloneDX files** (`sbom-<slug>.cdx.json`) are generated by the `vuln-report` composite action but only survive as **ephemeral GitHub Actions workflow artifacts** (retention-limited, buried in a run, no stable URL).

This publishes a stable, public, linkable CycloneDX SBOM for **every published image, every release**, reusing the existing `arthur-cft` S3 pattern (the same bucket that hosts the CloudFormation templates).

## What changed

**`.github/workflows/arthur-engine-workflow.yml`** — new `push-all-sboms` job (next to `push-all-cfts`):
- Generates a CycloneDX SBOM per image with Trivy for all six published images — `genai-engine-cpu`, `genai-engine-gpu`, `ml-engine`, `genai-engine-models-{s3,fs,gcs}`.
- Syncs to `s3://arthur-cft/arthur-engine/sbom/<VERSION>/` on every release, and to `sbom/latest/` **on `main` only** (see note below).
- `needs` all six image jobs; `if: !cancelled() && <engine builds succeeded> && ...` so it tolerates the mutually-exclusive model build/tag jobs being skipped while still ordering after whichever ran.
- Per-image generation is **advisory** (a single missing/failed image can't block publishing the rest), and `trivy clean --scan-cache` runs between images to bound peak disk (model images bundle large HF weights).
- Reuses the exact AWS OIDC role + `aws s3 sync --acl public-read` idiom from `push-all-cfts`. The release/tag path is left **independent** of this job, so a Trivy/S3 hiccup never blocks a release.

**`security/README.md`** — documents the public download URLs.

Resulting URLs:
```
https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/sbom/<VERSION>/sbom-genai-engine-cpu.cdx.json
https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/sbom/latest/sbom-ml-engine.cdx.json   # main only
```

### `latest` aliasing — intentional divergence from `push-all-cfts`
`push-all-cfts` updates `latest` on both main and dev. For SBOMs that would point the public `latest` at the newest **dev** build, which is misleading — so `sbom/latest/` is updated on `main` only, while `<VERSION>` is published on both branches.

## ⚠️ Prerequisite to confirm before first release relies on this
The assumed role `AWS_S3_ROLE_ARN` currently writes to `arthur-cft/arthur-engine/templates/*`. **If its IAM policy is prefix-scoped, writes to the new `arthur-engine/sbom/*` prefix will fail with AccessDenied.** Please confirm the policy allows `s3:PutObject`/`s3:PutObjectAcl` (with `public-read`) on `arthur-cft/arthur-engine/sbom/*`.

## Verification
- YAML parses; `needs` graph resolves (all 7 targets exist, no self-reference).
- Real Trivy dry-run against `arthurplatform/ml-engine:latest-dev` produced valid CycloneDX (specVersion 1.7, 1211 components).
- Confirmed all six images tag with `${VERSION}` across both build and retag paths, so the pulls resolve on both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)