### PR TITLE
security: patch base /lib libraries and report true OS package versions

### DIFF
--- a/deployment/model-upload/Dockerfile
+++ b/deployment/model-upload/Dockerfile
@@ -15,6 +15,12 @@
 
 ARG BACKEND=s3
 
+# The distroless base is referenced here so the builder stage can read the dpkg
+# metadata it ships (see the status.d sync at the end of that stage), in addition to
+# the runtime-s3/runtime-fs stages below. The same tag resolves to the same digest
+# within one build, so this adds a metadata read, not a second base image.
+FROM gcr.io/distroless/python3-debian12:nonroot AS distroless_meta
+
 # =============================================================================
 # Stage 1: Download models (shared across all backends)
 # =============================================================================
@@ -71,6 +77,65 @@ RUN if [ "$BACKEND" != "fs" ]; then \
            -r /tmp/requirements.txt; \
     fi
 
+# Patch the libraries the distroless base keeps in /lib. Unlike bookworm, the base
+# is NOT merged-/usr: /lib is a real directory holding glibc (libc.so.6, libm,
+# libpthread, libnss_*, and the ELF interpreter that /lib64 symlinks to) plus
+# liblzma, libexpat, libgcc_s, libbz2, libcom_err, libcrypt, libkeyutils,
+# libncursesw and libreadline. `COPY --from=builder /usr/lib /usr/lib` in the
+# distroless runtimes does not reach any of them, so they stayed at the base's
+# versions in every image shipped so far — the libc6 and liblzma5 CVEs scanners
+# report against them are real, not stale metadata. (The libssl3 and krb5 objects do
+# live under /usr/lib and were genuinely being patched.)
+#
+# Mirror the base's /lib layout using this stage's apt-upgraded libraries. Only
+# paths the base already has are emitted, so this replaces files rather than adding
+# any, and the base's layout is preserved. In this stage /lib is a symlink to
+# /usr/lib, hence the /usr/lib source path.
+COPY --from=distroless_meta /lib /tmp/base-lib
+RUN set -eu; \
+    out=/tmp/patched-lib; rm -rf "$out"; mkdir -p "$out"; \
+    cd /tmp/base-lib; \
+    find . -mindepth 1 \( -type f -o -type l \) -print | while IFS= read -r p; do \
+      rel="${p#./}"; src="/usr/lib/${rel}"; \
+      { [ -e "$src" ] || [ -L "$src" ]; } || continue; \
+      mkdir -p "$out/$(dirname "$rel")"; \
+      cp -a "$src" "$out/$rel"; \
+      echo "  /lib patch: ${rel}"; \
+    done
+
+# Rewrite the distroless base's dpkg metadata to the package versions this stage
+# actually installed. With the /lib mirror above and `COPY /usr/lib` in the
+# distroless runtimes, the base's shared objects are replaced by the apt-upgraded
+# ones from bookworm-security, but the base's /var/lib/dpkg/status.d keeps
+# advertising the versions it was built with. Scanners resolve OS-package CVEs from
+# that metadata (Wiz reports these as `detectionMethod: PACKAGE`), so they flag
+# already-fixed CVEs against libssl3/libkrb5* indefinitely and block downstream
+# image-policy gates — the situation security/vex/openvex.json documents.
+#
+# Only packages that this stage has installed AND that ship a shared object under
+# /lib|/usr/lib/<triplet>/ are synced: those, and only those, are the files the two
+# copies overwrite, so the synced version is what genuinely ships. (Both prefixes
+# are matched because bookworm packages are split between them.) Packages the base
+# ships but this stage lacks keep their original version — their files survive
+# untouched. md5sums are refreshed from this stage's dpkg database so the checksums
+# describe the files that actually ship.
+COPY --from=distroless_meta /var/lib/dpkg/status.d /tmp/base-status.d
+RUN set -eu; \
+    out=/tmp/dpkg-status.d; \
+    rm -rf "$out"; cp -a /tmp/base-status.d "$out"; \
+    for f in "$out"/*; do \
+      pkg="${f##*/}"; \
+      case "$pkg" in *.md5sums) continue ;; esac; \
+      dpkg-query -L "$pkg" 2>/dev/null | grep -qE '^(/usr)?/lib/[^/]*-linux-gnu/.*\.so' || continue; \
+      ver="$(dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null)" || continue; \
+      [ -n "$ver" ] || continue; \
+      sed -i "s/^Version: .*/Version: ${ver}/" "$f"; \
+      if [ -f "/var/lib/dpkg/info/${pkg}.md5sums" ]; then \
+        cp "/var/lib/dpkg/info/${pkg}.md5sums" "${f}.md5sums"; \
+      fi; \
+      echo "  dpkg-status sync: ${pkg} -> ${ver}"; \
+    done
+
 # =============================================================================
 # Runtime: ECS / S3  (distroless)
 # =============================================================================
