### PR TITLE
ci(renovate): resume auto-merge for low-risk updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,8 +42,8 @@
     {
       "description": "Auto-merge low-risk update types. lockFileMaintenance (nightly lockfile refresh) and replacement (curated drop-in package swaps from replacements:all) are gated by CI + the auto-fixer like minor/patch, so they merge without a human reviewer instead of sitting open.",
       "matchUpdateTypes": ["minor", "patch", "lockFileMaintenance", "replacement"],
-      "automerge": false,
-      "autoApprove": false
+      "automerge": true,
+      "autoApprove": true
     },
     {
       "description": "Label major updates so the auto-fixer can flag them for human review instead of self-approving.",


### PR DESCRIPTION
## What

Flips the low-risk Renovate rule in `renovate.json` back to `automerge: true` / `autoApprove: true`, reverting the pause from #2104.

## Why

#2104 paused auto-merge on 2026-08-04 as a keyv/Shai-Hulud supply-chain precaution. That window has passed, and the pause has left approved, all-green dependency PRs sitting open waiting for a human to click merge (e.g. #2116, #2103) — the rule's own description still claims these auto-merge.

Both flags flip together on purpose: the `dev` ruleset requires 1 approving review, and the auto-fixer only approves PRs it had to fix. With `automerge: true` but `autoApprove: false`, low-risk PRs would enable auto-merge and then never satisfy the review requirement.

## Guardrails unchanged

- `minimumReleaseAge: 3 days` soak (the supply-chain guard that actually covers this class of attack), plus the Yarn-layer and `exclude-newer` cooldowns.
- All 6 required checks must pass on the PR **and** on the merge-queue branch.
- Major bumps keep `addLabels: ["major"]` and stay routed to human reviewers — they are never auto-approved.

## Scope

Only `minor`, `patch`, `lockFileMaintenance`, and `replacement` update types are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)