### PR TITLE
ci: fix auto-fix approval race (pin SHA) + flag major PRs for human review

### DIFF
--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -285,23 +285,34 @@ jobs:
             exit 0
           fi
 
-          # Minor/patch: approve the EXACT fix commit — but only once GitHub reports it as the
-          # PR head. A bare 'gh pr review --approve' immediately after a push races GitHub and
-          # can attach the approval to the PRE-push commit, which dismiss_stale_reviews_on_push
-          # then instantly dismisses. Pinning commit_id to FIX_SHA (and confirming it's head)
-          # makes the approval stick, and also means we never approve a stale head.
-          HEAD_SHA=""
-          for i in 1 2 3 4 5 6; do
+          # Minor/patch: approve the EXACT fix commit and CONFIRM the approval sticks.
+          # Why this dance: a bare `gh pr review --approve` right after a push races GitHub —
+          # the approval can attach to the PRE-push commit, which dismiss_stale_reviews_on_push
+          # then dismisses (observed on #2070: approval landed on the old SHA and was dismissed
+          # 1s later). This loop does not trust that reasoning; it verifies the END STATE:
+          #   (a) wait until GitHub reports FIX_SHA as the PR head,
+          #   (b) approve pinned to FIX_SHA,
+          #   (c) re-read reviews and confirm a NON-dismissed APPROVED review on FIX_SHA exists,
+          #   retrying if not. If the head has moved on to some other commit (a newer push
+          #   superseded us), FIX_SHA never becomes head and we exit without approving a stale
+          #   commit — a newer run/human owns it.
+          approved=false
+          for attempt in 1 2 3 4 5 6; do
             HEAD_SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha' || echo "")
-            [ "$HEAD_SHA" = "$FIX_SHA" ] && break
-            echo "Waiting for GitHub to register $FIX_SHA as PR head (currently ${HEAD_SHA:-unknown})..."
-            sleep 5
+            if [ "$HEAD_SHA" != "$FIX_SHA" ]; then
+              echo "PR head is ${HEAD_SHA:-unknown}, waiting for our fix $FIX_SHA to register (attempt $attempt/6)..."
+              sleep 5
+              continue
+            fi
+            gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+              -f commit_id="$FIX_SHA" -f event="APPROVE" \
+              -f body="🤖 Auto-fix verified: adapted the code to the dependency update and confirmed the full required suite passes locally. Approving $FIX_SHA to re-enter the merge queue." >/dev/null || true
+            sleep 4
+            STUCK=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+              | jq -r --arg sha "$FIX_SHA" 'any(.[]; .user.login=="github-actions[bot]" and .state=="APPROVED" and .commit_id==$sha)')
+            if [ "$STUCK" = "true" ]; then approved=true; echo "Approval confirmed sticking on $FIX_SHA."; break; fi
+            echo "Approval did not stick yet (attempt $attempt/6); retrying..."
           done
-          if [ "$HEAD_SHA" != "$FIX_SHA" ]; then
-            echo "::warning::PR head is $HEAD_SHA, not our fix $FIX_SHA — skipping approval so we never approve a stale commit."
-            exit 0
+          if [ "$approved" != "true" ]; then
+            echo "::warning::Could not confirm a sticking approval on $FIX_SHA after retries; leaving it for a human to approve."
           fi
-          gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
-            -f commit_id="$FIX_SHA" -f event="APPROVE" \
-            -f body="🤖 Auto-fix verified: adapted the code to the dependency update and confirmed the full required suite passes locally. Approving $FIX_SHA to re-enter the merge queue." >/dev/null
-          echo "Approved $FIX_SHA."

--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -21,8 +21,11 @@ name: Renovate Auto-Fix
 #
 # Identity split (required by the ruleset's require_last_push_approval +
 # dismiss_stale_reviews_on_push): the fix is PUSHED as the Arthur GitHub
-# Automator App, and RE-APPROVED as github-actions[bot] — two distinct actors,
-# so the post-push approval is valid.
+# Automator App, and APPROVED as github-actions[bot] — two distinct actors,
+# so the post-push approval is valid. The approval is pinned to the exact fix
+# commit SHA (a bare approve races the push and gets dismissed as stale).
+# Major-version PRs (labelled 'major' by Renovate) are fixed but NOT approved —
+# they get their title flagged for human review instead.
 #
 # This is a workflow_run listener; it only becomes active once merged to the
 # default branch (dev). It always runs the version of itself from the default
@@ -226,7 +229,7 @@ jobs:
             merge queue (and an independent Claude review) before merging. Never leave broken, unreviewed,
             or unverified edits.
 
-      - name: Commit, push & re-approve (only if verified)
+      - name: Commit, push, then approve (minor/patch) or flag (major)
         if: steps.guard.outputs.proceed == 'true'
         env:
           # Approve as github-actions[bot] — a DIFFERENT identity than the app that
@@ -255,13 +258,50 @@ jobs:
           git config user.email "${{ secrets.ARTHUR_GH_AUTOMATOR_APP_ID }}+arthur-github-automator[bot]@users.noreply.github.com"
           git add -A
           git commit -m "fix(deps): auto-resolve CI failures from dependency update [claude-autofix]"