@@ -81,7 +146,13 @@ FROM gcr.io/distroless/python3-debian12:nonroot AS runtime-s3
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /usr/local/lib/ /usr/local/lib/
 COPY --from=builder /usr/lib /usr/lib
+# The base keeps real glibc/liblzma/libexpat/... files in /lib (it is not
+# merged-/usr), which the /usr/lib copy above does not reach. See builder stage.
+COPY --from=builder /tmp/patched-lib /lib
 COPY --from=builder /etc/ld.so.cache /etc/ld.so.cache
+# dpkg metadata corrected to match the shared objects copied above (see builder stage).
+# Must precede the python3.11 cleanup below, which deletes three of these stanzas.
+COPY --from=builder /tmp/dpkg-status.d /var/lib/dpkg/status.d
 
 # Remove the unused Python 3.11 runtime inherited from the distroless base so it
 # neither ships nor trips scanners (CVE-2025-8194, CVE-2025-13836). The job runs on
@@ -124,7 +195,13 @@ FROM gcr.io/distroless/python3-debian12:nonroot AS runtime-fs
 COPY --from=builder /usr/local/bin/ /usr/local/bin/
 COPY --from=builder /usr/local/lib/ /usr/local/lib/
 COPY --from=builder /usr/lib /usr/lib
+# The base keeps real glibc/liblzma/libexpat/... files in /lib (it is not
+# merged-/usr), which the /usr/lib copy above does not reach. See builder stage.
+COPY --from=builder /tmp/patched-lib /lib
 COPY --from=builder /etc/ld.so.cache /etc/ld.so.cache
+# dpkg metadata corrected to match the shared objects copied above (see builder stage).
+# Must precede the python3.11 cleanup below, which deletes three of these stanzas.
+COPY --from=builder /tmp/dpkg-status.d /var/lib/dpkg/status.d
 
 # Remove the unused Python 3.11 runtime inherited from the distroless base (see s3 stage).
 USER root

--- a/deployment/model-upload/Dockerfile
+++ b/deployment/model-upload/Dockerfile
@@ -117,8 +117,16 @@ RUN set -eu; \
 # copies overwrite, so the synced version is what genuinely ships. (Both prefixes
 # are matched because bookworm packages are split between them.) Packages the base
 # ships but this stage lacks keep their original version — their files survive
-# untouched. md5sums are refreshed from this stage's dpkg database so the checksums
-# describe the files that actually ship.
+# untouched.
+#
+# The md5sums sidecars are refreshed from this stage's dpkg database, resolved via
+# `dpkg-query --control-path` rather than by composing the path: dpkg stores those
+# files arch-qualified (libc6:amd64.md5sums) for Multi-Arch: same packages, which
+# every package selected above is, so a hand-built /var/lib/dpkg/info/<pkg>.md5sums
+# never exists. The refreshed lists match every shipped shared object byte-for-byte;
+# their /usr/share/doc entries (changelog, NEWS) stay stale because these images
+# never copy /usr/share. That residue is inert — no scanner resolves CVEs from
+# checksums — but the shared objects, which the Version above now claims, do match.
 COPY --from=distroless_meta /var/lib/dpkg/status.d /tmp/base-status.d
 RUN set -eu; \
     out=/tmp/dpkg-status.d; \
@@ -130,8 +138,8 @@ RUN set -eu; \
       ver="$(dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null)" || continue; \
       [ -n "$ver" ] || continue; \
       sed -i "s/^Version: .*/Version: ${ver}/" "$f"; \
-      if [ -f "/var/lib/dpkg/info/${pkg}.md5sums" ]; then \
-        cp "/var/lib/dpkg/info/${pkg}.md5sums" "${f}.md5sums"; \
+      if src="$(dpkg-query --control-path "$pkg" md5sums 2>/dev/null)" && [ -f "$src" ]; then \
+        cp "$src" "${f}.md5sums"; \
       fi; \
       echo "  dpkg-status sync: ${pkg} -> ${ver}"; \
     done

--- a/genai-engine/dockerfile
+++ b/genai-engine/dockerfile
@@ -189,8 +189,16 @@ RUN set -eu; \
 # copies overwrite, so the synced version is what genuinely ships. (Both prefixes
 # are matched because bookworm packages are split between them.) Packages the base
 # ships but this stage lacks keep their original version — their files survive
-# untouched. md5sums are refreshed from this stage's dpkg database so the checksums
-# describe the files that actually ship.
+# untouched.
+#
+# The md5sums sidecars are refreshed from this stage's dpkg database, resolved via
+# `dpkg-query --control-path` rather than by composing the path: dpkg stores those
+# files arch-qualified (libc6:amd64.md5sums) for Multi-Arch: same packages, which
+# every package selected above is, so a hand-built /var/lib/dpkg/info/<pkg>.md5sums
+# never exists. The refreshed lists match every shipped shared object byte-for-byte;
+# their /usr/share/doc entries (changelog, NEWS) stay stale because these images
+# never copy /usr/share. That residue is inert — no scanner resolves CVEs from
+# checksums — but the shared objects, which the Version above now claims, do match.
 COPY --from=distroless_meta /var/lib/dpkg/status.d /tmp/base-status.d
 RUN set -eu; \
     out=/tmp/dpkg-status.d; \
