### PR TITLE
security: remediate & VEX-justify Trivy HIGH backlog

### DIFF
--- a/deployment/model-upload/Dockerfile
+++ b/deployment/model-upload/Dockerfile
@@ -22,7 +22,7 @@ FROM python:3.12-slim-bookworm AS downloader
 ARG BACKEND
 
 WORKDIR /app
-RUN pip install --no-cache-dir uv==0.11.25
+RUN pip install --no-cache-dir uv==0.11.26
 COPY pyproject.toml uv.lock* ./
 
 RUN uv export --frozen --no-emit-project --no-hashes -o /tmp/requirements.txt \
@@ -50,7 +50,7 @@ ARG BACKEND
 RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-RUN pip install --no-cache-dir uv==0.11.25
+RUN pip install --no-cache-dir uv==0.11.26
 COPY pyproject.toml uv.lock* ./
 
 RUN if [ "$BACKEND" != "fs" ]; then \

--- a/genai-engine/Dockerfile_changelog
+++ b/genai-engine/Dockerfile_changelog
@@ -14,7 +14,7 @@ WORKDIR /app
 COPY . /app/genai-engine/
 
 # Install uv
-RUN pip3 install uv==0.11.25
+RUN pip3 install uv==0.11.26
 
 # Set environment variables
 ENV PYTHONPATH="$PYTHONPATH:/app/genai-engine/src"

--- a/genai-engine/dockerfile
+++ b/genai-engine/dockerfile
@@ -15,7 +15,7 @@ COPY pyproject.toml /app/
 COPY uv.lock /app/
 
 # Install Python dependencies
-RUN pip3 install uv==0.11.25
+RUN pip3 install uv==0.11.26
 # Set working directory
 WORKDIR /app
 

--- a/ml-engine/Dockerfile
+++ b/ml-engine/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=linux/amd64 python:3.13-slim-bookworm AS install
 # (libssl3, libc6, libexpat1, ...). These libraries live in /usr/lib and are
 # copied into the distroless final image below, so upgrading here patches the
 # shared objects that actually ship.
-RUN pip install uv==0.11.25 && \
+RUN pip install uv==0.11.26 && \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y wget curl gnupg apt-transport-https && \

--- a/security/vex/openvex.json
+++ b/security/vex/openvex.json
@@ -4,8 +4,8 @@
   "author": "Arthur Security <security@arthur.ai>",
   "role": "Document Creator",
   "timestamp": "2026-07-28T00:00:00.000000000-00:00",
