### PR TITLE
ci: scope release/publish jobs to the canonical repository

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -422,6 +422,7 @@ jobs:
   build-genai-engine-docker-images:
     environment: shared-protected-branch-secrets
     if: |
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
@@ -495,6 +496,7 @@ jobs:
   build-ml-engine-docker-images:
     environment: shared-protected-branch-secrets
     if: |
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
@@ -576,6 +578,7 @@ jobs:
   check-models-updates:
     environment: shared-protected-branch-secrets
     if: |
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
@@ -649,6 +652,7 @@ jobs:
     needs: [check-models-updates]
     if: |
       needs.check-models-updates.outputs.has_updates == 'true' &&
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     with:
@@ -661,6 +665,7 @@ jobs:
     environment: shared-protected-branch-secrets
     if: |
       needs.check-models-updates.outputs.has_updates == 'false' &&
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
@@ -700,6 +705,7 @@ jobs:
     needs: [check-models-updates]
     if: |
       needs.check-models-updates.outputs.has_updates == 'true' &&
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     with:
@@ -712,6 +718,7 @@ jobs:
     environment: shared-protected-branch-secrets
     if: |
       needs.check-models-updates.outputs.has_updates == 'false' &&
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
@@ -750,6 +757,7 @@ jobs:
     uses: ./.github/workflows/build-gcp-model-upload.yml
     needs: [check-models-updates]
     if: |
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     with:
@@ -761,6 +769,7 @@ jobs:
     needs: [build-genai-engine-docker-images, build-ml-engine-docker-images]
     environment: shared-protected-branch-secrets
     if: |
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
@@ -795,6 +804,7 @@ jobs:
     needs: [build-genai-engine-docker-images, build-ml-engine-docker-images]
     environment: shared-protected-branch-secrets
     if: |
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
@@ -856,6 +866,7 @@ jobs:
       !cancelled() &&
       needs.build-genai-engine-docker-images.result == 'success' &&
       needs.build-ml-engine-docker-images.result == 'success' &&
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
@@ -937,7 +948,8 @@ jobs:
     needs: [build-genai-engine-docker-images, build-ml-engine-docker-images]
     environment: shared-protected-branch-secrets
     if: |
-      (contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
+      (github.repository == 'arthur-ai/arthur-engine' &&
+      contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     permissions:
@@ -971,6 +983,7 @@ jobs:
   push-tag:
     needs: [push-all-cfts, push-all-helm-charts]
     if: |
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
@@ -990,6 +1003,7 @@ jobs:
   deploy-genai-engine-cloudformation:
     needs: [push-tag]
     if: |
+      github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds `github.repository == 'arthur-ai/arthur-engine'` to the `if:` of the 14 jobs that publish or deploy official artifacts.

**In this repository the condition is always true, so behavior is unchanged.** No job that runs today stops running. The diff is 15 added lines and 1 reworded line in a single file.

## Why

Those 14 jobs are gated on the version-bump commit message plus `github.ref == 'refs/heads/main' || 'refs/heads/dev'`. Neither condition is repository-scoped, so a fork whose default branch is named `main` or `dev` satisfies both on an ordinary commit.

For a random public fork this is mostly harmless — secrets are empty there, so the jobs fail at authentication and just produce noisy red runs. The case that matters is a fork that legitimately holds credentials: an in-org fork created for migration or staging work typically has a Docker Hub token for the `arthurplatform` namespace and can assume the S3/ECS roles. On such a fork these jobs would:

- push to the official `arthurplatform/genai-engine-cpu|gpu`, `ml-engine`, and `genai-engine-models-*` image tags
- overwrite the public `arthur-cft` objects under both the versioned and `latest` prefixes — CloudFormation templates, SBOMs, and the AI-BOM
- push release git tags
- run the ECS deploy

We hit this on a downstream fork and have been carrying the condition locally; upstreaming it removes the divergence.

## Secondary benefit

Putting the check on each gate makes it inherited by construction. A new publish job copied from an existing one carries the scope with it, instead of relying on the author remembering. `push-aibom` is a recent example of a new gate that landed without it.

## Tradeoff worth naming

The repository name is hardcoded, so renaming the repo or moving orgs would silently disable all 14 jobs. A repo-level variable would avoid that. I went with the literal because it matches the existing style of these `if:` blocks and needs no configuration, but happy to switch to a variable if you'd prefer.

## Jobs covered

`build-genai-engine-docker-images`, `build-ml-engine-docker-images`, `check-models-updates`, `build-genai-engine-models-docker-image`, `tag-genai-engine-models-docker-image`, `build-genai-engine-models-fs-docker-image`, `tag-genai-engine-models-fs-docker-image`, `build-gcp-model-upload-docker-image`, `push-all-cfts`, `push-aibom`, `push-all-sboms`, `push-all-helm-charts`, `push-tag`, `deploy-genai-engine-cloudformation`.

## Note on merging

Please avoid putting the version-bump trigger phrase into the squash commit subject or body when merging. `contains()` is case-insensitive, and once this change is in, that phrase on a `dev` commit would satisfy every gate here — including the repository check, since this *is* the canonical repo. The title and body above are deliberately written without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)