-          # Push with the app token EXPLICITLY. Do not rely on the credential persisted by
-          # checkout: claude-code-action rewrites the workspace git auth config during its
-          # run, so the persisted header is gone by now. An installation token pushed as
-          # x-access-token is attributed to the Automator App (distinct from the approver).
+          FIX_SHA=$(git rev-parse HEAD)
+
+          # Push with the app token EXPLICITLY (checkout's persisted credential is gone —
+          # claude-code-action rewrites the workspace git auth during its run). The push is
+          # x-access-token, so GitHub attributes it to the Automator App (distinct from the
+          # approver). NOT a force push: if Renovate rebased this branch while Claude worked,
+          # this is a non-fast-forward and is rejected — safe, a newer run handles the new head.
           git push "https://x-access-token:${APP_TOKEN}@github.com/${{ github.repository }}.git" \
             "HEAD:$HEAD_BRANCH"
 
-          # Re-approve so the PR (now with a fresh commit) can re-enter the merge queue.
-          gh pr review "$PR_NUMBER" --repo "${{ github.repository }}" --approve \
-            -b "🤖 Auto-fix verified: adapted the code to the dependency update and confirmed the full required suite passes locally. Re-approving to re-enter the merge queue."
+          # Major-version bumps are labelled 'major' by Renovate. For those we adapt the code
+          # so CI passes, but do NOT self-approve — a human must review the major bump. We flag
+          # the title instead.
+          IS_MAJOR=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq 'any(.labels[]; .name == "major")')
+          if [ "$IS_MAJOR" = "true" ]; then
+            TITLE=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json title --jq '.title')
+            case "$TITLE" in
+              "⚠️ major update"*) : ;;  # already flagged on a previous attempt; don't stack
+              *) gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
+                   --title "⚠️ major update — human review required: $TITLE" ;;
+            esac
+            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body \
+              "🤖 Applied an auto-fix so CI passes, but this is a **major** dependency update, so it is **not** being auto-approved. A human should review and approve before it merges."
+            echo "Major update: flagged title, skipped self-approval."
+            exit 0
+          fi
+
+          # Minor/patch: approve the EXACT fix commit — but only once GitHub reports it as the
+          # PR head. A bare 'gh pr review --approve' immediately after a push races GitHub and
+          # can attach the approval to the PRE-push commit, which dismiss_stale_reviews_on_push
+          # then instantly dismisses. Pinning commit_id to FIX_SHA (and confirming it's head)
+          # makes the approval stick, and also means we never approve a stale head.
+          HEAD_SHA=""
+          for i in 1 2 3 4 5 6; do
+            HEAD_SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha' || echo "")
+            [ "$HEAD_SHA" = "$FIX_SHA" ] && break
+            echo "Waiting for GitHub to register $FIX_SHA as PR head (currently ${HEAD_SHA:-unknown})..."
+            sleep 5
+          done
+          if [ "$HEAD_SHA" != "$FIX_SHA" ]; then
+            echo "::warning::PR head is $HEAD_SHA, not our fix $FIX_SHA — skipping approval so we never approve a stale commit."
+            exit 0
+          fi
+          gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+            -f commit_id="$FIX_SHA" -f event="APPROVE" \
+            -f body="🤖 Auto-fix verified: adapted the code to the dependency update and confirmed the full required suite passes locally. Approving $FIX_SHA to re-enter the merge queue." >/dev/null
+          echo "Approved $FIX_SHA."

--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,11 @@
       "autoApprove": true
     },
     {
+      "description": "Label major updates so the auto-fixer can flag them for human review instead of self-approving.",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major"]
+    },
+    {
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "npm minor and patch"


### PR DESCRIPTION
Two fixes surfaced by the first true end-to-end auto-fix run (on #2070).

## 1. Approval race — the real bug (I initially misdiagnosed this as concurrency)

The live run on #2070 pushed Claude's fix and then approved, but the approval got **dismissed**. The timeline shows why:

```
07:17:22  automator app   committed  7c030378   (fix pushed → new head)
07:17:24  github-actions   APPROVED   f7d59e54   (approval attached to the OLD commit!)
07:17:25  automator app    review_dismissed
```

The approval's `commit_id` was the **pre-fix** SHA. A bare `gh pr review --approve` immediately after `git push` **races GitHub** — the approval lands on the stale head, which `dismiss_stale_reviews_on_push` then instantly dismisses. This is a race *inside the single run*, not concurrency between runs, so `cancel-in-progress`/stale-head-guard changes would not have fixed it.

**Fix:** capture the fix commit SHA, push (non-force), **poll until GitHub reports that SHA as the PR head**, then approve **that exact SHA** via the REST reviews API (`commit_id` pinned). The approval now sticks. As a bonus this also covers the stale-head concern for free: the push is non-force (a stale run is safely rejected as non-fast-forward), and we only approve when our SHA is still head.

## 2. Major PRs → human review, not auto-approval

Per direction: major-version bumps should not be silently auto-merged.

- **`renovate.json`**: label major updates `major`.
- **auto-fixer**: for a `major`-labelled PR, Claude still adapts the code so CI passes, but instead of self-approving it **prepends the title** with `⚠️ major update — human review required:`, comments, and **skips the approval** — a human approves the major bump.

(Applies to future major PRs once Renovate relabels them on its next run.)

## Validation
- YAML + JSON valid; the commit/push/approve step passes `bash -n`; `renovate-config-validator` shows no new errors (only the pre-existing `managerFilePatterns` v37-artifact ones).
- Real end-to-end confirmation comes on the next auto-fix run after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)