### PR TITLE
security: bump hf-xet 1.5.2 to fix vendored quinn-proto (follow-up to #2034)

### DIFF
--- a/genai-engine/pyproject.toml
+++ b/genai-engine/pyproject.toml
@@ -103,13 +103,11 @@ linters = [
 [tool.uv]
 exclude-newer = "3 days"
 exclude-newer-package = { torch = false, arthur-common = false, arthur-client = false }
-# Security: pin transitive hf-xet (its wheel vendors Rust crates) to >=1.5.1, which bundles
-# rustls-webpki 0.103.13 — fixing RUSTSEC-2026-0104 (HIGH: DoS panic in CRL parsing).
-# Accepted exception: hf-xet 1.5.1 still vendors quinn-proto 0.11.14 (RUSTSEC-2026-0185, HIGH:
-# remote memory exhaustion). No hf-xet release fixes it as of 2026-06-25 (xet-core main also pins
-# 0.11.14). Low risk here — hf-xet's QUIC is a client to HuggingFace's TLS-authenticated CAS
-# servers and the DoS needs a malicious QUIC peer. Re-bump hf-xet once upstream lands the fix.
-constraint-dependencies = ["hf-xet>=1.5.1"]
+# Security: pin transitive hf-xet (its wheel vendors Rust crates) to >=1.5.2, which bundles
+# rustls-webpki 0.103.13 (RUSTSEC-2026-0104, HIGH: DoS panic in CRL parsing) and quinn-proto
+# 0.11.15 (RUSTSEC-2026-0185 / CVE-2026-25800, HIGH: remote memory exhaustion). Both are fixed
+# as of hf-xet 1.5.2 (xet-core v1.5.2 bumped the vendored quinn-proto 0.11.14 -> 0.11.15).
+constraint-dependencies = ["hf-xet>=1.5.2"]
 
 [[tool.uv.index]]
 name = "PyPI"

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-26T07:22:37.951948Z"
+exclude-newer = "2026-07-26T07:40:15.375428Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -17,7 +17,7 @@ arthur-client = false
 torch = false
 
 [manifest]
-constraints = [{ name = "hf-xet", specifier = ">=1.5.1" }]
+constraints = [{ name = "hf-xet", specifier = ">=1.5.2" }]
 
 [[package]]
 name = "aiofiles"
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "arthur-genai-engine"
-version = "2.1.746"
+version = "2.1.747"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -1513,18 +1513,18 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.5.1"
+version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/39/67be8d71f900d9a55761b6022821d6679fb56c64f1b6063d5af2c2606727/hf_xet-1.5.2.tar.gz", hash = "sha256:73044bd31bae33c984af832d19c752a0dffb67518fee9ddbd91d616e1101cf47", size = 903674, upload-time = "2026-07-16T17:29:56.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
-    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
-    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
-    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ba/2b70603c7552db82baeb2623e2336898304a17328845151be4fe1f48d420/hf_xet-1.5.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f922b8f5fb84f1dd3d7ab7a1316354a1bca9b1c73ecfc19c76e51a2a49d29799", size = 4033760, upload-time = "2026-07-16T17:29:43.884Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/b097a86a1e4a6098f3a79382643ab09d5733d87ccc864877ad1e12b49b70/hf_xet-1.5.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:045f84440c55cdeb659cf1a1dd48c77bcd0d2e93632e2fea8f2c3bdee79f38ed", size = 3841438, upload-time = "2026-07-16T17:29:45.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/35/db860aa3a0780660324a506ad4b3d322ddc6ecbba4b9340aed0942cbf21c/hf_xet-1.5.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db78c39c83d6279daddc98e2238f373ab8980685556d42472b4ec51abcf03e8c", size = 4428006, upload-time = "2026-07-16T17:29:46.996Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/832dd980af4b0c3ae0660e309285f2ffcdff2faa38129390dbb47aa4a3f9/hf_xet-1.5.2-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7db73c810500c54c6760be8c39d4b2e476974de85424c50063efc22fdda13025", size = 4221099, upload-time = "2026-07-16T17:29:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/05/ae50f0d34e3254e6c3e208beb2519f6b8673016fc4b3643badaf6450d186/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6395cfe3c9cbead4f16b31808b0e67eac428b66c656f856e99636adaddea878f", size = 4420766, upload-time = "2026-07-16T17:29:50.092Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/c050bc2743a2bcd68928bfee157b08681667a164a24ec95fbfcfcd717e08/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cde8cd167126bb6109b2ceb19b844433a4988643e8f3e01dd9dd0e4a34535097", size = 4636716, upload-time = "2026-07-16T17:29:51.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/68b01c5c2edb56ac9a67b3d076ffddcb90867abaee923923eb34e7a14e76/hf_xet-1.5.2-cp38-abi3-win_amd64.whl", hash = "sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65", size = 3988373, upload-time = "2026-07-16T17:29:53.395Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c6/988383e9dc17294d536fcbcd6fd16eed882e411ad16c954984a53e47b09c/hf_xet-1.5.2-cp38-abi3-win_arm64.whl", hash = "sha256:1da28519496eb7c8094c11e4d25509b4a468457a0302d58136099db2fd9a671d", size = 3816957, upload-time = "2026-07-16T17:29:54.991Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Follow-up to #2034. That PR (torch 2.13.0 + uv 0.12.0) was **squash-merged without the hf-xet commit**, so `dev` still pins `hf-xet>=1.5.1`. This PR lands the remaining quinn-proto fix.

## Context: there are two copies of quinn-proto in the image
| Copy | Status |
|---|---|
| Inside the **`uv` binary** | Already 0.11.15 (fixed); handled by #2034's uv 0.12.0 bump. ✅ |
| Vendored inside the **`hf-xet` wheel** | Was **0.11.14** (vulnerable) — the accepted exception in `pyproject.toml`. **This PR.** |

## Change: hf-xet `1.5.1` → `1.5.2`
- hf-xet 1.5.1 vendored quinn-proto **0.11.14** (RUSTSEC-2026-0185 / CVE-2026-25800, HIGH: remote memory exhaustion).
- **xet-core `v1.5.2` bumped it to 0.11.15**, so hf-xet 1.5.2 fixes it — the upstream fix the `pyproject.toml` comment was waiting for ("Re-bump hf-xet once upstream lands the fix").
- `rustls-webpki` stays at 0.103.13, so RUSTSEC-2026-0104 remains fixed (verified in xet-core v1.5.2's Cargo.lock).
- Replaces the accepted exception with an actual fix; updates the security comment accordingly.

Both quinn-proto copies are now on the fixed 0.11.15.

## Validation
- hf-xet-only lock diff (+ a stale project-version correction 2.1.746→2.1.747); `uv lock --check` passes; no package churn.
- hf-xet 1.5.2 imports cleanly with huggingface-hub / torch 2.13.0 / transformers / sentence-transformers (validated on #2034's branch — identical bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)