@@ -202,8 +210,8 @@ RUN set -eu; \
       ver="$(dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null)" || continue; \
       [ -n "$ver" ] || continue; \
       sed -i "s/^Version: .*/Version: ${ver}/" "$f"; \
-      if [ -f "/var/lib/dpkg/info/${pkg}.md5sums" ]; then \
-        cp "/var/lib/dpkg/info/${pkg}.md5sums" "${f}.md5sums"; \
+      if src="$(dpkg-query --control-path "$pkg" md5sums 2>/dev/null)" && [ -f "$src" ]; then \
+        cp "$src" "${f}.md5sums"; \
       fi; \
       echo "  dpkg-status sync: ${pkg} -> ${ver}"; \
     done

--- a/genai-engine/dockerfile
+++ b/genai-engine/dockerfile
@@ -110,6 +110,12 @@ RUN set -e; \
 # Copy the built static files
 RUN cp -r dist /app/ui-dist
 
+# The distroless base is referenced twice: here, so the build stage can read the
+# dpkg metadata it ships (see the status.d sync at the end of the install stage),
+# and again as the final image below. The same tag resolves to the same digest
+# within one build, so this adds a metadata read, not a second base image.
+FROM gcr.io/distroless/python3-debian12:nonroot AS distroless_meta
+
 # Install Stage: Install GenAI Engine on either CPU Install or GPU Install depending on the TORCH_DEVICE variable
 FROM ${TORCH_DEVICE}-install AS install
 # Copy backend files
@@ -143,6 +149,65 @@ RUN mkdir -p /home/nonroot/models
 RUN TIKTOKEN_CACHE_DIR=/home/nonroot/tiktoken \
     python3 -c "import os, tiktoken; os.makedirs('/home/nonroot/tiktoken', exist_ok=True); [tiktoken.get_encoding(e) for e in ['cl100k_base', 'p50k_base', 'r50k_base', 'o200k_base']]"
 
+# Patch the libraries the distroless base keeps in /lib. Unlike bookworm, the base
+# is NOT merged-/usr: /lib is a real directory holding glibc (libc.so.6, libm,
+# libpthread, libnss_*, and the ELF interpreter that /lib64 symlinks to) plus
+# liblzma, libexpat, libgcc_s, libbz2, libcom_err, libcrypt, libkeyutils,
+# libncursesw and libreadline. `COPY --from=install /usr/lib /usr/lib` in the final
+# stage does not reach any of them, so they stayed at the base's versions in every
+# image shipped so far — the libc6 and liblzma5 CVEs scanners report against them
+# are real, not stale metadata. (The libssl3 and krb5 objects do live under
+# /usr/lib and were genuinely being patched.)
+#
+# Mirror the base's /lib layout using this stage's apt-upgraded libraries. Only
+# paths the base already has are emitted, so this replaces files rather than adding
+# any, and the base's layout is preserved. In this stage /lib is a symlink to
+# /usr/lib, hence the /usr/lib source path.
+COPY --from=distroless_meta /lib /tmp/base-lib
+RUN set -eu; \
+    out=/tmp/patched-lib; rm -rf "$out"; mkdir -p "$out"; \
+    cd /tmp/base-lib; \
+    find . -mindepth 1 \( -type f -o -type l \) -print | while IFS= read -r p; do \
+      rel="${p#./}"; src="/usr/lib/${rel}"; \
+      { [ -e "$src" ] || [ -L "$src" ]; } || continue; \
+      mkdir -p "$out/$(dirname "$rel")"; \
+      cp -a "$src" "$out/$rel"; \
+      echo "  /lib patch: ${rel}"; \
+    done
+
+# Rewrite the distroless base's dpkg metadata to the package versions this stage
+# actually installed. With the /lib mirror above and `COPY /usr/lib` in the final
+# stage, the base's shared objects are replaced by the apt-upgraded ones from
+# bookworm-security, but the base's /var/lib/dpkg/status.d keeps advertising the
+# versions it was built with. Scanners resolve OS-package CVEs from that metadata
+# (Wiz reports these as `detectionMethod: PACKAGE`), so they flag already-fixed
+# CVEs against libssl3/libkrb5* indefinitely and block downstream image-policy
+# gates — the situation security/vex/openvex.json documents.
+#
+# Only packages that this stage has installed AND that ship a shared object under
+# /lib|/usr/lib/<triplet>/ are synced: those, and only those, are the files the two
+# copies overwrite, so the synced version is what genuinely ships. (Both prefixes
+# are matched because bookworm packages are split between them.) Packages the base
+# ships but this stage lacks keep their original version — their files survive
+# untouched. md5sums are refreshed from this stage's dpkg database so the checksums
+# describe the files that actually ship.
+COPY --from=distroless_meta /var/lib/dpkg/status.d /tmp/base-status.d
+RUN set -eu; \
+    out=/tmp/dpkg-status.d; \
+    rm -rf "$out"; cp -a /tmp/base-status.d "$out"; \
+    for f in "$out"/*; do \
+      pkg="${f##*/}"; \
+      case "$pkg" in *.md5sums) continue ;; esac; \
+      dpkg-query -L "$pkg" 2>/dev/null | grep -qE '^(/usr)?/lib/[^/]*-linux-gnu/.*\.so' || continue; \
+      ver="$(dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null)" || continue; \
+      [ -n "$ver" ] || continue; \
+      sed -i "s/^Version: .*/Version: ${ver}/" "$f"; \
+      if [ -f "/var/lib/dpkg/info/${pkg}.md5sums" ]; then \
+        cp "/var/lib/dpkg/info/${pkg}.md5sums" "${f}.md5sums"; \
+      fi; \
+      echo "  dpkg-status sync: ${pkg} -> ${ver}"; \
+    done
+
 
 #####################################################################################
 #                                                                                   #
