### PR TITLE
ci: enable dev merge queue support + reconcile Renovate for throughput

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -13,6 +13,12 @@ on:
     branches:
       - main
       - dev
+  # Required for the `dev` merge queue: GitHub runs the required checks on a
+  # temporary `gh-readonly-queue/dev/...` branch via the merge_group event.
+  # Without this trigger the queue would never see the checks and would stall.
+  merge_group:
+    branches:
+      - dev
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -160,18 +166,20 @@ jobs:
     if: |
       (
         github.event_name == 'pull_request' ||
+        github.event_name == 'merge_group' ||
         (github.event_name == 'push' && github.ref_type == 'branch')
       ) &&
       github.ref != 'refs/heads/main' &&
       github.ref != 'refs/heads/dev'
     runs-on: ubuntu-latest
     outputs:
-      backend: ${{ steps.changes.outputs.backend }}
-      ui: ${{ steps.changes.outputs.ui }}
+      backend: ${{ steps.decide.outputs.backend }}
+      ui: ${{ steps.decide.outputs.ui }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v2
         id: changes
+        if: github.event_name != 'merge_group'
         with:
           filters: |
             ui:
@@ -193,34 +201,61 @@ jobs:
               - 'genai-engine/Dockerfile*'
               - 'genai-engine/docker-compose.yml'
               - 'arthur-observability-sdk/**'
+      # In the merge queue there is no PR base to diff against, and paths-filter's
+      # base detection is unreliable on merge_group. Run the full required suite as
+      # the final pre-merge gate instead of trying to narrow it by path.
+      - name: Decide affected areas
+        id: decide
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            echo "ui=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "backend=${{ steps.changes.outputs.backend }}" >> "$GITHUB_OUTPUT"
+            echo "ui=${{ steps.changes.outputs.ui }}" >> "$GITHUB_OUTPUT"
+          fi
 
   check-ml-engine-changes:
     if: |
       (
         github.event_name == 'pull_request' ||
+        github.event_name == 'merge_group' ||
         (github.event_name == 'push' && github.ref_type == 'branch')
       ) &&
       github.ref != 'refs/heads/main' &&
       github.ref != 'refs/heads/dev'
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.changes.outputs.changed }}
+      changed: ${{ steps.decide.outputs.changed }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v2
         id: changes
+        if: github.event_name != 'merge_group'
         with:
           filters: |
             changed:
               - 'ml-engine/**'
               - 'arthur-observability-sdk/**'
               - 'genai-engine/staging.openapi.json'
+      # In the merge queue, run the full required suite (see note above).
+      - name: Decide affected areas
+        id: decide
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=${{ steps.changes.outputs.changed }}" >> "$GITHUB_OUTPUT"
+          fi
 
   run-genai-engine-ui-lint:
     needs: check-genai-engine-changes
     if: |
       (
         github.event_name == 'pull_request' ||
+        github.event_name == 'merge_group' ||
         (github.event_name == 'push' && github.ref_type == 'branch')
       ) &&
       github.ref != 'refs/heads/main' &&
@@ -274,6 +309,7 @@ jobs:
     if: |
       (
         github.event_name == 'pull_request' ||
+        github.event_name == 'merge_group' ||
         (github.event_name == 'push' && github.ref_type == 'branch')
       ) &&
       github.ref != 'refs/heads/main' &&

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "minimumReleaseAge": "3 days",
-  "schedule": ["* 0-4 * * *"],
-  "automergeSchedule": ["* 0-4 * * *"],
+  "rebaseWhen": "conflicted",
   "timezone": "America/New_York",
   "enabledManagers": ["npm", "pep621", "dockerfile", "docker-compose", "custom.regex"],
   "includePaths": [
@@ -18,7 +17,7 @@
     "**/docker-compose*.yaml"
   ],
   "osvVulnerabilityAlerts": true,
-  "prConcurrentLimit": 20,
+  "prConcurrentLimit": 10,
   "prHourlyLimit": 6,
   "vulnerabilityAlerts": {
     "labels": ["security"]
@@ -44,6 +43,16 @@
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "autoApprove": true
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm minor and patch"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python minor and patch"
     },
     {
       "matchManagers": ["pep621"],


### PR DESCRIPTION
## Why

Renovate auto-merge is **not** broken — ~90 commits (many Renovate auto-merges) landed on `dev` in the last 7 days. But approved dep PRs **starve**: the `dev-branch-ruleset` requires branches be up to date before merging (`strict_required_status_checks_policy: true`), so the moment any PR merges — or the version-bump / main→dev-sync automation pushes to `dev` — **every other open PR goes `BEHIND` again**. Each PR then needs a full rebase → re-run all required CI → re-approve, and Renovate only rebases inside a 4-hour nightly window. Only a handful clear per night, so a backlog of `BEHIND` PRs persists (evidence: some PRs carry 8–10 stacked dismissed `renovate-approve` reviews yet never merged).

The fix is a **GitHub merge queue on `dev`** (enabled separately in ruleset settings — see below), plus the CI and Renovate changes in this PR that make the queue safe and stop Renovate fighting the clock.

## Changes

### CI — `.github/workflows/arthur-engine-workflow.yml`
- Add a **`merge_group`** trigger for `dev`. Without it, the merge queue would never see the required checks and would stall.
- `check-genai-engine-changes` / `check-ml-engine-changes` now run on `merge_group` and emit `true` for all outputs (paths-filter has no reliable base to diff against in a queue), so the **full** required suite runs as the final pre-merge gate.
- Allow `merge_group` in the `run-genai-engine-ui-lint` and `run-genai-engine-unit-tests` guards. The other four required jobs gate only on the detection outputs and run automatically.
- Build/deploy jobs remain gated on the `Increment arthur-engine version` commit message (false on `merge_group`), so nothing heavy runs in the queue.

### Renovate — `renovate.json`
- Remove `schedule` + `automergeSchedule` (the 4-hour window was the throughput cap; the queue now handles up-to-dateness any time of day). Keep `minimumReleaseAge: 3 days`.
- `prConcurrentLimit` 20 → 10 to trim lockfile-conflict churn.
- Group npm and pep621 minor/patch into two PRs (they inherit `automerge` + `autoApprove`; the existing `langchain + openai` group still wins for its packages).
- `rebaseWhen: "conflicted"` so Renovate doesn't rebase every PR on each `dev` move — the queue does the final rebase.

## ⚠️ Required follow-up (order matters)

Enable the merge queue **after** this PR merges to `dev`. Merge-queue events run the workflow from the **base** branch, so the `merge_group` handling must already be on `dev`, otherwise the first queued PR runs the old workflow, no required checks report, and the queue stalls.

On the `dev-branch-ruleset` (id `7855890`):
1. Enable **Require merge queue** (merge method: **Squash**).
2. Set **`strict_required_status_checks_policy: false`** (turn off "require branches up to date" — redundant and contradictory with a merge queue).
3. Keep the same 6 required status checks.

## Verification
- This PR runs as a normal `pull_request`; the `merge_group` paths only activate once on `dev`.
- After enabling the queue: queue one approved Renovate PR, confirm a `gh-readonly-queue/dev/...` branch appears, the 6 checks run green on it, and it merges without a manual rebase.
- Confirm major-update PRs (Node 24, litellm, langchain-openai, framer-motion→motion) remain `REVIEW_REQUIRED` — unchanged and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)