### PR TITLE
ci: stop uv network flakes on the en-core-web-lg direct-URL wheel

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -201,6 +201,12 @@ jobs:
               - 'genai-engine/Dockerfile*'
               - 'genai-engine/docker-compose.yml'
               - 'arthur-observability-sdk/**'
+              # Changes to the CI plumbing itself must exercise the jobs they
+              # affect, otherwise a broken workflow edit passes as an all-skipped
+              # green run and only surfaces in the merge queue, where it blocks
+              # everyone.
+              - '.github/workflows/arthur-engine-workflow.yml'
+              - '.github/workflows/composite-actions/**'
       # In the merge queue there is no PR base to diff against, and paths-filter's
       # base detection is unreliable on merge_group. Run the full required suite as
       # the final pre-merge gate instead of trying to narrow it by path.
@@ -239,6 +245,9 @@ jobs:
               - 'ml-engine/**'
               - 'arthur-observability-sdk/**'
               - 'genai-engine/staging.openapi.json'
+              # See the note in check-genai-engine-changes.
+              - '.github/workflows/arthur-engine-workflow.yml'
+              - '.github/workflows/composite-actions/**'
       # In the merge queue, run the full required suite (see note above).
       - name: Decide affected areas
         id: decide

--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -51,22 +51,22 @@ jobs:
         id: isort
         continue-on-error: true
         run: |
-          uv run --directory genai-engine isort src --profile black --check
+          uv run --no-sync --directory genai-engine isort src --profile black --check
       - name: Run autoflake
         id: autoflake
         continue-on-error: true
         run: |
-          uv run --directory genai-engine autoflake --remove-all-unused-imports --in-place --check --recursive --quiet src
+          uv run --no-sync --directory genai-engine autoflake --remove-all-unused-imports --in-place --check --recursive --quiet src
       - name: Run black
         id: black
         continue-on-error: true
         run: |
-          uv run --directory genai-engine black --check src
+          uv run --no-sync --directory genai-engine black --check src
       - name: Run mypy
         id: mypy
         continue-on-error: true
         run: |
-          uv run --directory genai-engine mypy src
+          uv run --no-sync --directory genai-engine mypy src
       - name: Check linter results
         if: steps.isort.outcome == 'failure' || steps.autoflake.outcome == 'failure' || steps.black.outcome == 'failure' || steps.mypy.outcome == 'failure'
         run: |
@@ -102,22 +102,22 @@ jobs:
         id: isort
         continue-on-error: true
         run: |
-          uv run --directory ml-engine isort src/ml_engine --profile black --check
+          uv run --no-sync --directory ml-engine isort src/ml_engine --profile black --check
       - name: Run autoflake
         id: autoflake
         continue-on-error: true
         run: |
-          uv run --directory ml-engine autoflake --remove-all-unused-imports --in-place --check --recursive --quiet src/ml_engine
+          uv run --no-sync --directory ml-engine autoflake --remove-all-unused-imports --in-place --check --recursive --quiet src/ml_engine
       - name: Run black
         id: black
         continue-on-error: true
         run: |
-          uv run --directory ml-engine black --check src/ml_engine
+          uv run --no-sync --directory ml-engine black --check src/ml_engine
       - name: Run mypy
         id: mypy
         continue-on-error: true
         run: |
-          uv run --directory ml-engine mypy src/ml_engine
+          uv run --no-sync --directory ml-engine mypy src/ml_engine
       - name: Check linter results
         if: steps.isort.outcome == 'failure' || steps.autoflake.outcome == 'failure' || steps.black.outcome == 'failure' || steps.mypy.outcome == 'failure'
         run: |
@@ -151,7 +151,7 @@ jobs:
           GENAI_ENGINE_DEMO_MODE: ENABLED
           PYTHONPATH: src
         run: |
-          uv run --directory genai-engine generate_changelog
+          uv run --no-sync --directory genai-engine generate_changelog
       - name: Upload artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -331,7 +331,7 @@ jobs:
           GENAI_ENGINE_SECRET_STORE_KEY: changeme_secret_store_key
         run: |
           set -o pipefail
-          uv run --directory genai-engine pytest --cov --cov=src \
+          uv run --no-sync --directory genai-engine pytest --cov --cov=src \
             --cov-report term \
             --junitxml=report.xml \
             -m "unit_tests" | tee pytest-coverage.txt
@@ -388,7 +388,7 @@ jobs:
           PYTHONPATH: "src:$PYTHONPATH"
         run: |
           cd genai-engine
