### PR TITLE
Fix UI type-check: dedupe OpenInferenceSpanKind to 2.5.0, handle PROMPT span kind

### DIFF
--- a/genai-engine/ui/package.json
+++ b/genai-engine/ui/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "packageManager": "yarn@4.12.0",
+  "resolutions": {
+    "@arizeai/openinference-semantic-conventions": "2.5.0"
+  },
   "scripts": {
     "dev": "vite --mode dev",
     "build": "tsc -b && vite build",

--- a/genai-engine/ui/src/components/common/span/TypeChip.tsx
+++ b/genai-engine/ui/src/components/common/span/TypeChip.tsx
@@ -37,4 +37,5 @@ const TYPE_COLORS = {
   [OpenInferenceSpanKind.RERANKER]: "info",
   [OpenInferenceSpanKind.GUARDRAIL]: "error",
   [OpenInferenceSpanKind.EVALUATOR]: "info",
+  [OpenInferenceSpanKind.PROMPT]: "secondary",
 } as const;

--- a/genai-engine/ui/src/components/traces/constants.tsx
+++ b/genai-engine/ui/src/components/traces/constants.tsx
@@ -13,6 +13,7 @@ export const SPAN_TYPE_ICONS = {
   [OpenInferenceSpanKind.RERANKER]: <AutoAwesomeIcon />,
   [OpenInferenceSpanKind.GUARDRAIL]: <AutoAwesomeIcon />,
   [OpenInferenceSpanKind.EVALUATOR]: <AutoAwesomeIcon />,
+  [OpenInferenceSpanKind.PROMPT]: <AutoAwesomeIcon />,
 };
 
 export const TIME_RANGES = {

--- a/genai-engine/ui/src/components/traces/data/details-strategy.tsx
+++ b/genai-engine/ui/src/components/traces/data/details-strategy.tsx
@@ -226,9 +226,8 @@ const spanDetailsStrategy = [
     widgets: [WIDGETS.LATENCY],
   },
   {
-    // PROMPT is in the OpenInference spec but not the installed JS package version.
     // Input shows the original template + variable values; Output shows the rendered result.
-    kind: "PROMPT",
+    kind: OpenInferenceSpanKind.PROMPT,
     panels: [PANELS.INPUT, PANELS.OUTPUT],
     raw: PANELS.RAW_DATA,
     tabs: [PANELS.RAW_DATA],

--- a/genai-engine/ui/yarn.lock
+++ b/genai-engine/ui/yarn.lock
@@ -459,13 +459,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@arizeai/openinference-semantic-conventions@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@arizeai/openinference-semantic-conventions@npm:2.1.0"
-  checksum: 10c0/6e9672a6d39003ba8065fe12bc47d553ad588bf126f892e4a5cb816fcf032885a634de08db0b954cd44980c735641a10fe6de39f48eb2e3d0d4e0a4e17805289
-  languageName: node
-  linkType: hard
-
 "@arizeai/openinference-semantic-conventions@npm:2.5.0":
   version: 2.5.0
   resolution: "@arizeai/openinference-semantic-conventions@npm:2.5.0"


### PR DESCRIPTION
## Problem

The `run-genai-engine-ui-lint` CI job fails at `yarn type-check` ([example run](https://github.com/arthur-ai/arthur-engine/actions/runs/29279563435/job/86917214453)).

Root cause is a **version skew** of `@arizeai/openinference-semantic-conventions`:

- #1875 bumped the UI's direct dependency to **2.5.0**
- `@arthur/shared-components@3.20.0` still hard-pins **2.1.0**

`yarn install --immutable` therefore keeps **two copies** of the package, so TypeScript sees two nominally-distinct `OpenInferenceSpanKind` enums. That produced:

1. `TypeChip.tsx` (TS7053) — 2.5.0 adds a new `PROMPT` member, so the `TYPE_COLORS` map was no longer exhaustive over the enum and indexing became unsafe.
2. `SpanDetails.tsx:66` (TS2345) — `isSpanOfType(span, OpenInferenceSpanKind.LLM)` passes the app's 2.5.0 enum into a parameter typed against shared-components' 2.1.0 enum → not assignable.

## Fix

- **`package.json`** — add a `resolutions` entry pinning `@arizeai/openinference-semantic-conventions` to a single `2.5.0` across the tree (including inside `shared-components`), deduping the enum and eliminating the cross-boundary mismatch. 2.5.0 is purely additive over 2.1.0, so forcing shared-components onto it is safe. `yarn.lock` regenerated accordingly.
- **`TypeChip.tsx` / `constants.tsx`** — add the `PROMPT` color and icon.
- **`details-strategy.tsx`** — replace the `"PROMPT"` string workaround (added when the enum member didn't yet exist) with `OpenInferenceSpanKind.PROMPT`.

## Verification

- `yarn type-check` → exit 0
- `yarn check` (type-check + lint + format:check) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)