### PR TITLE
fix(pre-commit): make the mypy hooks install the group mypy lives in

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,11 @@ repos:
         files: ^genai-engine/src/
       - id: genai-engine-mypy-check
         name: "genai-engine: mypy type checking"
-        entry: uv run --directory genai-engine mypy src
+        # --group linters: mypy lives in the linters group, which is not in uv's
+        # default group set, so without this the hook falls through to whatever
+        # mypy happens to be on PATH (or fails to spawn). Mirrors CI, which syncs
+        # the group via setup-uv's with-groups input.
+        entry: uv run --directory genai-engine --frozen --group linters mypy src
         language: system
         types: [python]
         pass_filenames: false
@@ -101,7 +105,8 @@ repos:
         files: ^ml-engine/src/
       - id: ml-engine-mypy-check
         name: "ml-engine: mypy type checking"
-        entry: uv run --directory ml-engine mypy src/ml_engine
+        # --group linters: see the genai-engine mypy hook above.
+        entry: uv run --directory ml-engine --frozen --group linters mypy src/ml_engine
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
## The bug

`mypy` is in the **`linters`** dependency group for both genai-engine and ml-engine, and neither `pyproject.toml` sets `[tool.uv] default-groups` — so uv's default group set is `dev` alone, which has no mypy. The hooks ran `uv run --directory <proj> mypy ...` with no group flag, making their behaviour depend on whatever the developer happened to sync last:

| Local venv state | What the hook actually did |
| --- | --- |
| `linters` synced | project mypy, correct result |
| dev-only + a global mypy on PATH | **silently ran the wrong mypy**, wrong interpreter and site-packages, spurious errors |
| dev-only, no global mypy | `uv run` fails to spawn, hook errors out |

The middle case isn't hypothetical — I hit it. On a dev-only sync the ml-engine hook resolved `/opt/anaconda3/bin/mypy` and reported **16 errors that do not exist**, with misleading `Hint: install types-python-dateutil` notes that made it look like a stubs problem. Same tree with the group synced: `Success: no issues found in 49 source files`.

```
$ uv sync --frozen                         # default groups = dev
mypy present in project venv? NO
mypy on system PATH:  /opt/anaconda3/bin/mypy
$ uv run --directory ml-engine mypy src/ml_engine
Found 16 errors in 9 files (checked 49 source files)
```

**CI was never affected** — it syncs the group explicitly via `setup-uv`'s `with-groups: linters` input. This just brings the hooks in line with what CI already does.

## Why `--frozen` is also needed

Without it, `uv run` re-locks as a side effect and rewrites `uv.lock` — the relative `exclude-newer` placeholder becomes a concrete timestamp, plus the project's own stale version — which makes pre-commit fail the hook with `files were modified by this hook`. I confirmed this mutation is **pre-existing** (the old entry does it too), but it would turn into a hard failure the moment the hook starts actually running the project's mypy. `--frozen` matches CI's `uv sync --frozen --group linters`: sync the environment from the existing lock, never rewrite it.

## Verification

Stripped each venv to dev-only (`uv sync --frozen`, mypy confirmed absent), then ran each hook end-to-end:

```
$ pre-commit run ml-engine-mypy-check --all-files
ml-engine: mypy type checking....................................Passed
$ pre-commit run genai-engine-mypy-check --all-files
genai-engine: mypy type checking.................................Passed
```

`uv.lock` unchanged in both cases. `pre-commit validate-config` and `check-yaml` pass.

## Not changed

- `arthur-observability-sdk-mypy-check` — that project keeps mypy in `dev`, so it is already self-sufficient.
- The pytest hooks — `pytest` is in `dev` everywhere, same reason.
- The repo-wide isort/black/autoflake hooks — those come from upstream pre-commit repos with their own isolated environments.

Worth noting separately: every `language: system` hook that shells out to `uv run` without `--frozen` (the pytest, routes-security, and changelog hooks) carries the same latent `uv.lock`-rewrite hazard. I left them alone to keep this focused — happy to follow up if you want `--frozen` applied across the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