-  "version": 5,
-  "_comment": "Scope: HIGH/CRITICAL CVEs a container-image re-scan still reports for the genai-engine, ml-engine and genai-engine-models-* images, but which are remediated in the shipped binary (the apt-upgraded library is copied over the distroless base, whose stale dpkg metadata the scanner reads) or are not in the execute path. Fully remediated CVEs are intentionally excluded: python3.11 is removed from every image (its dpkg metadata deleted), litellm/langsmith/msgpack are upgraded past their advisories, and nltk is upgraded to 3.10.0 (fixes CVE-2026-54293, GHSA-p4gq-832x-fm9v). See genai-engine/dockerfile, ml-engine/Dockerfile, deployment/model-upload/Dockerfile and PR #1851.",
+  "version": 6,
+  "_comment": "Scope: HIGH/CRITICAL CVEs a container-image re-scan still reports for the genai-engine, ml-engine and genai-engine-models-* images, but which are remediated in the shipped binary (the apt-upgraded library is copied over the distroless base, whose stale dpkg metadata the scanner reads) or are not in the execute path. Fully remediated CVEs are intentionally excluded: python3.11 is removed from every image (its dpkg metadata deleted), litellm/langsmith/msgpack are upgraded past their advisories, nltk is upgraded to 3.10.0 (fixes CVE-2026-54293, GHSA-p4gq-832x-fm9v), uv is upgraded 0.11.25 -> 0.11.26 (bundles quinn-proto 0.11.15, fixing GHSA-4w2j-m93h-cj5j / RUSTSEC-2026-0185), and pyasn1 is upgraded to 0.6.4 (fixes CVE-2026-59885/59886) in deployment/model-upload/uv.lock and genai-engine/uv.lock — the models-gcs 0.6.3 finding is a stale pre-bump :latest artifact that clears on rebuild. See genai-engine/dockerfile, ml-engine/Dockerfile, deployment/model-upload/Dockerfile and PR #1851.",
   "statements": [
     {
       "_comment": "libssl3: the shipped libssl.so.3/libcrypto.so.3 is OpenSSL 3.0.20 (deb 3.0.20-1~deb12u2), copied from the apt-upgraded *-slim-bookworm build stage over the distroless base. Scanners read stale dpkg metadata (3.0.19-1~deb12u2) inherited from the distroless base. The shipped binary contains the fix. The genai-engine-models-s3/-fs images do the same via deployment/model-upload/Dockerfile.",
@@ -412,6 +412,127 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local (deployment/model-upload/Dockerfile); the inherited system 3.11 is removed and never executed. A Debian fix exists but is moot — the package is removed, not upgraded, in these images.",
       "timestamp": "2026-06-27T00:00:00Z"
+    },
+    {
+      "_comment": "krb5: the shipped libgssapi-krb5-2/libk5crypto3/libkrb5-3/libkrb5support0 are krb5 1.20.1-2+deb12u5 (the bookworm/bookworm-security fix), copied from the apt-upgraded *-slim-bookworm build stage over the distroless base. Scanners read stale dpkg metadata (1.20.1-2+deb12u4) inherited from the distroless base; the shipped binary contains the fix. Not flagged on genai-engine-models-gcs, which apt-upgrades the slim runtime in place (fresh metadata). CVE-2026-40355 is a NULL-pointer-dereference DoS in the GSS-API NegoEx acceptor (gss_accept_sec_context).",
+      "vulnerability": { "name": "CVE-2026-40355" },
+      "products": [
+        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
+        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
+        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
+        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
+        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] }
+      ],
+      "status": "fixed"
+    },
+    {
+      "_comment": "krb5 — shipped binaries are krb5 1.20.1-2+deb12u5 (bookworm fix); reported version is stale distroless dpkg metadata (1.20.1-2+deb12u4). CVE-2026-40356 is an integer-underflow / out-of-bounds-read DoS in the GSS-API NegoEx acceptor (gss_accept_sec_context).",
+      "vulnerability": { "name": "CVE-2026-40356" },
+      "products": [
+        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
+        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
+        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
+        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
+        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] }
+      ],
+      "status": "fixed"
+    },
+    {
+      "_comment": "libexpat1: CVE-2026-56131 is a use-after-free reachable only through an XML_ResumeParser suspend/resume flow on a policy violation; no Debian bookworm fix is available (bookworm/bookworm-security ship 2.5.0-1+deb12u2, still vulnerable; fixed upstream in expat 2.8.2, only in sid). The system libexpat1 is not loaded by the application: CPython 3.12/3.13 bundle their own expat statically and do not link /usr/lib/*/libexpat.so.1, and the only base-image consumer (Python 3.11) has been removed. The engines expose JSON/HTTP APIs and never parse attacker-controlled XML through the system libexpat. Owner: security@arthur.ai. Review by: 2027-01-28.",
+      "vulnerability": { "name": "CVE-2026-56131" },
+      "products": [
+        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-56131 (use-after-free via XML_ResumeParser in libexpat < 2.8.2) is reachable only by parsing attacker-controlled XML through the system libexpat1. That library is not loaded by the application: CPython 3.12/3.13 bundle their own expat statically and do not link /usr/lib/*/libexpat.so.1, and the only base-image consumer (Python 3.11) has been removed. No Debian bookworm fix is available yet (fixed upstream in expat 2.8.2).",
+      "timestamp": "2026-07-28T00:00:00Z"
+    },
+    {
+      "_comment": "libexpat1: CVE-2026-56407 is an integer overflow (CWE-190) in doProlog/storeEntityValue; no Debian bookworm fix is available (fixed upstream in expat 2.8.2, only in sid). The system libexpat1 is not loaded by the application (CPython bundles expat statically; the only base-image consumer, Python 3.11, has been removed) and the engines never parse attacker-controlled XML through it. DoS-class. Owner: security@arthur.ai. Review by: 2027-01-28.",
+      "vulnerability": { "name": "CVE-2026-56407" },
+      "products": [
+        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-56407 (integer overflow in doProlog/storeEntityValue in libexpat < 2.8.2, DoS-class) is reachable only by parsing attacker-controlled XML through the system libexpat1, which the application does not load (CPython bundles expat statically; the base-image Python 3.11 consumer is removed). No Debian bookworm fix is available yet (fixed upstream in expat 2.8.2).",
+      "timestamp": "2026-07-28T00:00:00Z"
+    },
+    {
+      "_comment": "libexpat1: CVE-2026-56408 is an integer overflow (CWE-190) in copyString; no Debian bookworm fix is available (fixed upstream in expat 2.8.2, only in sid). The system libexpat1 is not loaded by the application (CPython bundles expat statically; the only base-image consumer, Python 3.11, has been removed) and the engines never parse attacker-controlled XML through it. DoS-class. Owner: security@arthur.ai. Review by: 2027-01-28.",
+      "vulnerability": { "name": "CVE-2026-56408" },
+      "products": [
+        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
+        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-56408 (integer overflow in copyString in libexpat < 2.8.2, DoS-class) is reachable only by parsing attacker-controlled XML through the system libexpat1, which the application does not load (CPython bundles expat statically; the base-image Python 3.11 consumer is removed). No Debian bookworm fix is available yet (fixed upstream in expat 2.8.2).",
+      "timestamp": "2026-07-28T00:00:00Z"
+    },
+    {
+      "_comment": "util-linux (libblkid1 and sibling packages): CVE-2026-53615 is an integer overflow in libblkid's DOS/MBR partition parser (partitions/dos.c, parse_dos_extended); no Debian bookworm fix is available (bookworm ships 2.38.1-5+deb12u3, still vulnerable; Debian bug #1140197). Triggering requires libblkid to probe an attacker-controlled block device / disk image / partition table. These images never probe disks or mount untrusted media — the engines are network services and the model-upload job only downloads model files and writes to cloud storage / a mounted volume. Subcomponents are name-only so the statement matches whichever util-linux binary packages a given image ships (distroless images carry only libuuid1; the slim models-gcs runtime carries the full set). Owner: security@arthur.ai. Review by: 2027-01-28.",
+      "vulnerability": { "name": "CVE-2026-53615" },
+      "products": [
+        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libblkid1" }, { "@id": "pkg:deb/debian/libmount1" }, { "@id": "pkg:deb/debian/libsmartcols1" }, { "@id": "pkg:deb/debian/libuuid1" }, { "@id": "pkg:deb/debian/bsdutils" }, { "@id": "pkg:deb/debian/mount" }, { "@id": "pkg:deb/debian/util-linux" }, { "@id": "pkg:deb/debian/util-linux-extra" } ] },
+        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libblkid1" }, { "@id": "pkg:deb/debian/libmount1" }, { "@id": "pkg:deb/debian/libsmartcols1" }, { "@id": "pkg:deb/debian/libuuid1" }, { "@id": "pkg:deb/debian/bsdutils" }, { "@id": "pkg:deb/debian/mount" }, { "@id": "pkg:deb/debian/util-linux" }, { "@id": "pkg:deb/debian/util-linux-extra" } ] },
+        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libblkid1" }, { "@id": "pkg:deb/debian/libmount1" }, { "@id": "pkg:deb/debian/libsmartcols1" }, { "@id": "pkg:deb/debian/libuuid1" }, { "@id": "pkg:deb/debian/bsdutils" }, { "@id": "pkg:deb/debian/mount" }, { "@id": "pkg:deb/debian/util-linux" }, { "@id": "pkg:deb/debian/util-linux-extra" } ] },
+        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libblkid1" }, { "@id": "pkg:deb/debian/libmount1" }, { "@id": "pkg:deb/debian/libsmartcols1" }, { "@id": "pkg:deb/debian/libuuid1" }, { "@id": "pkg:deb/debian/bsdutils" }, { "@id": "pkg:deb/debian/mount" }, { "@id": "pkg:deb/debian/util-linux" }, { "@id": "pkg:deb/debian/util-linux-extra" } ] },
+        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libblkid1" }, { "@id": "pkg:deb/debian/libmount1" }, { "@id": "pkg:deb/debian/libsmartcols1" }, { "@id": "pkg:deb/debian/libuuid1" }, { "@id": "pkg:deb/debian/bsdutils" }, { "@id": "pkg:deb/debian/mount" }, { "@id": "pkg:deb/debian/util-linux" }, { "@id": "pkg:deb/debian/util-linux-extra" } ] },
+        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/libblkid1" }, { "@id": "pkg:deb/debian/libmount1" }, { "@id": "pkg:deb/debian/libsmartcols1" }, { "@id": "pkg:deb/debian/libuuid1" }, { "@id": "pkg:deb/debian/bsdutils" }, { "@id": "pkg:deb/debian/mount" }, { "@id": "pkg:deb/debian/util-linux" }, { "@id": "pkg:deb/debian/util-linux-extra" } ] }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-53615 is an integer overflow in libblkid's DOS/MBR partition-table parser (partitions/dos.c). It is reachable only when libblkid probes an attacker-controlled block device, disk image, or partition table. These images never probe disks or mount untrusted media: the engines are network services and the model-upload job only downloads model files and writes them to cloud storage / a mounted volume. No Debian bookworm fix is available yet.",
+      "timestamp": "2026-07-28T00:00:00Z"
+    },
+    {
+      "_comment": "libacl1: CVE-2026-54369 is a symlink-traversal privilege escalation in libacl's pathname-based functions (acl_get_file/acl_set_file/acl_extended_file/acl_delete_def_file follow symlinks); no Debian bookworm fix is available (bookworm ships acl 2.3.1-3, no-dsa/postponed; fixed upstream in acl 2.4.0). Exploitation requires a local unprivileged attacker racing a higher-privileged process that operates on ACLs of attacker-controllable paths. The models-gcs image runs a single non-interactive Python entrypoint (upload_models.py) as one user with no other local users and performs no ACL operations on untrusted paths. Owner: security@arthur.ai. Review by: 2027-01-28.",
+      "vulnerability": { "name": "CVE-2026-54369" },
+      "products": [
+        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/libacl1" } ] }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-54369 is a local symlink-traversal privilege escalation in libacl's pathname-based functions. It requires a local unprivileged attacker and a higher-privileged process performing ACL operations on attacker-controllable paths. The models-gcs image runs a single non-interactive Python entrypoint (upload_models.py) as one user, has no other local users, and performs no ACL operations on untrusted paths. No Debian bookworm fix is available yet (fixed upstream in acl 2.4.0).",
+      "timestamp": "2026-07-28T00:00:00Z"
+    },
+    {
+      "_comment": "gzip: CVE-2026-41992 is a global buffer overflow (OOB read) from improperly reused global state between the LZW and LZH decoders in a single gzip invocation; no Debian bookworm fix is available (bookworm ships gzip 1.12-1, no-dsa/postponed). Triggering requires feeding gzip a crafted LZW file followed by a crafted LZH file in one command. The models-gcs image never invokes gzip on attacker-controlled .lzw/.lzh archives — the upload job downloads model files and writes them to cloud storage. gzip is a transitive base-OS package. Owner: security@arthur.ai. Review by: 2027-01-28.",
+      "vulnerability": { "name": "CVE-2026-41992" },
+      "products": [
+        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/gzip" } ] }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-41992 is an out-of-bounds read from reused global state between gzip's LZW and LZH decoders, triggered only by decompressing a crafted LZW file followed by a crafted LZH file in a single gzip invocation. The models-gcs image never invokes gzip on attacker-controlled archives; gzip is a transitive base-OS package and the upload job only downloads model files and writes them to cloud storage. No Debian bookworm fix is available yet.",
+      "timestamp": "2026-07-28T00:00:00Z"
+    },
+    {
+      "_comment": "perl-base: CVE-2026-57432 is an integer overflow in S_measure_struct (pack/unpack template with large repeat counts) causing an out-of-bounds heap read; no Debian bookworm fix is available (bookworm ships perl 5.36.0-7+deb12u3, no-dsa; fixed upstream in sid 5.42.2-3). perl-base is a transitive base-OS package on the models-gcs image; no Arthur process invokes the Perl interpreter, and no attacker-controlled pack/unpack template is ever executed. The upload job runs a single Python entrypoint (upload_models.py). Owner: security@arthur.ai. Review by: 2027-01-28.",
+      "vulnerability": { "name": "CVE-2026-57432" },
+      "products": [
+        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/perl-base" } ] }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "CVE-2026-57432 is an integer overflow in Perl's S_measure_struct (pack/unpack of a template with large repeat counts) causing an out-of-bounds heap read. It is reachable only when the Perl interpreter runs an attacker-controlled pack/unpack template. perl-base is a transitive base-OS package on the models-gcs image; no Arthur process invokes Perl, and the upload job runs a single Python entrypoint (upload_models.py). No Debian bookworm fix is available yet.",
+      "timestamp": "2026-07-28T00:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
Triages **every open HIGH finding** in the GitHub **Security → Code scanning** tab (`trivy-*` categories) to a documented position per [`security/README.md`](../blob/dev/security/README.md) — remediate if a fix exists, otherwise justify via a VEX statement. Each CVE was verified against the **Debian security tracker** + upstream advisories (not inferred).

## Remediated (real fixes)

| Finding | Package | Fix |
| --- | --- | --- |
| **GHSA-4w2j-m93h-cj5j** / RUSTSEC-2026-0185 (quinn-proto remote memory exhaustion) | `uv`/`uvx` binary | Bump `uv 0.11.25 → 0.11.26` in all Dockerfiles — 0.11.26 bundles the patched quinn-proto 0.11.15. `uv`/`uvx` ship into the distroless images via `/usr/local/bin`. (uv doesn't enable reqwest's `http3`/QUIC feature, so quinn was unreachable regardless — this clears it cleanly.) |
| **CVE-2026-59885 / 59886** (pyasn1 DoS) | `pyasn1` | Already fixed by the `0.6.4` bump (#2014) in `model-upload/uv.lock` + `genai-engine/uv.lock`. The models-gcs `0.6.3` alert is a stale pre-bump `:latest` artifact that clears on the next rebuild — no new change needed. |

Dockerfiles touched: `genai-engine/dockerfile`, `ml-engine/Dockerfile`, `deployment/model-upload/Dockerfile` (2 stages), `genai-engine/Dockerfile_changelog`.

## Justified via VEX (`security/vex/openvex.json`, v5 → v6)

**`status: fixed`** — bookworm has the fix; distroless ships the apt-upgraded `.so`, only stale distroless dpkg metadata trips the scanner (same pattern as the existing libssl3/libc6 entries):
- **krb5 CVE-2026-40355 / 40356** (`libgssapi-krb5-2`, `libk5crypto3`, `libkrb5-3`, `libkrb5support0`) — fixed in `1.20.1-2+deb12u5`. cpu/gpu/ml/s3/fs. Not on models-gcs (apt-upgrades in place).

**`status: not_affected` / `vulnerable_code_not_in_execute_path`** — no bookworm fix exists, and each needs an attack surface these images don't expose:
- **libexpat CVE-2026-56131 / 56407 / 56408** — never parse untrusted XML through system libexpat (CPython bundles expat statically).
- **util-linux/libblkid CVE-2026-53615** — never probe untrusted disks / partition tables.
- **acl CVE-2026-54369** — no local untrusted users / privileged ACL ops on attacker paths.
- **gzip CVE-2026-41992** — never decompress untrusted `.lzw`/`.lzh` archives.
- **perl CVE-2026-57432** — Perl interpreter is never invoked (single Python entrypoint).

## Coverage & validation
- All **12 open HIGH findings** covered: 9 VEX'd, 3 remediated via bumps. None uncovered.
- OpenVEX document validated (justifications + product purls) and **parses under Trivy 0.71.2**.
- Subcomponent purls are **name-only** per the repo's drift rule.
- Full suppression match runs in CI on image rebuild (needs the built images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)