@@ -163,9 +228,15 @@ COPY --from=install /usr/bin/env /usr/bin/env
 COPY --from=install /usr/bin/printenv /usr/bin/printenv
 COPY --from=install /usr/bin/lsof /usr/bin/lsof
 COPY --from=install /usr/lib /usr/lib
+# The base keeps real glibc/liblzma/libexpat/... files in /lib (it is not
+# merged-/usr), which the /usr/lib copy above does not reach. See install stage.
+COPY --from=install /tmp/patched-lib /lib
 COPY --from=install /usr/local/lib/ /usr/local/lib/
 COPY --from=install /usr/local/bin/ /usr/local/bin/
 COPY --from=install /etc/ld.so.cache /etc/ld.so.cache
+# dpkg metadata corrected to match the shared objects copied above (see install stage).
+# Must precede the python3.11 cleanup below, which deletes three of these stanzas.
+COPY --from=install /tmp/dpkg-status.d /var/lib/dpkg/status.d
 COPY --from=install --chown=nonroot:nonroot /app/ /home/nonroot/app/
 COPY --from=install --chown=nonroot:nonroot /home/nonroot/models /home/nonroot/models
 COPY --from=install --chown=nonroot:nonroot /home/nonroot/tiktoken /home/nonroot/tiktoken

--- a/ml-engine/Dockerfile
+++ b/ml-engine/Dockerfile
@@ -128,8 +128,16 @@ RUN set -eu; \
 # copies overwrite, so the synced version is what genuinely ships. (Both prefixes
 # are matched because bookworm packages are split between them.) Packages the base
 # ships but this stage lacks keep their original version — their files survive
-# untouched. md5sums are refreshed from this stage's dpkg database so the checksums
-# describe the files that actually ship.
+# untouched.
+#
+# The md5sums sidecars are refreshed from this stage's dpkg database, resolved via
+# `dpkg-query --control-path` rather than by composing the path: dpkg stores those
+# files arch-qualified (libc6:amd64.md5sums) for Multi-Arch: same packages, which
+# every package selected above is, so a hand-built /var/lib/dpkg/info/<pkg>.md5sums
+# never exists. The refreshed lists match every shipped shared object byte-for-byte;
+# their /usr/share/doc entries (changelog, NEWS) stay stale because these images
+# never copy /usr/share. That residue is inert — no scanner resolves CVEs from
+# checksums — but the shared objects, which the Version above now claims, do match.
 COPY --from=distroless_meta /var/lib/dpkg/status.d /tmp/base-status.d
 RUN set -eu; \
     out=/tmp/dpkg-status.d; \
@@ -141,8 +149,8 @@ RUN set -eu; \
       ver="$(dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null)" || continue; \
       [ -n "$ver" ] || continue; \
       sed -i "s/^Version: .*/Version: ${ver}/" "$f"; \
-      if [ -f "/var/lib/dpkg/info/${pkg}.md5sums" ]; then \
-        cp "/var/lib/dpkg/info/${pkg}.md5sums" "${f}.md5sums"; \
+      if src="$(dpkg-query --control-path "$pkg" md5sums 2>/dev/null)" && [ -f "$src" ]; then \
+        cp "$src" "${f}.md5sums"; \
       fi; \
       echo "  dpkg-status sync: ${pkg} -> ${ver}"; \
     done

--- a/ml-engine/Dockerfile
+++ b/ml-engine/Dockerfile
@@ -1,3 +1,9 @@
+# The distroless base is referenced twice: here, so the install stage can read the
+# dpkg metadata it ships (see the status.d sync at the end of that stage), and again
+# as the final image below. The same tag resolves to the same digest within one
+# build, so this adds a metadata read, not a second base image.
+FROM --platform=linux/amd64 gcr.io/distroless/python3-debian12:nonroot AS distroless_meta
+
 FROM --platform=linux/amd64 python:3.13-slim-bookworm AS install
 
 # install uv and wget; upgrade OS packages for Debian security fixes
