### PR TITLE
Add auditLog, gcpDiscoveryConfig, genaiEngineOpenAIVerifySSL to umbrella template

### DIFF
--- a/deployment/helm/arthur-engine/values.yaml.template
+++ b/deployment/helm/arthur-engine/values.yaml.template
@@ -16,6 +16,10 @@ arthur-genai-engine:
   scopeFeIngressURI: ""
   # Provider of OpenAI LLMs (must be set to 'Azure' or 'OpenAI')
   genaiEngineOpenAIProvider: "Azure"
+  # TLS verification for the LLM endpoint (e.g. an OpenAI-compatible LiteLLM proxy). Referenced
+  # unconditionally by the deployment as GENAI_ENGINE_OPENAI_VERIFY_SSL, so set it explicitly
+  # (empty renders an invalid bool and crashes worker boot). "false" disables verification (dev/test only).
+  genaiEngineOpenAIVerifySSL: "true"
 
   ###################################
   ## Additional Required Configurations For GPU Deployment
@@ -47,6 +51,18 @@ arthur-genai-engine:
     #  - key: "nvidia.com/gpu"
     #    operator: "Exists"
     #    effect: "NoSchedule"
+    # Audit log PVC. Referenced unconditionally by the deployment template
+    # (.arthurGenaiEngineDeployment.auditLog.enabled), so this block must be present.
+    auditLog:
+      enabled: false
+      mountPath: "/home/nonroot/app/audit_logs"
+      # Size requested for the audit log PVC
+      storageSize: "10Gi"
+      # ReadWriteMany-capable storage class to back the audit log PVC (e.g. NFS, EFS, Azure Files)
+      storageClassName: ""
+      # (Optional) Group ID applied as the pod's fsGroup so the non-root container can write to the mounted PVC.
+      # Required on platforms that mount volumes as root (e.g. OpenShift - use a GID from the namespace's allowed range).
+      fsGroup: ""
   # CPU deployment - Comment out the below 4 lines
   gpuEnabled: false
   genaiEngineDeploymentType: "deployment"
@@ -207,6 +223,20 @@ arthur-genai-engine:
   genaiEngineSecretOpenAIGPTModelNamesEndpointsKeysName: "genai-engine-secret-open-ai-gpt-model-names-endpoints-keys"
   # GenAI Engine secret store key name (expecting value for key 'key' - should be a base64-encoded 32-byte Fernet key)
   genaiEngineSecretStoreKeyName: "genai-engine-secret-store-key"
+
+  ###################################
+  ## Advanced - GCP Service Account
+  ###################################
+  # Referenced unconditionally by the deployment template (.gcpDiscoveryConfig.isEnabled), so this
+  # block must be present. Leave isEnabled: false unless integrating Vertex AI.
+  gcpDiscoveryConfig:
+    isEnabled: false
+    # Google Cloud project ID for Vertex AI integration
+    # googleCloudProject: ""
+    # (Optional) Google Cloud region/location
+    # googleCloudLocation: ""
+    # (Optional) Name of the K8s secret containing the GCP service account JSON key
+    # googleCredentialsSecretName: ""
 
 arthur-ml-engine:
   ###################################


### PR DESCRIPTION
## Problem
Follow-up to #1922 — same umbrella/leaf drift. Building a `values.yaml` from the **arthur-engine umbrella** `values.yaml.template` and installing still fails, because the umbrella omits three more keys that the `arthur-genai-engine` leaf templates use:

1. **`arthurGenaiEngineDeployment.auditLog`** — dereferenced unconditionally in `arthur-genai-engine-deployment.yaml` (`.auditLog.enabled`, line 40):
   ```
   nil pointer evaluating interface {}.enabled
   ```
2. **`gcpDiscoveryConfig`** — likewise dereferenced (`.gcpDiscoveryConfig.isEnabled`) → next nil-pointer.
3. **`genaiEngineOpenAIVerifySSL`** — rendered into `GENAI_ENGINE_OPENAI_VERIFY_SSL`; when absent it becomes `""`, and the app's pydantic settings crash on bool parsing at worker boot.

## Fix
Add all three to the umbrella's `arthur-genai-engine` block, mirroring the leaf `values.yaml.template` defaults and comments (`auditLog.enabled: false`, `gcpDiscoveryConfig.isEnabled: false`, `genaiEngineOpenAIVerifySSL: "true"`).

## Notes
- Behavior unchanged for existing installs that already set these in their values; this only makes the umbrella template self-sufficient so a fresh `values.yaml` renders without nil-pointers / boot crashes.
- Longer term, the umbrella `arthur-genai-engine` block should be kept in sync with the leaf `values.yaml.template` (these keep drifting — cf. #1922).

🤖 Generated with [Claude Code](https://claude.com/claude-code)