### PR TITLE
ci: skip Claude Code Review when Renovate is the triggering actor

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,9 +12,18 @@ on:
 
 jobs:
   claude-review:
-    # Skip only for Renovate PRs so the job is skipped, not failed
-    # GitHub App bots use login 'renovate[bot]'; legacy/self-hosted may use 'renovate'
-    if: github.event.pull_request.user.login != 'renovate' && github.event.pull_request.user.login != 'renovate[bot]'
+    # Skip only for Renovate PRs so the job is skipped, not failed.
+    # GitHub App bots use login 'renovate[bot]'; legacy/self-hosted may use 'renovate'.
+    # Check both the PR author AND the triggering actor: Renovate can rebase/synchronize
+    # a PR opened by another bot (e.g. the version-bump app), which makes github.actor
+    # 'renovate[bot]' while pull_request.user.login stays the original author. The
+    # claude-code-action gates on the triggering actor, so guarding only on the author
+    # lets the job run and then fail with "Workflow initiated by non-human actor: renovate".
+    if: >-
+      github.event.pull_request.user.login != 'renovate' &&
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.actor != 'renovate' &&
+      github.actor != 'renovate[bot]'
 
     # Optional: Filter by PR author
     # if: |


### PR DESCRIPTION
## Problem

The **Claude Code Review** workflow fails on runs like [this one](https://github.com/arthur-ai/arthur-engine/actions/runs/30427752708/job/90497839270) with:

> `Action failed with error: Workflow initiated by non-human actor: renovate (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`

This is a **bot-gating mismatch**, not a code failure. The workflow has two gates that look at *different* signals:

| Gate | Signal checked | Value for the failing run |
| --- | --- | --- |
| Job-level `if` | `pull_request.user.login` (PR **author**) | `arthur-github-automator-app[bot]` — allowed, so job did **not** skip |
| `claude-code-action` `allowed_bots` | `github.actor` (**triggering actor**) | `renovate[bot]` — not allowed, so action **failed** |

The failing PR (#2026, "Increment arthur-engine version") was *opened* by the version-bump automator app, but this run was a `synchronize` event **triggered by Renovate** (it rebased the branch). The `if` guard only checked the author, so the job ran and then the action failed on the triggering actor.

## Fix

Extend the job-level `if` in `.github/workflows/claude-code-review.yml` to also skip when `github.actor` is `renovate` / `renovate[bot]`. This matches the file's stated intent — *"skip Renovate PRs so the job is skipped, not failed"* — so Renovate-triggered runs are cleanly **skipped** rather than failing red.

Human PRs and automator-app PRs are unaffected: their author and triggering actor are unchanged, so reviews still run as before.

Note: I intentionally did **not** add `renovate` to `allowed_bots`, since that would *run* reviews on every Renovate PR (burning API tokens) — the opposite of the documented intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)