### PR TITLE
fix(ci): unblock release PRs when dev's tip carries a CI-skip directive

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -46,6 +46,41 @@ jobs:
             exit 1
           fi
 
+          # GitHub honours CI-skip directives on the head commit for `pull_request`
+          # events, not just `push`. If dev's tip carries one, the release PR opens
+          # with *zero* workflow runs, so main-branch-ruleset's required checks can
+          # never report and the PR is permanently BLOCKED (see #2078, #2081).
+          #
+          # dev's tip regularly carries one: the model-upload workflows push
+          # "Update models manifest [skip ci]" straight to dev. That [skip ci] is
+          # deliberate and must stay — Arthur Engine CI uses a per-ref concurrency
+          # group with cancel-in-progress on non-main refs, so a non-skipped push
+          # would cancel the very release build that produced the manifest.
+          #
+          # So fix it here instead: land an empty commit to give the PR a checkable
+          # head. Three constraints on that commit message, all load-bearing:
+          #   * no skip directive        - the whole point; the head must be checkable.
+          #   * must NOT contain "Increment arthur-engine version" - Arthur Engine CI
+          #     gates the image-build jobs on that phrase, so it would kick off a
+          #     premature release build on dev.
+          #   * MUST start with "chore(release)" - Version Management bumps the version
+          #     on every push to dev except for an allow-list of prefixes. Without a
+          #     matching prefix this commit bumps the version, which pushes an
+          #     "Increment arthur-engine version" commit, which rebuilds the model
+          #     images, which pushes a fresh "[skip ci]" manifest commit — putting the
+          #     PR head straight back on a skipped commit and re-blocking it. The
+          #     matching allow-list entry lives in version-workflow.yml; keep in sync.
+          TIP_MSG="$(git log -1 --pretty=%B origin/dev)"
+          if printf '%s' "$TIP_MSG" | grep -qiE '\[(skip ci|ci skip|no ci|skip actions|actions skip)\]'; then
+            echo "dev tip carries a CI-skip directive; adding an empty commit so the release PR gets checks."
+            git config user.name "arthur-github-automator[bot]"
+            git config user.email "arthur-github-automator[bot]@users.noreply.github.com"
+            git checkout -B dev origin/dev
+            git commit --allow-empty -m "chore(release): enable checks for the release PR"
+            git push origin dev
+            git fetch origin dev
+          fi
+
           BODY="Production release PR. Merging this PR will trigger the production build and deployment pipeline."
 
           gh pr create \

--- a/.github/workflows/version-workflow.yml
+++ b/.github/workflows/version-workflow.yml
@@ -30,7 +30,8 @@ jobs:
        !startsWith(github.event.head_commit.message, 'Increment arthur-engine') &&
        !startsWith(github.event.head_commit.message, 'Update dependency') &&
        !startsWith(github.event.head_commit.message, 'Update models manifest') &&
-       !startsWith(github.event.head_commit.message, 'chore(deps)')) ||
+       !startsWith(github.event.head_commit.message, 'chore(deps)') &&
+       !startsWith(github.event.head_commit.message, 'chore(release)')) ||
       (github.event_name == 'workflow_dispatch' &&
        github.event.inputs.intent == 'bump_version' &&
        github.ref != 'refs/heads/main')


### PR DESCRIPTION
## The bug

Two release PRs in a row opened permanently unmergeable — **#2078** and **#2081** — and every future one would fail the same way.

GitHub honours CI-skip directives on the head commit for **`pull_request`** events, not only `push`. dev's tip was `Update models manifest [skip ci]` both times, so opening the PR created **zero** workflow runs — not just Arthur Engine CI, but Claude Code Review too. The only check suites on those SHAs came from `workflow_dispatch`, `issue_comment` and `pull_request_review` — all human- or manually-triggered.

With no runs, `main-branch-ruleset`'s five required checks (`run-genai-engine-linter`, `run-ml-engine-linter`, `run-genai-engine-changelog-cop`, `run-genai-engine-unit-tests`, `run-ml-engine-unit-tests`) can never report. The PR sits `BLOCKED` forever rather than merely pending. `gh pr checks 2081` → *"no checks reported"*.

It isn't a general outage: a renovate PR at 00:20 the same night triggered both CI and Claude Code Review normally.

## Root cause: #1909

**#1909** (merged 2026-07-30T19:14Z) added the AI-BOM to the files the model-upload workflows stage:

```diff
-  git add deployment/model-upload/models-manifest.json
+  git add deployment/model-upload/models-manifest.json deployment/model-upload/aibom.cdx.json
```

