### PR TITLE
chore: add arthur-blazity-ai-workflow to allowed_bots

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_bots: 'arthur-github-automator-app'
+          allowed_bots: 'arthur-github-automator-app,arthur-blazity-ai-workflow'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
##  Changes
- adds `arthur-blazity-ai-workflow` to `allowed_bots` in `claude-code-review.yml` fixing claude code review in PRs authored by ai-workflow