### PR TITLE
docs(helm): clarify genaiEngineInternalIngressHost requires https:// scheme

### DIFF
--- a/deployment/helm/arthur-engine/values.yaml.template
+++ b/deployment/helm/arthur-engine/values.yaml.template
@@ -290,7 +290,10 @@ arthur-ml-engine:
     imagePullSecretName: ""
   mlEngine:
     deployment:
-      # This should be the same as the genaiEngineIngressURL in the arthur-genai-engine chart
+      # Full URL of the GenAI Engine ingress, INCLUDING the "https://" scheme.
+      # This is the same host as genaiEngineIngressURL in the arthur-genai-engine chart, but note that
+      # genaiEngineIngressURL is a bare hostname (no scheme) whereas this value MUST include "https://".
+      # Example: "https://arthur-genai-engine.mydomain.com"
       genaiEngineInternalIngressHost: ""
       fetchRawDataEnabled: true
       genaiEngineMaxPageSize: 1500

--- a/deployment/helm/ml-engine/values.yaml.template
+++ b/deployment/helm/ml-engine/values.yaml.template
@@ -8,7 +8,10 @@ mlEngine:
     ###################################
     ## Minimum Required Configurations for when deployed with Arthur GenAI Engine
     ###################################
-    # This should be the same as the genaiEngineIngressURL in the arthur-genai-engine chart
+    # Full URL of the GenAI Engine ingress, INCLUDING the "https://" scheme.
+    # This is the same host as genaiEngineIngressURL in the arthur-genai-engine chart, but note that
+    # genaiEngineIngressURL is a bare hostname (no scheme) whereas this value MUST include "https://".
+    # Example: "https://arthur-genai-engine.mydomain.com"
     genaiEngineInternalIngressHost: ""
     fetchRawDataEnabled: true
     genaiEngineMaxPageSize: 1500


### PR DESCRIPTION
## Summary

Clarifies in the Helm `values.yaml.template` comments that `genaiEngineInternalIngressHost` (ML Engine) must include the `https://` scheme, and calls out the format asymmetry with `genaiEngineIngressURL` (arthur-genai-engine chart), which is a **bare hostname**.

## Why

The ML Engine deployment template injects `genaiEngineInternalIngressHost` verbatim into the `GENAI_ENGINE_INTERNAL_INGRESS_HOST` env var. In code (`ml-engine/src/ml_engine/connectors/shield_connector.py`) this becomes `_shield_external_host` and is sent to the control plane as the task `api_host` — a full URL. The previous comment only said "This should be the same as the genaiEngineIngressURL in the arthur-genai-engine chart," which is misleading because:

- `genaiEngineIngressURL` is a **bare hostname** (no scheme) — the chart prepends `https://` and also uses it as the Ingress rule `host:`.
- `genaiEngineInternalIngressHost` is a **raw passthrough** used as a URL, so it **must** include `https://`.

## Changes

- `deployment/helm/ml-engine/values.yaml.template`
- `deployment/helm/arthur-engine/values.yaml.template`

Comment updated to state the `https://` requirement, explain the asymmetry, and provide an example (`https://arthur-genai-engine.mydomain.com`).

Docs-only change; no template rendering or runtime behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)