-          uv run alembic upgrade head
+          uv run --no-sync alembic upgrade head
 
   run-ml-engine-unit-tests:
     needs: check-ml-engine-changes
@@ -417,7 +417,7 @@ jobs:
             --skip-validate-spec --package-name genai_client
       - name: Run unit-tests
         run: |
-          uv run --directory ml-engine pytest tests/unit
+          uv run --no-sync --directory ml-engine pytest tests/unit
 
   build-genai-engine-docker-images:
     environment: shared-protected-branch-secrets

--- a/.github/workflows/arthur-observability-sdk-workflow.yml
+++ b/.github/workflows/arthur-observability-sdk-workflow.yml
@@ -55,22 +55,22 @@ jobs:
         id: isort
         continue-on-error: true
         run: |
-          uv run --directory arthur-observability-sdk/python isort src/arthur_observability_sdk tests --profile black --check
+          uv run --no-sync --directory arthur-observability-sdk/python isort src/arthur_observability_sdk tests --profile black --check
       - name: Run autoflake
         id: autoflake
         continue-on-error: true
         run: |
-          uv run --directory arthur-observability-sdk/python autoflake --remove-all-unused-imports --in-place --check --recursive --quiet src/arthur_observability_sdk tests
+          uv run --no-sync --directory arthur-observability-sdk/python autoflake --remove-all-unused-imports --in-place --check --recursive --quiet src/arthur_observability_sdk tests
       - name: Run black
         id: black
         continue-on-error: true
         run: |
-          uv run --directory arthur-observability-sdk/python black --check src/arthur_observability_sdk tests
+          uv run --no-sync --directory arthur-observability-sdk/python black --check src/arthur_observability_sdk tests
       - name: Run mypy
         id: mypy
         continue-on-error: true
         run: |
-          uv run --directory arthur-observability-sdk/python mypy src/arthur_observability_sdk
+          uv run --no-sync --directory arthur-observability-sdk/python mypy src/arthur_observability_sdk
       - name: Check linter results
         if: steps.isort.outcome == 'failure' || steps.autoflake.outcome == 'failure' || steps.black.outcome == 'failure' || steps.mypy.outcome == 'failure'
         run: |
@@ -104,7 +104,7 @@ jobs:
           with-groups: dev
       - name: Run unit tests
         run: |
-          uv run --directory arthur-observability-sdk/python pytest tests -m "unit_tests" -v
+          uv run --no-sync --directory arthur-observability-sdk/python pytest tests -m "unit_tests" -v
 
   run-integration-tests:
     needs: generate-client
@@ -129,7 +129,7 @@ jobs:
           with-groups: dev
       - name: Run integration tests
         run: |
-          uv run --directory arthur-observability-sdk/python pytest tests -m "integration_tests" -v
+          uv run --no-sync --directory arthur-observability-sdk/python pytest tests -m "integration_tests" -v
 
   check-new-instrumentors:
     runs-on: ubuntu-latest

--- a/.github/workflows/composite-actions/setup-uv/action.yml
+++ b/.github/workflows/composite-actions/setup-uv/action.yml
@@ -1,6 +1,11 @@
 name: "Setup uv"
 description: "Installs uv and syncs dependencies"
 
+# This action leaves a fully synced environment behind, so steps that follow it
+# should invoke tools as `uv run --no-sync`. Without that flag `uv run` re-checks
+# the lockfile, which forces a network round trip for `en-core-web-lg` (a
+# direct-URL wheel, not a registry package) on every single step.
+
 inputs:
   working-directory:
     description: "Directory containing the pyproject.toml file"
@@ -15,9 +20,15 @@ runs:
   steps:
     - name: "Install uv"
       shell: bash
-      run: curl -LsSf https://astral.sh/uv/0.11.7/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+      run: curl -LsSf --retry 5 --retry-delay 2 --retry-all-errors https://astral.sh/uv/0.11.7/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
     - name: "Install dependencies"
       shell: bash
+      env:
+        # `en-core-web-lg` is served from github.com's release CDN, which answers
+        # parallel fetches with HTTP/2 REFUSED_STREAM once enough streams are open.
+        # Capping concurrency keeps the resolver inside what that CDN tolerates.
+        UV_CONCURRENT_DOWNLOADS: "4"
+        UV_HTTP_TIMEOUT: "120"
       run: |
         uv --version
         GROUPS_FLAG=""
@@ -27,4 +38,16 @@ runs:
             GROUPS_FLAG="$GROUPS_FLAG --group $group"
           done
         fi
