### PR TITLE
feat(arthur-engine helm): expose ml-engine HPA in umbrella values

### DIFF
--- a/deployment/helm/arthur-engine/values.yaml.template
+++ b/deployment/helm/arthur-engine/values.yaml.template
@@ -301,6 +301,8 @@ arthur-ml-engine:
       ###################################
       ## Advanced - General
       ###################################
+      # Number of replicas of the ML Engine pod running in the k8s cluster (this is automatically
+      # overridden if the ML Engine HPA is enabled - see arthurMLEngineHPA below)
       replicas: 1
       labels: {}
       annotations: {}
@@ -328,3 +330,34 @@ arthur-ml-engine:
       mlEngineClientSecretName: "ml-engine-client-secret"
       # GenAI Engine secret admin key name (expecting value for key 'key')
       genaiEngineInternalAPIKeySecretName: "genai-engine-secret-admin-key"
+
+  ###################################
+  ## Advanced - Autoscaling
+  ###################################
+  # HorizontalPodAutoscaler for the ML Engine.
+  # NOTE: each replica requests ~16Gi RAM / 7-8 CPU, so maxReplicas multiplies that footprint
+  # (e.g. maxReplicas: 5 => up to ~80Gi / ~40 CPU). Requires a metrics-server in the cluster.
+  # Set enabled: false to pin a fixed replica count via mlEngine.deployment.replicas instead.
+  arthurMLEngineHPA:
+    enabled: true
+    annotations: {}
+    labels: {}
+    # Conservative scale-down / aggressive scale-up (mirrors the genai-engine chart).
+    behavior:
+      scaleDown:
+        stabilizationWindowSeconds: 300
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+      scaleUp:
+        stabilizationWindowSeconds: 30
+        policies:
+          - type: Percent
+            value: 100
+            periodSeconds: 15
+        selectPolicy: Max
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 80


### PR DESCRIPTION
## Summary
The ml-engine sub-chart ships a `HorizontalPodAutoscaler` template gated on `arthurMLEngineHPA.enabled` (added in #1977), but the **umbrella** chart's `values.yaml.template` never surfaced the key. As a result operators had no documented way to configure it, and because the packaged sub-chart ships no effective `values.yaml`, the HPA stayed **off** by default.

This PR adds the missing `arthurMLEngineHPA` block to `deployment/helm/arthur-engine/values.yaml.template`, mirroring the existing `arthurGenaiEngineHPA` block.

## Changes
- Add `arthurMLEngineHPA` under `arthur-ml-engine:` (top-level sibling of `mlEngine:`, matching what the sub-chart HPA template consumes):
  - `enabled: true`
  - `minReplicas: 1`, `maxReplicas: 5`
  - `targetCPUUtilizationPercentage: 50`, `targetMemoryUtilizationPercentage: 80`
  - conservative scale-down / aggressive scale-up `behavior` (mirrors genai-engine)
  - footprint + metrics-server caveat comment
- Add a note on `mlEngine.deployment.replicas` being overridden when the HPA is enabled (mirrors the genai-engine `genaiEngineReplicaCount` comment).

## Testing
- `values.yaml.template` lints as valid YAML.
- Rendered the umbrella chart with these values against the published `arthur-ml-engine` 2.1.725 sub-chart; a correct `HorizontalPodAutoscaler` for `arthur-ml-engine` is produced (min 1 / max 5, CPU+memory metrics, behavior block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)