### PR TITLE
ci(renovate-autofix): label soak-blocked Renovate PRs

### DIFF
--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -183,6 +183,21 @@ jobs:
                 dependencies", incompatible version pins between packages).
               - Anything that would require changing a version pin or lockfile to resolve.
 
+            RELEASE-AGE SOAK (a specific out-of-scope case — flag it precisely instead of just "needs a
+            human"): the blocker is that a NEWER release of a dependency WOULD fix the build but is being
+            held back by this repo's 3-day soak — `minimumReleaseAge` in /renovate.json and
+            `tool.uv exclude-newer` in the pyproject.toml files. Tell-tale signs: `uv lock` reports the
+            fixing version is unavailable / "not at the requested version", OR a package imports a symbol
+            that a just-updated dependency renamed/removed and that dependency's compat patch was published
+            less than 3 days ago. When you identify this, IN ADDITION to the explanatory comment, label the
+            PR so humans can see it is a timing hold, not a defect:
+              `gh pr edit ${{ steps.pr.outputs.number }} --add-label "blocked: release-age soak"`
+            In the comment, name the package, the exact version that fixes it, and the UTC timestamp it
+            clears the soak (the fixing release's upload time + 3 days). Do NOT change any pin or lockfile
+            to pull it in early — the soak is deliberate. (The label pre-exists in the repo and
+            `pull-requests: write` is enough to apply it; if the `add-label` call ever fails because the
+            label is missing, skip it and rely on the comment — do not block on it.)
+
             HARD RULES (never violate — these protect the "don't break anything" objective):
               - Do NOT edit anything under .github/, any CI config, pyproject.toml/package.json version
                 pins, uv.lock, or yarn.lock.


### PR DESCRIPTION
## What

Teaches the Renovate auto-fixer (`renovate-autofix.yml`) to **label** a Renovate PR with `blocked: release-age soak` when the CI failure is caused by the repo's 3-day release-age soak — i.e. a newer release *would* fix the build but is being held back by `minimumReleaseAge` (renovate.json) / `tool.uv exclude-newer` (pyproject.toml), so neither Renovate nor `uv lock` can pull it in yet.

## Why

This exact situation just happened on #2064: `fastapi 0.136.3 → 0.140.9` broke `fastapi-pagination==0.15.15` (removed `get_body_field`); the fix — `fastapi-pagination==0.15.16` — existed but was < 3 days old, so it was soaking. Today the auto-fixer would (correctly) treat that as out-of-scope and post a generic "needs a human" comment. A dedicated label makes the **timing-hold-vs-actual-defect** distinction visible and filterable, so humans don't waste time investigating a PR that will go green on its own.

## How

- Adds a `RELEASE-AGE SOAK` clause to the auto-fixer's OUT-OF-SCOPE section describing the tell-tale signs (uv lock "not at the requested version"; a package importing a symbol a just-updated dep renamed/removed with a compat patch < 3 days old).
- On detection, it runs `gh pr edit <num> --add-label "blocked: release-age soak"` **in addition to** the explanatory comment (which now names the package, the fixing version, and the UTC time the soak clears).
- It must **not** change any pin/lockfile to force the fix in early — the soak is deliberate.

## Notes / scope

- **No new permissions**: `pull-requests: write` (already granted) is enough to apply an existing label. The label `blocked: release-age soak` is pre-created in the repo. The instruction is best-effort — if the label is ever missing, it skips labeling and falls back to the comment.
- **Adds, does not remove**: the label is applied on detection; removal when the soak clears (Renovate rebases → CI passes) isn't wired here, since the auto-fixer only triggers on *failure*. Tracking auto-removal as a possible follow-up.
- Prompt-only change to an existing workflow; the workflow always runs from the default branch, so it takes effect once merged to `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)