@@ -82,6 +88,65 @@ RUN mkdir -p /genai_client
 COPY src/genai_client /genai_client
 RUN uv pip install --system /genai_client
 
+# Patch the libraries the distroless base keeps in /lib. Unlike bookworm, the base
+# is NOT merged-/usr: /lib is a real directory holding glibc (libc.so.6, libm,
+# libpthread, libnss_*, and the ELF interpreter that /lib64 symlinks to) plus
+# liblzma, libexpat, libgcc_s, libbz2, libcom_err, libcrypt, libkeyutils,
+# libncursesw and libreadline. `COPY --from=install /usr/lib /usr/lib` in the final
+# stage does not reach any of them, so they stayed at the base's versions in every
+# image shipped so far — the libc6 and liblzma5 CVEs scanners report against them
+# are real, not stale metadata. (The libssl3 and krb5 objects do live under
+# /usr/lib and were genuinely being patched.)
+#
+# Mirror the base's /lib layout using this stage's apt-upgraded libraries. Only
+# paths the base already has are emitted, so this replaces files rather than adding
+# any, and the base's layout is preserved. In this stage /lib is a symlink to
+# /usr/lib, hence the /usr/lib source path.
+COPY --from=distroless_meta /lib /tmp/base-lib
+RUN set -eu; \
+    out=/tmp/patched-lib; rm -rf "$out"; mkdir -p "$out"; \
+    cd /tmp/base-lib; \
+    find . -mindepth 1 \( -type f -o -type l \) -print | while IFS= read -r p; do \
+      rel="${p#./}"; src="/usr/lib/${rel}"; \
+      { [ -e "$src" ] || [ -L "$src" ]; } || continue; \
+      mkdir -p "$out/$(dirname "$rel")"; \
+      cp -a "$src" "$out/$rel"; \
+      echo "  /lib patch: ${rel}"; \
+    done
+
+# Rewrite the distroless base's dpkg metadata to the package versions this stage
+# actually installed. With the /lib mirror above and `COPY /usr/lib` in the final
+# stage, the base's shared objects are replaced by the apt-upgraded ones from
+# bookworm-security, but the base's /var/lib/dpkg/status.d keeps advertising the
+# versions it was built with. Scanners resolve OS-package CVEs from that metadata
+# (Wiz reports these as `detectionMethod: PACKAGE`), so they flag already-fixed
+# CVEs against libssl3/libkrb5* indefinitely and block downstream image-policy
+# gates — the situation security/vex/openvex.json documents.
+#
+# Only packages that this stage has installed AND that ship a shared object under
+# /lib|/usr/lib/<triplet>/ are synced: those, and only those, are the files the two
+# copies overwrite, so the synced version is what genuinely ships. (Both prefixes
+# are matched because bookworm packages are split between them.) Packages the base
+# ships but this stage lacks keep their original version — their files survive
+# untouched. md5sums are refreshed from this stage's dpkg database so the checksums
+# describe the files that actually ship.
+COPY --from=distroless_meta /var/lib/dpkg/status.d /tmp/base-status.d
+RUN set -eu; \
+    out=/tmp/dpkg-status.d; \
+    rm -rf "$out"; cp -a /tmp/base-status.d "$out"; \
+    for f in "$out"/*; do \
+      pkg="${f##*/}"; \
+      case "$pkg" in *.md5sums) continue ;; esac; \
+      dpkg-query -L "$pkg" 2>/dev/null | grep -qE '^(/usr)?/lib/[^/]*-linux-gnu/.*\.so' || continue; \
+      ver="$(dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null)" || continue; \
+      [ -n "$ver" ] || continue; \
+      sed -i "s/^Version: .*/Version: ${ver}/" "$f"; \
+      if [ -f "/var/lib/dpkg/info/${pkg}.md5sums" ]; then \
+        cp "/var/lib/dpkg/info/${pkg}.md5sums" "${f}.md5sums"; \
+      fi; \
+      echo "  dpkg-status sync: ${pkg} -> ${ver}"; \
+    done
+
 # Final Stage(s): Create ml-engine image
 FROM --platform=linux/amd64 gcr.io/distroless/python3-debian12:nonroot AS ml-engine-distroless-base
 
@@ -94,9 +159,15 @@ COPY --from=install /usr/bin/env /usr/bin/env
 COPY --from=install /usr/bin/printenv /usr/bin/printenv
 COPY --from=install /usr/bin/wget /usr/bin/wget
 COPY --from=install /usr/lib /usr/lib
+# The base keeps real glibc/liblzma/libexpat/... files in /lib (it is not
+# merged-/usr), which the /usr/lib copy above does not reach. See install stage.
+COPY --from=install /tmp/patched-lib /lib
 COPY --from=install /usr/local/lib/ /usr/local/lib/
 COPY --from=install /usr/local/bin/ /usr/local/bin/
 COPY --from=install /etc/ld.so.cache /etc/ld.so.cache
