### PR TITLE
chore(renovate): group langchain + openai package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,19 @@
       "enabled": false
     },
     {
+      "matchManagers": ["pep621"],
+      "groupName": "langchain + openai",
+      "matchPackageNames": [
+        "langchain",
+        "langchain-core",
+        "langchain-community",
+        "langchain-openai",
+        "langchain-text-splitters",
+        "langsmith",
+        "openai"
+      ]
+    },
+    {
       "matchManagers": ["dockerfile", "docker-compose"],
       "matchPackageNames": ["python"],
       "enabled": false


### PR DESCRIPTION
## What

Adds a Renovate `packageRules` entry that batches the langchain family together with `openai` into a single grouped PR titled **"langchain + openai"**:

- `langchain`, `langchain-core`, `langchain-community`, `langchain-openai`, `langchain-text-splitters`, `langsmith`
- `openai`

## Why

These packages are tightly coupled and frequently require coordinated version bumps. Grouping them into one PR avoids partial upgrades that leave the lockfile in an internally inconsistent state and reduces interdependent-version breakage / PR churn.

## Notes

Config-only change (`renovate.json`). No source or dependency changes. Split out from the already-merged #2012 (`chore/renovate-close-automation-gap`) as a standalone follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)