### PR TITLE
fix(docker): retry the RDS cert download and fail loudly on a bad one

### DIFF
--- a/genai-engine/dockerfile
+++ b/genai-engine/dockerfile
@@ -131,9 +131,19 @@ COPY .env /app/
 ARG ENABLE_TELEMETRY=false
 RUN echo "TELEMETRY_ENABLED=${ENABLE_TELEMETRY}" >> /app/.env
 
-# Download AWS RDS global certificate bundle
+# Download AWS RDS global certificate bundle.
+# Retried: this is a release-blocking single point of failure — a bare `curl` here
+# failed a dev release build with exit 35 (SSL connect error) reaching AWS. Notes on
+# the flags, since the defaults are wrong for this in two ways:
+#   --retry-all-errors  plain --retry only covers timeouts and 5xx/408/429, NOT the
+#                       connection and TLS handshake failures that actually occur here.
+#   -f                  without it curl exits 0 on an HTTP error and writes the error
+#                       body into the file, silently shipping a corrupt cert bundle.
+# The grep is a last guard against a proxy or captive portal returning 200 + junk.
 RUN apt-get update && apt-get install -y curl && \
-    curl -o /app/postgres-cert.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors --connect-timeout 15 --max-time 180 \
+      -o /app/postgres-cert.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && \
+    grep -q "BEGIN CERTIFICATE" /app/postgres-cert.pem
 
 # Copy alembic files to run directory
 COPY alembic /app/alembic


### PR DESCRIPTION
## Why

This unretried `curl` is a release-blocking single point of failure. It took down the **2.1.758** dev image build with `exit 35` (SSL connect error) reaching `truststore.pki.rds.amazonaws.com` — after the release commit had already landed.

```
#74 ERROR: process "/bin/sh -c apt-get update && apt-get install -y curl &&
    curl -o /app/postgres-cert.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
    did not complete successfully: exit code: 35
```

## Why `--retry` alone would not have fixed it

Two of curl's defaults are wrong for this call:

- **`--retry-all-errors`** — plain `--retry` only covers timeouts and HTTP 408/429/5xx. It does **not** cover connection or TLS handshake failures, which is exactly the class of error that broke the build. Adding `--retry` on its own would have left the failure mode intact.
- **`-f`** — without `--fail`, curl exits **0** on an HTTP error and writes the error body into the output file. Today a transient 403/404 from the AWS endpoint would ship a genai-engine image whose `postgres-cert.pem` is a short error page, and the build would pass green.

That second one is a latent bug this PR also closes. Demonstrated on bookworm:

```
=== OLD behaviour (no -f) ===
  old curl exit=0  wrote 111 bytes of non-certificate content
```

A `grep -q "BEGIN CERTIFICATE"` guard closes the last hole — a proxy or captive portal answering `200` with junk.

## Verification

On `python:3.12-slim-bookworm` (curl 7.88.1, `--retry-all-errors` supported):

| Path | Result |
| --- | --- |
| Happy path, exact command from the Dockerfile | exit 0, **165408 bytes, 108 certificates**, guard passes |
| HTTP error path | retries, then **exit 22**; guard correctly rejects the file |
| Old command, HTTP error path | **exit 0**, 111 bytes of non-certificate content written |

`docker build --check` clean — 11 warnings, all pre-existing UI build-arg ones, unchanged from `dev`.

## Not changed

Same hazard exists elsewhere; left alone to keep this reviewable, happy to follow up:

- `ml-engine/Dockerfile` — the Oracle Instant Client `wget` pair and the Microsoft signing-key `curl`
- `genai-engine/Dockerfile_changelog` — the oasdiff `.deb` download

🤖 Generated with [Claude Code](https://claude.com/claude-code)
