### PR TITLE
security(vex): drop remediated nltk CVE-2026-54293

### DIFF
--- a/security/vex/openvex.json
+++ b/security/vex/openvex.json
@@ -3,9 +3,9 @@
   "@id": "https://arthur.ai/vex/arthur-engine",
   "author": "Arthur Security <security@arthur.ai>",
   "role": "Document Creator",
-  "timestamp": "2026-06-27T00:00:00.000000000-00:00",
-  "version": 4,
-  "_comment": "Scope: HIGH/CRITICAL CVEs a container-image re-scan still reports for the genai-engine, ml-engine and genai-engine-models-* images, but which are remediated in the shipped binary (the apt-upgraded library is copied over the distroless base, whose stale dpkg metadata the scanner reads) or are not in the execute path. Fully remediated CVEs are intentionally excluded: python3.11 is removed from every image (its dpkg metadata deleted) and litellm/langsmith/msgpack are upgraded past their advisories. See genai-engine/dockerfile, ml-engine/Dockerfile, deployment/model-upload/Dockerfile and PR #1851.",
+  "timestamp": "2026-07-28T00:00:00.000000000-00:00",
+  "version": 5,
+  "_comment": "Scope: HIGH/CRITICAL CVEs a container-image re-scan still reports for the genai-engine, ml-engine and genai-engine-models-* images, but which are remediated in the shipped binary (the apt-upgraded library is copied over the distroless base, whose stale dpkg metadata the scanner reads) or are not in the execute path. Fully remediated CVEs are intentionally excluded: python3.11 is removed from every image (its dpkg metadata deleted), litellm/langsmith/msgpack are upgraded past their advisories, and nltk is upgraded to 3.10.0 (fixes CVE-2026-54293, GHSA-p4gq-832x-fm9v). See genai-engine/dockerfile, ml-engine/Dockerfile, deployment/model-upload/Dockerfile and PR #1851.",
   "statements": [
     {
       "_comment": "libssl3: the shipped libssl.so.3/libcrypto.so.3 is OpenSSL 3.0.20 (deb 3.0.20-1~deb12u2), copied from the apt-upgraded *-slim-bookworm build stage over the distroless base. Scanners read stale dpkg metadata (3.0.19-1~deb12u2) inherited from the distroless base. The shipped binary contains the fix. The genai-engine-models-s3/-fs images do the same via deployment/model-upload/Dockerfile.",
@@ -153,17 +153,6 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "The system libexpat1 is not loaded by the application: CPython 3.12/3.13 bundle their own expat statically and do not link /usr/lib/*/libexpat.so.1, and the only base-image consumer (Python 3.11) has been removed. The flaw is a denial-of-service (inefficient algorithmic complexity, CWE-407, CVSS ~2.9) reachable only by parsing attacker-controlled XML through this system library."
-    },
-    {
-      "_comment": "nltk: CVE-2026-54293 is a path-traversal bypass in nltk.data.load() via URL-encoded input, with no upstream fix available (affects nltk <= 3.9.4). genai-engine only imports PunktSentenceTokenizer (src/utils/claim_parser.py:7) and instantiates it once with no resource path (SENTENCE_TOKENIZER = PunktSentenceTokenizer()); nltk.data.load() is never called and no untrusted path reaches it. nltk is a genai-engine-only dependency (absent from ml-engine).",
-      "vulnerability": { "name": "CVE-2026-54293" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:pypi/nltk" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:pypi/nltk" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The vulnerable function nltk.data.load() is never invoked. The sole nltk usage is PunktSentenceTokenizer, imported and instantiated with no resource path, so no attacker-controlled path can reach the path-traversal sink."
     },
     {
       "_comment": "zlib1g: The overflow is in MiniZip (zlib contrib/minizip), which upstream states is not a supported part of zlib. Debian's zlib1g shared library does not build or export the MiniZip code (the vulnerable zipOpenNewFileInZip4_64 symbol is absent); Arthur links only the core inflate/deflate API. Owner: security@arthur.ai. Review by: 2026-12-27.",


### PR DESCRIPTION
## What

Removes the OpenVEX statement for **CVE-2026-54293** (path traversal in `nltk.data.load()`) from `security/vex/openvex.json`, and bumps the document `version` (4 → 5) and `timestamp`.

## Why

The statement justified the finding on execute-path grounds and noted *"no upstream fix available (affects nltk <= 3.9.4)"*. That is now stale:

- **nltk 3.10.0** (released 2026-07-08, [GHSA-p4gq-832x-fm9v](https://github.com/nltk/nltk/security/advisories/GHSA-p4gq-832x-fm9v)) fixes the vulnerability.
- The engine **already pins `nltk==3.10.0`** in `genai-engine/pyproject.toml` + `uv.lock` (bumped in `d105d9812` `[SECURITY]`).

A container re-scan therefore sees the patched version and no longer flags CVE-2026-54293, so the `not_affected` exception is no longer needed. `nltk` is added to the header's "fully remediated / intentionally excluded" note for the record.

## Verification

Checked every remaining CVE against the Debian security tracker (JSON) / PyPI / GitHub advisories. No other statement became removable:

| Package | CVEs | Bookworm fix status | Kept because |
| --- | --- | --- | --- |
| openssl (libssl3) | 6 | fixed `3.0.20-1~deb12u2` | apt-patched binary, stale distroless dpkg metadata → `status: fixed` |
| glibc (libc6) | 5 | fixed `2.36-9+deb12u14` | same stale-metadata false positive |
| python3.11 | `CVE-2026-4224`, `CVE-2026-6100` (`+deb12u8`), `CVE-2025-13836` (`+deb12u7`) | fixed | package is **removed** (not upgraded) from images yet still scanned → fix is moot |
| python3.11 | `CVE-2025-69534`, `CVE-2026-3644`, `CVE-2026-7210` | no fix (no-dsa) | still unfixed |
| expat (libexpat1) | 3 | no fix (fixed only in unstable) | still unfixed |
| perl (perl-base) | 7 | no fix (no-dsa/postponed) | still unfixed |
| sqlite3 (libsqlite3-0) | 3 | no fix (no-dsa/postponed) | still unfixed |
| ncurses | 1 | no fix (no-dsa) | still unfixed |
| zlib (zlib1g) | 1 | `ignored` (minizip not built) | not present |

JSON re-validated; net change is −1 statement (33 → 32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)