`generate_aibom.py` stamps `metadata.component.version` with the engine version, so that file changes on **every release**. `git diff --staged --quiet` is therefore never true any more, and a `[skip ci]` commit lands after every release build — where before #1909 it landed only when HuggingFace models actually changed:

| commit | aibom version | message |
| --- | --- | --- |
| a0796ef98 | 2.1.761-dev | Update models manifest [skip ci] |
| 362633792 | 2.1.758-dev | Update models manifest [skip ci] |
| 4e206b11e | 2.1.757-dev | Update models manifest [skip ci] |
| edc47c3af | 2.1.755-dev | Update models manifest [skip ci] |
| 1d4a0fa8f | 2.1.754-dev | Update models manifest [skip ci] |
| 8e434e942 | unknown | **Add build-time CycloneDX AI-BOM (#1909)** |

The workflow does pass `--no-timestamp`, so the version stamp is the only churning field — but once per release is enough. The split is exact:

| Release PR | Head commit | Outcome |
| --- | --- | --- |
| #1980 | `Increment arthur-engine version to 2.1.725` | merged |
| #2026 | `Increment arthur-engine version to 2.1.748` | merged |
| *#1909 merged 2026-07-30T19:14Z* | | |
| #2078 | `Update models manifest [skip ci]` | never merged |
| #2081 | `Update models manifest [skip ci]` | never merged |

## Why the obvious fix would be harmful

Dropping `[skip ci]` from the three model-upload workflows looks right and isn't. Arthur Engine CI declares:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

A non-skipped manifest push to dev would **cancel the in-flight dev run that produced it**, killing the genai-engine and ml-engine image builds mid-flight. Several such cancellations are already visible in the run history. That `[skip ci]` is load-bearing and stays.

## The fix

Handle it at the release-PR boundary. If dev's tip carries a skip directive, land an empty commit so the PR head is checkable.

### That empty commit has to thread three gates

Getting the message wrong turns the fix into a loop. **`Version Management` bumps the version on every push to dev** outside an allow-list of prefixes (`fix(deps)`, `Increment arthur-engine`, `Update dependency`, `Update models manifest`, `chore(deps)`). A neutral message like `ci: enable checks...` matches none of them, so it would:

```
empty commit -> version bump -> "Increment arthur-engine version" commit
             -> model images rebuilt -> fresh "[skip ci]" manifest commit
             -> PR head back on a skipped commit -> BLOCKED again
```

…plus an unintended version bump and a wasted release build. So the commit is prefixed **`chore(release)`**, with a matching allow-list entry added to `version-workflow.yml`. The three constraints, all load-bearing:

| Constraint | Why |
| --- | --- |
| no skip directive | the entire point — the head must be checkable |
| must **not** contain `Increment arthur-engine version` | Arthur Engine CI gates the image-build jobs on that phrase |
| must start with `chore(release)` | otherwise Version Management bumps and the loop above fires |

An alternative worth considering separately: have `generate_aibom.py` omit the engine-version stamp from the committed copy, so the file only churns on real model changes. That fixes the churn at source but leaves the underlying trap — any future `[skip ci]` tip would block a release again — so this guard is worth having either way.

An alternative worth considering separately: have `generate_aibom.py` omit the engine-version stamp from the committed copy, so the file only churns on real model changes. That fixes the churn at source but leaves the underlying trap — any future `[skip ci]` tip would block a release again — so this guard is worth having either way.

## Verification

Detection tested against both real blocked tips and a spread of negatives/positives:

| Message | Result |
| --- | --- |
| `Update models manifest [skip ci]` (362633792, real) | detected |
| `Update models manifest [skip ci]` (a0796ef98, real) | detected |
| `Increment arthur-engine version to 2.1.758` | no-skip |
| `Merge pull request #2081 from arthur-ai/dev` | no-skip |
| `fix(docker): retry the RDS cert download` | no-skip |
| `[ci skip]` / `[NO CI]` / `[skip actions]` | detected |
| prose "skip ci", no brackets | no-skip (no false positive) |

Every gate re-evaluated against the final message, with the allow-list **parsed out of the YAML** rather than retyped:

```
candidate: "chore(release): enable checks for the release PR"
  Version Management bump              -> NO  (exempt via chore(release))
  image build / check-models-updates   -> NO  (lacks the version phrase)
  GitHub pull_request skip             -> NO  (checks will run)
  SDK release                          -> NO  (paths filter; empty commit touches nothing)
```

Both YAML files validate. The automator app has `bypass_mode=always` on `dev-branch-ruleset`, so it can push the empty commit — the same mechanism the manifest commit already uses.

## Note

Merging this PR also unblocks **#2081** as a side effect: it advances dev's tip to a merge commit without a skip directive, which fires `pull_request: synchronize` and lets the required checks finally run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

