### PR TITLE
Cap alert log buckets per rule per job run (fixes alert_logs table flooding)

### DIFF
--- a/ml-engine/src/ml_engine/job_executors/alert_check_executor.py
+++ b/ml-engine/src/ml_engine/job_executors/alert_check_executor.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 from uuid import UUID
 
 from arthur_client.api_bindings import (
@@ -55,6 +55,13 @@ ALERT_RULES_NON_ADDITIONAL_DIMENSION_FIELDS = [
 ]
 ALERT_RULES_SCALAR_TYPES = (str, int, float, bool, datetime, UUID)
 
+# Caps how many per-bucket alert logs a single rule can emit per job run. A
+# fine-grained interval over a wide check window (e.g. a 1-second rule on a
+# multi-day backfill) would otherwise enumerate one no_data log per interval —
+# millions of rows in one job — and flood the app-plane alert_logs table. The
+# fired-alert path is separately capped by ALERT_RULES_QUERY_LIMIT.
+MAX_ALERT_LOG_BUCKETS_PER_RULE = 100
+
 # TimescaleDB's time_bucket anchors buckets to a fixed origin that depends on
 # the bucket width. Midnight Jan 3, 2000 for buckets using seconds/minutes/
 # hours/days and midnight Jan 1, 2000 for buckets using month/year/century.
@@ -67,7 +74,8 @@ def get_expected_bucket_timestamps(
     adjusted_end_time: datetime,
     td: timedelta,
     interval: AlertRuleInterval,
-) -> List[datetime]:
+    max_buckets: int = MAX_ALERT_LOG_BUCKETS_PER_RULE,
+) -> Tuple[List[datetime], int]:
     """
     This function gets every time bucket interval within thes specified window.
     We can then compare which buckets the query actually returned to determine
@@ -78,6 +86,10 @@ def get_expected_bucket_timestamps(
     account for this, we snap adjusted_start_time to that same grid so our generated
     timestamps match the ones the query returns, then create a bucket for each td
     until our end time.
+
+    At most max_buckets buckets are returned, keeping the most recent ones.
+    Returns (buckets, num_skipped) where num_skipped is the count of older
+    buckets in the window that were dropped by the cap.
 
     Timescale's docs on time_bucket:
     https://www.tigerdata.com/docs/reference/timescaledb/hyperfunctions/time-series-utilities/time_bucket
@@ -107,11 +119,25 @@ def get_expected_bucket_timestamps(
     if bucket_ts < adjusted_start_time:
         bucket_ts += bucket_step
 
+    num_skipped = 0
+    # jump straight to the last max_buckets buckets instead of enumerating a
+    # potentially huge window one interval at a time
+    if isinstance(bucket_step, timedelta) and bucket_ts <= adjusted_end_time:
+        total = (adjusted_end_time - bucket_ts) // bucket_step + 1
+        if total > max_buckets:
+            num_skipped = total - max_buckets
+            bucket_ts += num_skipped * bucket_step
+
     buckets = []
     while bucket_ts <= adjusted_end_time:
         buckets.append(bucket_ts)
         bucket_ts += bucket_step
-    return buckets
+
+    if len(buckets) > max_buckets:
+        num_skipped += len(buckets) - max_buckets
+        buckets = buckets[-max_buckets:]
+
+    return buckets, num_skipped
 
 
 class AlertCheckExecutor:
@@ -271,12 +297,21 @@ class AlertCheckExecutor:
 
             results_by_ts[ts.astimezone(timezone.utc)].append(r)
 
-        expected_bucket_timestamps = get_expected_bucket_timestamps(
-            adjusted_start_time,
-            adjusted_end_time,
-            td,
-            alert_rule.interval,
+        expected_bucket_timestamps, num_skipped_buckets = (
+            get_expected_bucket_timestamps(
+                adjusted_start_time,
+                adjusted_end_time,
+                td,
+                alert_rule.interval,
+            )
         )
+        if num_skipped_buckets:
+            self.logger.warning(
+                f"Alert rule {alert_rule.id} (interval: {alert_rule.interval.count} "
+                f"{alert_rule.interval.unit}) has {num_skipped_buckets + len(expected_bucket_timestamps)} "
+                f"buckets in check window {adjusted_start_time} -> {adjusted_end_time}; "
+                f"only logging the most recent {len(expected_bucket_timestamps)}",
+            )
 
         logs: List[PostAlertLog] = []
         fired_rows: List[Dict[str, Any]] = []

--- a/ml-engine/tests/unit/job_executors/test_alert_check_executor.py
+++ b/ml-engine/tests/unit/job_executors/test_alert_check_executor.py
@@ -26,6 +26,7 @@ from arthur_client.api_bindings import (
 
 from job_executors._interval_utils import alert_interval_to_timedelta
 from job_executors.alert_check_executor import (
+    MAX_ALERT_LOG_BUCKETS_PER_RULE,
     AlertCheckExecutor,
     get_expected_bucket_timestamps,
 )
@@ -33,12 +34,13 @@ from job_executors.alert_check_executor import (
 
 def expected_buckets(job_spec, alert_rule):
     td = alert_interval_to_timedelta(alert_rule.interval)
-    return get_expected_bucket_timestamps(
+    buckets, _ = get_expected_bucket_timestamps(
         job_spec.check_range_start_timestamp - td,
         job_spec.check_range_end_timestamp - td,
         td,
         alert_rule.interval,
     )
+    return buckets
 
 
 def make_alert_rule(model_id: str, now: datetime) -> AlertRule:
@@ -549,6 +551,65 @@ def test_alert_rule_log_okay():
     statuses = {log.timestamp: log.status for log in posted.logs}
     assert statuses[buckets[0]] == AlertLogStatus.OKAY
     alerts_client.post_model_alerts.assert_not_called()
+
+
+def test_expected_bucket_timestamps_capped():
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    interval = AlertRuleInterval(unit=IntervalUnit.SECONDS, count=1)
+
+    buckets, num_skipped = get_expected_bucket_timestamps(
+        start,
+        end,
+        timedelta(seconds=1),
+        interval,
+    )
+
+    assert len(buckets) == MAX_ALERT_LOG_BUCKETS_PER_RULE
+    assert num_skipped == 86401 - MAX_ALERT_LOG_BUCKETS_PER_RULE
+    # the most recent buckets are kept, on the 1-second grid ending at `end`
+    assert buckets[-1] == end
+    assert buckets[0] == end - timedelta(seconds=MAX_ALERT_LOG_BUCKETS_PER_RULE - 1)
+
+    # a window smaller than the cap is unaffected
+    buckets, num_skipped = get_expected_bucket_timestamps(
+        start,
+        start + timedelta(seconds=10),
+        timedelta(seconds=1),
+        interval,
+    )
+    assert len(buckets) == 11
+    assert num_skipped == 0
+
+
+def test_alert_rule_log_bucket_cap_applied():
+    now = datetime(2026, 7, 18, 8, 0, tzinfo=timezone.utc)
+    model_id = str(uuid4())
+    alert_rule = make_alert_rule(model_id, now)
+    alert_rule.interval = AlertRuleInterval(unit=IntervalUnit.SECONDS, count=1)
+
+    alerts_client = Mock()
+    alert_rules_client = Mock()
+    metrics_client = Mock()
+
+    alert_rules_response = Mock()
+    alert_rules_response.records = [alert_rule]
+    alert_rules_client.get_model_alert_rules.return_value = alert_rules_response
+
+    metrics_client.post_model_metrics_query.return_value = MetricsQueryResult(
+        results=[],
+    )
+
+    # 1-hour check window with a 1-second rule would otherwise emit 3600 logs
+    job, job_spec = make_job_and_spec(model_id, now)
+    executor = make_executor(alerts_client, alert_rules_client, metrics_client)
+    executor.execute(job, job_spec)
+
+    alerts_client.post_model_alert_logs.assert_called_once()
+    posted = alerts_client.post_model_alert_logs.call_args.kwargs["post_alert_logs"]
+    assert len(posted.logs) == MAX_ALERT_LOG_BUCKETS_PER_RULE
+    assert all(log.status == AlertLogStatus.NO_DATA for log in posted.logs)
+    executor.logger.warning.assert_called()
 
 
 def test_alert_rule_log_no_data():


### PR DESCRIPTION
## TL;DR

The alert-check job writes one `alert_logs` row per interval-sized time bucket in its check window, with **no upper bound**. A rule configured with a 1-second interval emits **86,400 `no_data` rows/day**, and a backfill over a multi-day window can attempt **millions of rows in a single job**. This PR caps the emission at the **100 most recent buckets per rule per job run** and logs a warning when truncating.

## Background / production impact

Two related prod incidents traced back to this behavior:

1. **Hourly app-plane 5xx + latency alarms** (`platform-prod-app-plane-5xx-errors-v4`): high-volume concurrent `POST /models/{id}/alert_logs` batches from engine workers raced on the `uq_alert_logs_rule_timestamp` constraint. The app-plane side was fixed with an atomic upsert (arthur-scope MR 1810), but the *volume* originates here.
2. **`Prod RDS ReadIOPS` alarm** (2026-07-18 08:00 UTC, avg ~3,200 / peak ~15,800 IOPS vs a normal baseline of ~2-5): Performance Insights showed `autovacuum: VACUUM public.alert_logs` reading ~12 GB from storage in ~10 minutes on `platform-db-instance-v4`. The table has grown so large from per-second log rows (one prod rule alone writes 86,400 rows/day) that routine autovacuum is now a storage-I/O event. These vacuum spikes recur (a prior one hit ~14k IOPS on 2026-07-12) and get bigger as the table grows.

## Mechanism

In `AlertCheckExecutor._process_alert_rule`, `get_expected_bucket_timestamps()` enumerates **every** bucket of size `alert_rule.interval` inside the job's check window so it can record `fired` / `okay` / `no_data` per bucket. The check window comes from the triggering metrics-calculation job's window, so:

- 1-second rule, hourly schedule → 3,600 logs per run, 86,400/day
- 1-second rule, 30-day backfill → 2,592,000 logs in **one** job run

Note the fired-*alert* path is already capped (`ALERT_RULES_QUERY_LIMIT = 50`); the log path was the only unbounded one.

## Change

- `get_expected_bucket_timestamps()` takes a `max_buckets` cap (new constant `MAX_ALERT_LOG_BUCKETS_PER_RULE = 100`) and returns `(buckets, num_skipped)`, keeping the **most recent** buckets. For fixed-width intervals the start position is computed arithmetically, so a huge window is never enumerated in memory.
- The executor logs a warning when truncation happens, naming the rule, its interval, the window, and how many buckets were dropped — so misconfigured rules are visible in logs instead of silently flooding the DB.
- No changes to alert creation, webhooks, compliance-job chaining, or the API surface.

## Why this is safe

- **Consumers**: the only reader of `alert_logs` is the paginated `GET /models/{id}/alert_logs` endpoint in app-plane. Compliance evaluation reads `alerts`, not `alert_logs`, so compliance outcomes are unaffected.
- **Sane configs unaffected**: an hourly-interval rule produces 1 bucket per hourly run; a 1-minute rule produces 60. Both are under the cap. Only sub-minute intervals or very wide windows (backfills) get truncated, and they keep their most recent 100 buckets.
- **Idempotent**: app-plane upserts on `(alert_rule_id, timestamp)`, so overlapping/retried windows update in place.

## What this intentionally does not do

- The misconfigured per-second prod rule still exists — this caps the damage (86,400 → 2,400 rows/day) rather than fixing that rule. A follow-up could add app-plane validation rejecting sub-minute alert intervals.
- Existing `alert_logs` bloat in prod needs a one-time cleanup/retention job before the autovacuum ReadIOPS spikes fully subside.
- The cap value (100) mirrors the spirit of `ALERT_RULES_QUERY_LIMIT` (50) with headroom for 1-minute rules on hourly schedules; happy to tune.

## Testing

- `uv run pytest tests/unit/job_executors/test_alert_check_executor.py` → 9 passed, including two new tests: cap math for a 1-second rule over a 1-day window (86,401 buckets → 100 most recent, correct grid alignment) and an end-to-end executor test asserting a 1-second rule on a 1-hour window posts exactly 100 `no_data` logs and warns.
- `./scripts/lint.sh` clean.
- Pre-existing (on `main` too): 5 unrelated test modules in `tests/unit/job_executors/` fail *collection* due to the generated `genai_client` module not being installed in a fresh checkout (`scripts/openapi_client_utils.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)