### PR TITLE
ci: fix renovate auto-fix push auth (use app token explicitly)

### DIFF
--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -232,6 +232,8 @@ jobs:
           # Approve as github-actions[bot] — a DIFFERENT identity than the app that
           # pushes below, so require_last_push_approval is satisfied.
           GH_TOKEN: ${{ github.token }}
+          # Used ONLY for the push, so GitHub attributes the push to the Automator App.
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           AUTOFIX_MARKER: ${{ runner.temp }}/claude-autofix-success
@@ -249,13 +251,16 @@ jobs:
             exit 0
           fi
 
-          # Commit author = Automator App bot (cosmetic); push credential is the
-          # app token configured by checkout, so GitHub attributes the push to the app.
           git config user.name "arthur-github-automator[bot]"
           git config user.email "${{ secrets.ARTHUR_GH_AUTOMATOR_APP_ID }}+arthur-github-automator[bot]@users.noreply.github.com"
           git add -A
           git commit -m "fix(deps): auto-resolve CI failures from dependency update [claude-autofix]"
-          git push origin "HEAD:$HEAD_BRANCH"
+          # Push with the app token EXPLICITLY. Do not rely on the credential persisted by
+          # checkout: claude-code-action rewrites the workspace git auth config during its
+          # run, so the persisted header is gone by now. An installation token pushed as
+          # x-access-token is attributed to the Automator App (distinct from the approver).
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" \
+            "HEAD:$HEAD_BRANCH"
 
           # Re-approve so the PR (now with a fresh commit) can re-enter the merge queue.
           gh pr review "$PR_NUMBER" --repo "${{ github.repository }}" --approve \


### PR DESCRIPTION
## Context

First live run of the auto-fixer (on Renovate PR #2066) validated the hard parts:
- ✅ `claude-code-action` **runs under `workflow_run`** (the one open prerequisite) — no shim needed.
- ✅ Opus/xhigh produced a **verified 27-file fix** (removed stale `eslint-disable` directives, fixed `@tanstack/query` queryKeys / `zod` types), self-reviewed, and wrote the success marker.
- ❌ The **`git push` failed**: `remote: Invalid username or token`.

## Root cause

`anthropics/claude-code-action` rewrites the workspace git auth configuration during its run, so the credential `actions/checkout` persisted (the Automator App token) is no longer present by the time the commit/push step runs. The push then had no valid credential.

## Fix

Push with the Automator App installation token **explicitly** via an `x-access-token` URL, instead of relying on the persisted checkout header. The push is still attributed to the app, so the identity split (**app pushes**, **github-actions[bot] approves**) that satisfies `require_last_push_approval` is preserved.

```diff
-          git push origin "HEAD:$HEAD_BRANCH"
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" \
+            "HEAD:$HEAD_BRANCH"
```

## After merge

Re-trigger #2066 (tick its Renovate rebase checkbox) to validate the remaining untested links: the push lands, `github-actions[bot]` re-approves (this also confirms prereq #2 — the "Allow Actions to approve PRs" org setting), the independent `claude-code-review` runs on the fix commit, and it flows through the merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)