+# dpkg metadata corrected to match the shared objects copied above (see install stage).
+# Must precede the python3.11 cleanup below, which deletes three of these stanzas.
+COPY --from=install /tmp/dpkg-status.d /var/lib/dpkg/status.d
 COPY --from=install /opt/oracle/ /opt/oracle/
 COPY --from=install /opt/microsoft/msodbcsql18 /opt/microsoft/msodbcsql18
 COPY --from=install /opt/microsoft/msodbcsql17 /opt/microsoft/msodbcsql17

--- a/security/vex/openvex.json
+++ b/security/vex/openvex.json
@@ -3,142 +3,10 @@
   "@id": "https://arthur.ai/vex/arthur-engine",
   "author": "Arthur Security <security@arthur.ai>",
   "role": "Document Creator",
-  "timestamp": "2026-07-28T00:00:00.000000000-00:00",
-  "version": 6,
-  "_comment": "Scope: HIGH/CRITICAL CVEs a container-image re-scan still reports for the genai-engine, ml-engine and genai-engine-models-* images, but which are remediated in the shipped binary (the apt-upgraded library is copied over the distroless base, whose stale dpkg metadata the scanner reads) or are not in the execute path. Fully remediated CVEs are intentionally excluded: python3.11 is removed from every image (its dpkg metadata deleted), litellm/langsmith/msgpack are upgraded past their advisories, nltk is upgraded to 3.10.0 (fixes CVE-2026-54293, GHSA-p4gq-832x-fm9v), uv is upgraded 0.11.25 -> 0.11.26 (bundles quinn-proto 0.11.15, fixing GHSA-4w2j-m93h-cj5j / RUSTSEC-2026-0185), and pyasn1 is upgraded to 0.6.4 (fixes CVE-2026-59885/59886) in deployment/model-upload/uv.lock and genai-engine/uv.lock — the models-gcs 0.6.3 finding is a stale pre-bump :latest artifact that clears on rebuild. See genai-engine/dockerfile, ml-engine/Dockerfile, deployment/model-upload/Dockerfile and PR #1851.",
+  "timestamp": "2026-07-30T00:00:00.000000000-00:00",
+  "version": 7,
+  "_comment": "Scope: HIGH/CRITICAL findings that a container-image re-scan still reports for the genai-engine, ml-engine and genai-engine-models-* images AND that are not exploitable in our usage. Every statement here is 'not_affected' with a justification. Remediated CVEs are excluded by policy — fix, don't justify (security/README.md), so a CVE disappearing from this document means it was fixed, not dropped. Remediated and therefore absent: python3.11 is removed from every image (its dpkg metadata deleted); litellm/langsmith/msgpack/nltk/uv/pyasn1 are upgraded past their advisories; and as of 2026-07-30 the distroless OS-package findings (libc6, libssl3, libkrb5*, liblzma5) are fixed at the source — the build stages now mirror the base's /lib layout with their apt-upgraded libraries and rewrite /var/lib/dpkg/status.d to the versions actually installed, so the patched objects ship and scanners read true versions. Auditor note: the distroless base is not merged-/usr, so before that change `COPY /usr/lib` never reached the glibc and liblzma objects the base keeps in /lib. Images up to and including 2.1.754 shipped the base's unpatched glibc (2.36-9+deb12u13) and liblzma5 (5.4.1-1), and earlier revisions of this document incorrectly recorded those libc6 CVEs as fixed. The libssl3 and krb5 objects do live under /usr/lib and were genuinely patched throughout; only their dpkg metadata was stale. See genai-engine/dockerfile, ml-engine/Dockerfile, deployment/model-upload/Dockerfile and PR #2073.",
   "statements": [
-    {
-      "_comment": "libssl3: the shipped libssl.so.3/libcrypto.so.3 is OpenSSL 3.0.20 (deb 3.0.20-1~deb12u2), copied from the apt-upgraded *-slim-bookworm build stage over the distroless base. Scanners read stale dpkg metadata (3.0.19-1~deb12u2) inherited from the distroless base. The shipped binary contains the fix. The genai-engine-models-s3/-fs images do the same via deployment/model-upload/Dockerfile.",
-      "vulnerability": { "name": "CVE-2026-34182" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "libssl3 — shipped binary is OpenSSL 3.0.20-1~deb12u2; reported version is stale distroless dpkg metadata.",
-      "vulnerability": { "name": "CVE-2026-34180" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "libssl3 — shipped binary is OpenSSL 3.0.20-1~deb12u2; reported version is stale distroless dpkg metadata.",
-      "vulnerability": { "name": "CVE-2026-9076" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "libssl3 — shipped binary is OpenSSL 3.0.20-1~deb12u2; reported version is stale distroless dpkg metadata.",
-      "vulnerability": { "name": "CVE-2026-7383" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "libssl3 — shipped binary is OpenSSL 3.0.20-1~deb12u2; reported version is stale distroless dpkg metadata.",
-      "vulnerability": { "name": "CVE-2026-45447" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "libssl3 — shipped binary is OpenSSL 3.0.20-1~deb12u2; reported version is stale distroless dpkg metadata.",
-      "vulnerability": { "name": "CVE-2026-45445" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libssl3" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "libc6: the shipped libc.so.6 is glibc 2.36-9+deb12u14, copied from the apt-upgraded *-slim-bookworm build stage over the distroless base. Scanners read stale dpkg metadata (2.36-9+deb12u13) inherited from the distroless base. The shipped binary contains the fix.",
-      "vulnerability": { "name": "CVE-2026-4437" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "libc6 — shipped binary is glibc 2.36-9+deb12u14; reported version is stale distroless dpkg metadata.",
-      "vulnerability": { "name": "CVE-2026-4046" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "libc6 — shipped binary is glibc 2.36-9+deb12u14; reported version is stale distroless dpkg metadata.",
-      "vulnerability": { "name": "CVE-2026-0915" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "libc6 — shipped binary is glibc 2.36-9+deb12u14; reported version is stale distroless dpkg metadata.",
-      "vulnerability": { "name": "CVE-2026-0861" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "libc6 — shipped binary is glibc 2.36-9+deb12u14; reported version is stale distroless dpkg metadata.",
-      "vulnerability": { "name": "CVE-2025-15281" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libc6" } ] }
-      ],
-      "status": "fixed"
-    },
     {
       "_comment": "libexpat1: the reported system library (pkg:deb libexpat1 2.5.0-1~deb12u2 from the distroless base) is not linked by the application runtime. CPython 3.12/3.13 (from /usr/local) statically bundle their own expat (2.7.4 / 2.8.1) and do not load the system libexpat.so.1. Its only consumer in the base image, Python 3.11, has been removed. No Debian bookworm fix is available yet (fixed upstream in expat 2.8.1). DoS-only (CWE-407, CVSS ~2.9). Residual risk: the bundled CPython expat (2.7.4 on 3.12) is also affected, but is reachable only by parsing attacker-controlled XML, which these images do not do (the engines expose JSON APIs; the model-upload jobs parse no XML).",
       "vulnerability": { "name": "CVE-2026-45186" },
@@ -412,30 +280,6 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local (deployment/model-upload/Dockerfile); the inherited system 3.11 is removed and never executed. A Debian fix exists but is moot — the package is removed, not upgraded, in these images.",
       "timestamp": "2026-06-27T00:00:00Z"
-    },
-    {
-      "_comment": "krb5: the shipped libgssapi-krb5-2/libk5crypto3/libkrb5-3/libkrb5support0 are krb5 1.20.1-2+deb12u5 (the bookworm/bookworm-security fix), copied from the apt-upgraded *-slim-bookworm build stage over the distroless base. Scanners read stale dpkg metadata (1.20.1-2+deb12u4) inherited from the distroless base; the shipped binary contains the fix. Not flagged on genai-engine-models-gcs, which apt-upgrades the slim runtime in place (fresh metadata). CVE-2026-40355 is a NULL-pointer-dereference DoS in the GSS-API NegoEx acceptor (gss_accept_sec_context).",
-      "vulnerability": { "name": "CVE-2026-40355" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] }
-      ],
-      "status": "fixed"
-    },
-    {
-      "_comment": "krb5 — shipped binaries are krb5 1.20.1-2+deb12u5 (bookworm fix); reported version is stale distroless dpkg metadata (1.20.1-2+deb12u4). CVE-2026-40356 is an integer-underflow / out-of-bounds-read DoS in the GSS-API NegoEx acceptor (gss_accept_sec_context).",
-      "vulnerability": { "name": "CVE-2026-40356" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libgssapi-krb5-2" }, { "@id": "pkg:deb/debian/libk5crypto3" }, { "@id": "pkg:deb/debian/libkrb5-3" }, { "@id": "pkg:deb/debian/libkrb5support0" } ] }
-      ],
-      "status": "fixed"
     },
     {
       "_comment": "libexpat1: CVE-2026-56131 is a use-after-free reachable only through an XML_ResumeParser suspend/resume flow on a policy violation; no Debian bookworm fix is available (bookworm/bookworm-security ship 2.5.0-1+deb12u2, still vulnerable; fixed upstream in expat 2.8.2, only in sid). The system libexpat1 is not loaded by the application: CPython 3.12/3.13 bundle their own expat statically and do not link /usr/lib/*/libexpat.so.1, and the only base-image consumer (Python 3.11) has been removed. The engines expose JSON/HTTP APIs and never parse attacker-controlled XML through the system libexpat. Owner: security@arthur.ai. Review by: 2027-01-28.",


### PR DESCRIPTION
## Problem

A customer's Wiz gate fails our released images (reported against `genai-engine-gpu-2.1.748`) with **19 HIGH/CRITICAL OS-package CVEs** — 5 on `libc6`, 6 on `libssl3` (incl. CRITICAL CVE-2026-34182), 2 each across the four `krb5` packages — plus a `liblzma5` MEDIUM.

Investigating turned up **two distinct defects**. My first read was that this was purely stale metadata; that was wrong, and the more serious half is real.

## Defect 1 — the base's `/lib` libraries were never patched (real)

**The distroless base is not merged-`/usr`.** It keeps *real files* in `/lib/<triplet>/`:

- glibc — `libc.so.6`, `libm`, `libpthread`, `libnss_*`, **and the ELF interpreter that `/lib64` symlinks to**
- `liblzma`, `libexpat`, `libgcc_s`, `libbz2`, `libcom_err`, `libcrypt`, `libkeyutils`, `libncursesw`, `libreadline`

`COPY --from=install /usr/lib /usr/lib` never reached any of them. The upgraded glibc landed at `/usr/lib/.../libc.so.6` as a *new* file while the base's `/lib/.../libc.so.6` stayed at **2.36-9+deb12u13**, and `/lib64/ld-linux-x86-64.so.2` → that same unpatched loader.

**So every image shipped so far carried unpatched glibc and liblzma5.** The 5 libc6 HIGHs and the liblzma5 MEDIUM are real findings, and `security/vex/openvex.json` wrongly recorded libc6 as `fixed`.

**Fix:** mirror the base's `/lib` layout using the build stage's apt-upgraded libraries. Only paths the base already has are emitted, so files are *replaced*, not added, and the layout is preserved.

## Defect 2 — stale dpkg metadata (cosmetic, but blocks gates)

`libssl3` and the four krb5 packages *do* live under `/usr/lib` and were genuinely being patched — their shipped `.so` files are **byte-identical (md5)** to the upgraded build stage. But nothing ever touched `/var/lib/dpkg/status.d`, which the base ships declaring `libssl3 3.0.19` and krb5 `u4`. `detectionMethod: PACKAGE` reads exactly there, so those **14 findings are stale metadata**.

VEX already documented this, but VEX only silences **our** Trivy run — it does nothing for a customer's Wiz policy gate, which is why these return every release.

**Fix:** rewrite `status.d` to the versions the build stage actually installed. Only packages the stage installed that ship a `.so` under `/lib|/usr/lib/<triplet>/` are synced — exactly the files the two copies overwrite. Packages the base has but the stage lacks keep their version, since their files survive untouched. `md5sums` sidecars are refreshed from the stage's dpkg database via `dpkg-query --control-path` (dpkg stores them arch-qualified — `libc6:amd64.md5sums` — for `Multi-Arch: same` packages, which all of these are). Every shipped shared object matches byte-for-byte; nine `/usr/share/doc` changelog entries stay stale because these images never copy `/usr/share`, which is inert since no scanner resolves CVEs from checksums.

Applied as identical blocks to `genai-engine/dockerfile`, `ml-engine/Dockerfile`, and both distroless `model-upload` runtimes. `runtime-gcs` is slim-based and already correct.

## Verification

Assembled the final image with both blocks **extracted verbatim from these files**:

| Check | Result |
| --- | --- |
| `GLIBC 2.36-9+deb12u13` anywhere in the filesystem | **0 occurrences** (was the shipped glibc) |
| `/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2` | byte-identical (md5) to the patched build stage |
| All 7 flagged packages in `status.d` | declare the exact `fixedVersion` Wiz requires |
| **Image still runs** | python 3.12.13 imports `ssl`/`lzma`/`sqlite3`, reports **OpenSSL 3.0.20**; bash works |
| python3.11 cleanup | unaffected (sync `COPY` ordered before the `rm`) |
| `docker build --check` | no errors; warning counts unchanged from `dev` |

Replacing the ELF interpreter is the risky part of this change, hence the explicit runtime check.

**Not built end-to-end:** the genai-engine UI stage needs `GITLAB_UNIFY_FRONTEND_TOKEN`, so CI is the first full build.

## Reviewer notes

- **Images build on the next `Increment arthur-engine version` commit** — this PR alone produces no rescannable image.
- **VEX document: the 13 now-patched `fixed` statements are removed** (libssl3 ×6, libc6 ×5, krb5 ×2 across four packages), leaving 28 `not_affected` statements. This restores the convention the doc itself states — *fix, don't justify*: it now lists only findings that are unexploitable in our usage, so a CVE absent from it was remediated, not quietly dropped. The scope note records that the libc6 entries were wrong for prior releases, for auditors.
- **`aiohttp` 3.13.5 → 3.14.1 not bumped**: 7 medium / 4 low, no HIGH, transitive via langchain — fails neither the `severity: HIGH` threshold nor `ignoreTransitiveVulnerabilities: true`. Happy to add it (needs a `uv.lock` regen).
- **Pre-existing, out of scope:** `ml-engine` copies a much larger `/usr/lib` than the base declares (libpq, unixODBC, MS ODBC, Oracle Instant Client), so its SBOM *under*-reports those libraries entirely. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