-        uv sync --directory ${{ inputs.working-directory }} --frozen $GROUPS_FLAG
+        # uv's built-in retries cover a single request; a CDN that is refusing
+        # streams outright can outlast them, so retry the whole sync with backoff.
+        for attempt in 1 2 3; do
+          if uv sync --directory ${{ inputs.working-directory }} --frozen $GROUPS_FLAG; then
+            exit 0
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "::warning::uv sync failed (attempt ${attempt}/3), retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          fi
+        done
+        echo "::error::uv sync failed after 3 attempts"
+        exit 1


### PR DESCRIPTION
## Problem

CI has been failing intermittently across three separate genai-engine jobs — unit tests, linter, and changelog-cop — with:

```
error: Failed to generate package metadata for `en-core-web-lg==3.8.0 @
  direct+https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/...whl`
  Caused by: Request failed after 3 retries in 6.3s
  Caused by: http2 error
  Caused by: stream error received: refused stream before processing any application logic
```

Four occurrences in a ~50 minute window, including one that ejected [#2103](https://github.com/arthur-ai/arthur-engine/pull/2103) from the merge queue ([run 31633980794](https://github.com/arthur-ai/arthur-engine/actions/runs/31633980794/job/94239569401)):

| Run | Job | Broke at |
|---|---|---|
| 31633980794 | unit-tests | `uv run` (test step) |
| 31630175794 | linter | `setup-uv` (`uv sync`) |
| 31629969353 | changelog-cop | `setup-uv` (`uv sync`) |
| 31630603866 | unit-tests | resolution failure |

`en-core-web-lg` is declared as a direct-URL wheel (`genai-engine/pyproject.toml:53`) rather than a registry package, so every uv operation has to reach github.com's release CDN for it. That CDN answers parallel fetches with HTTP/2 `REFUSED_STREAM` under load, and uv's three built-in per-request retries don't outlast it.

## Fixes

Two independent failure points, so two fixes.

**1. `uv run` → `uv run --no-sync` (18 call sites).** All 18 run *after* the `setup-uv` composite has already synced the environment, but plain `uv run` still re-validates the lockfile — and validating a direct-URL requirement means a network round trip. This is precisely what broke the unit-test job, where `setup-uv` had already succeeded moments earlier.

**2. `setup-uv` genuinely needs the network, so make it resilient.** Retry `uv sync` up to 3× with backoff, cap `UV_CONCURRENT_DOWNLOADS` to stay under the CDN's stream limit, and add curl retries to the uv installer itself.

### Plus a third fix that fell out of testing

The first push to this PR came back **green with every affected job skipped** — the paths filters covered every source tree but not the workflow files driving them. A change to `arthur-engine-workflow.yml` or the composite actions produced an all-skipped green run, deferring all validation to the merge queue, which forces `backend=true` and is the worst place to discover a broken workflow edit since a failure there blocks every queued PR.

Second commit adds `.github/workflows/arthur-engine-workflow.yml` and `.github/workflows/composite-actions/**` to both filters.

## Verification

Reproduced the exact CI failure locally by forcing the cold-cache condition CI runs under:

```
$ uv lock --check --offline --no-cache --directory genai-engine
error: Failed to generate package metadata for `en-core-web-lg==3.8.0 @ direct+https://...`   # same error as CI

$ uv run --no-sync --offline --no-cache --directory genai-engine python -c "print('ok')"
ok                                                                                            # fix works
```

The retry loop was exercised under GitHub's `bash -e -o pipefail` for the success, fail-then-recover, and exhaust-all-attempts paths.

With the filter fix in place, [run 31636407834](https://github.com/arthur-ai/arthur-engine/actions/runs/31636407834) exercised all six changed jobs for real — all green:

`run-genai-engine-unit-tests` · `run-genai-engine-linter` · `run-genai-engine-changelog-cop` · `run-genai-engine-alembic-migration-check` · `run-ml-engine-linter` · `run-ml-engine-unit-tests`

## Why `--no-sync` is safe at all 18 sites

- No pyproject sets `default-groups`, so uv's default of `["dev"]` applies — `setup-uv`'s sync already installs `pytest`/`pytest-cov`, plus any groups passed via `with-groups` (`linters`).
- ml-engine's `genai_client` is not a declared dependency (it's on `pythonpath` via pytest config), so skipping the sync doesn't affect it. This actually *protects* the ml-engine linter job, whose manually `uv pip install`ed `genai_client` could previously be pruned by a re-sync.
- `arthur-observability-sdk-release.yml` deliberately bypasses `setup-uv` and is left untouched; the `uv run` strings in `renovate-autofix.yml` are local-dev instructions in a PR body template, where syncing is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)