### PR TITLE
ci(renovate): resolve dep-conflict PRs (transformers cap + fsspec family grouping)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -76,6 +76,12 @@
       "allowedVersions": "<5.14.0"
     },
     {
+      "description": "fsspec and its filesystem backends are lockstep (gcsfs/s3fs/adlfs each pin a matching fsspec calendar version), so they must bump together. Splitting them into separate PRs makes each individually unsatisfiable.",
+      "matchManagers": ["pep621"],
+      "groupName": "fsspec filesystems",
+      "matchPackageNames": ["fsspec", "gcsfs", "s3fs", "adlfs"]
+    },
+    {
       "matchManagers": ["pep621"],
       "groupName": "langchain + openai",
       "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -70,6 +70,12 @@
       "enabled": false
     },
     {
+      "description": "Cap transformers < 5.14.0: gliner (load-bearing for PII/NER) pins transformers<5.14.0, and gliner 0.2.28 is the latest release, so transformers 5.14.x is unsatisfiable. Remove this once gliner relaxes its ceiling.",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["transformers"],
+      "allowedVersions": "<5.14.0"
+    },
+    {
       "matchManagers": ["pep621"],
       "groupName": "langchain + openai",
       "matchPackageNames": [


### PR DESCRIPTION
Implements **option 1** from the auto-fixer's diagnosis on [#2064](https://github.com/arthur-ai/arthur-engine/pull/2064#issuecomment-5143206110).

## Problem
The `python minor and patch` group (#2064) bumps `transformers → 5.14.1`, but `gliner==0.2.28` (latest on PyPI, load-bearing for PII/NER) requires `transformers<5.14.0,>=4.51.3`. So `transformers 5.14.1` is **one patch above gliner's ceiling** → uv resolution is unsatisfiable → every `genai-engine` job fails before running any code. (This is a version-pin conflict, out of scope for the auto-fixer, which correctly commented and stopped.)

## Fix
Add a Renovate `allowedVersions` cap so `transformers` stays `<5.14.0`:

```json
{
  "matchManagers": ["pep621"],
  "matchPackageNames": ["transformers"],
  "allowedVersions": "<5.14.0"
}
```

Mirrors the existing `postgres <17` constraint. Once merged, Renovate re-proposes the group with the highest compatible `transformers` (5.13.x), which resolves cleanly.

**Remove this rule once `gliner` relaxes its `transformers` ceiling** (0.2.28 is currently the newest release, so there's nothing to bump gliner to yet).

## After merge
Trigger a Renovate run (or tick #2064's rebase box) so #2064 regenerates with `transformers 5.13.x` + the already-resolved `arthur-common 2.4.68` / `litellm 1.93.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)