### PR TITLE
Add genaiEngineSecretStoreKeyName to umbrella values template

### DIFF
--- a/deployment/helm/arthur-engine/values.yaml.template
+++ b/deployment/helm/arthur-engine/values.yaml.template
@@ -205,6 +205,8 @@ arthur-genai-engine:
   # Name of the secret which stores the connection strings for Azure OpenAI GPT-3.5 model endpoints. Must be in form "DEPLOYMENT_NAME1::OPENAI_ENDPOINT1::SECRET_KEY1,DEPLOYMENT_NAME2::OPENAI_ENDPOINT2::SECRET_KEY2"). Many may be specified.
   # (expecting value for key 'keys')
   genaiEngineSecretOpenAIGPTModelNamesEndpointsKeysName: "genai-engine-secret-open-ai-gpt-model-names-endpoints-keys"
+  # GenAI Engine secret store key name (expecting value for key 'key' - should be a base64-encoded 32-byte Fernet key)
+  genaiEngineSecretStoreKeyName: "genai-engine-secret-store-key"
 
 arthur-ml-engine:
   ###################################


### PR DESCRIPTION
## Problem
Building a `values.yaml` from the **arthur-engine umbrella** `values.yaml.template` and running `helm install/upgrade` fails schema validation:

```
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
arthur-genai-engine:
- at '': missing property 'genaiEngineSecretStoreKeyName'
```

The `arthur-genai-engine` leaf chart marks `genaiEngineSecretStoreKeyName` as **required** in its `values.schema.json` (and ships it in its own `values.yaml.template`), but the umbrella `values.yaml.template` omitted it. It is the only required leaf-schema key missing from the umbrella template.

## Fix
Add `genaiEngineSecretStoreKeyName: "genai-engine-secret-store-key"` under the umbrella's *"Advanced - Secrets name customization"* block, matching the leaf template's default and comment.

## Notes
- This is the secret name for the Fernet key that encrypts secrets in the DB. The genai-engine `templates/secrets.yaml` still auto-generates the secret if absent, so behavior is unchanged — this only satisfies schema validation for the umbrella path.
- No version bump (handled by the release automation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)