### PR TITLE
ci(renovate): exempt first-party Arthur packages from release-age soak

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,11 @@
       "groupName": "python minor and patch"
     },
     {
+      "description": "First-party Arthur packages are internal, so they skip the 3-day release-age soak that guards against third-party supply-chain risk. Mirrors tool.uv exclude-newer-package in the pyproject.toml files.",
+      "matchPackageNames": ["arthur-common", "arthur-client"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
       "matchManagers": ["pep621"],
       "matchPackageNames": ["python", "torch", "numpy"],
       "enabled": false


### PR DESCRIPTION
## What

Adds a `packageRule` so `arthur-common` and `arthur-client` skip the global `minimumReleaseAge: "3 days"`:

```json
{
  "matchPackageNames": ["arthur-common", "arthur-client"],
  "minimumReleaseAge": "0 days"
}
```

## Why

`minimumReleaseAge` is a supply-chain soak aimed at **third-party** packages — hold a release for 3 days so a compromised/broken publish is caught before we adopt it. `arthur-common` and `arthur-client` are **first-party** (we publish them), so the soak just delays our own updates for no security benefit. This mirrors what `pyproject.toml` already does at the uv level:

```toml
exclude-newer-package = { torch = false, arthur-common = false, arthur-client = false }
```

## Concrete effect

`arthur-common 2.4.68` was published today and **moves its pin to `litellm==1.93.0`** — the exact version the open **"python minor and patch"** group (#2064) is trying to install (the current conflict is that pinned `arthur-common 2.4.67` still requires `litellm 1.89.3`). Under the 3-day soak, 2.4.68 wouldn't be eligible until ~Aug 2.

With this rule, once merged, Renovate's next run pulls `arthur-common 2.4.68` into the group PR alongside `litellm 1.93.0` — mutually compatible — and **#2064's unsatisfiable-resolution failure clears** without waiting or a manual pin.

Note: takes effect after this merges to `dev` (Renovate reads config from the default branch). Updating the already-open #2064 group PR is not blocked by `prConcurrentLimit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)