### PR TITLE
ci: let the claude[bot] actor through the Claude review gate

### DIFF
--- a/.github/workflows/arthur-observability-sdk-workflow.yml
+++ b/.github/workflows/arthur-observability-sdk-workflow.yml
@@ -175,7 +175,23 @@ jobs:
             --body "**Docs reminder:** \`python/src/arthur_observability_sdk/\` was modified in this PR but \`docs/\` was not updated. Consider running \`scripts/update-docs.sh\` locally (requires the \`claude\` CLI) and committing any resulting changes. This is a reminder only — the PR is not blocked."
 
   claude-code-review:
-    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'renovate' && github.event.pull_request.user.login != 'renovate[bot]'
+    # Mirrors the gate in claude-code-review.yml: skip pure Renovate syncs, but keep
+    # reviewing once our Automator App pushes a Claude auto-fix onto a Renovate PR.
+    # Renovate rebases show up as github.actor even when pull_request.user.login is
+    # someone else, and claude-code-action gates on the triggering actor — guarding
+    # only on the author lets the job start and then hard-fail with
+    # "Workflow initiated by non-human actor: renovate".
+    if: >-
+      github.event_name == 'pull_request' &&
+      (
+        (
+          github.event.pull_request.user.login != 'renovate' &&
+          github.event.pull_request.user.login != 'renovate[bot]' &&
+          github.actor != 'renovate' &&
+          github.actor != 'renovate[bot]'
+        ) ||
+        github.actor == 'arthur-github-automator-app[bot]'
+      )
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
@@ -196,4 +212,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          allowed_bots: 'arthur-github-automator-app'
+          # Keep in sync with claude-code-review.yml — see the note there on why
+          # 'claude' (the Claude-in-Slack / Claude Code web app) is allowed.
+          allowed_bots: 'arthur-github-automator-app,arthur-blazity-ai-workflow,claude'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,7 +57,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_bots: 'arthur-github-automator-app,arthur-blazity-ai-workflow'
+          # Bots whose PRs we still want reviewed. The action strips a trailing
+          # '[bot]' before matching, so bare logins are correct here.
+          # 'claude' is the Claude-in-Slack / Claude Code web app: PRs it opens are
+          # Claude-authored code, exactly what this job exists to give a second look.
+          allowed_bots: 'arthur-github-automator-app,arthur-blazity-ai-workflow,claude'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Before

Both Claude review jobs fail on any PR opened by the Claude-in-Slack app, e.g. [#2141](https://github.com/arthur-ai/arthur-engine/pull/2141):

```
Action failed with error: Workflow initiated by non-human actor: claude (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

Those PRs run as actor `claude[bot]`, which is in neither job's `allowed_bots`. The `if:` gates only screen out Renovate, so each job starts, obtains its app token, and then hard-fails at the actor check — no review is posted. Both jobs are `continue-on-error: true`, so this is a red check rather than a blocked run.

## After

`claude[bot]` PRs get reviewed like any other.

## How

`claude-code-action` lowercases each `allowed_bots` entry and strips a trailing `[bot]` before comparing against the normalized actor ([`src/github/validation/actor.ts`](https://github.com/anthropics/claude-code-action/blob/main/src/github/validation/actor.ts)), so the bare login `claude` is the correct entry.

Allowing rather than skipping is deliberate: the policy comment already in `claude-code-review.yml` is that code Claude wrote always gets an independent, fresh-context review pass, and a Slack-opened PR is exactly that.

While in the same job in `arthur-observability-sdk-workflow.yml`, two ways it had drifted from its sibling in `claude-code-review.yml`:

- `allowed_bots` was missing `arthur-blazity-ai-workflow` (added to the other workflow in #1945).
- Its gate checked only `pull_request.user.login`, not `github.actor` — the author-only bug fixed for the other workflow in #2051 but never propagated. A Renovate *rebase* of a bot-authored SDK PR makes `github.actor` `renovate[bot]` while the author stays unchanged, so that job would hard-fail the same way. The gate now mirrors `claude-code-review.yml`.

## Verification

YAML parses on both files, and the gate was traced by hand for the failing case: author and actor both `claude[bot]` → neither is Renovate → job runs → `claude` matches `allowed_bots` → actor check passes. Matching semantics are read off the action source linked above.

What this PR's own CI does **not** prove: it is human-authored, so `claude-review` exercises the new YAML and gate but never reaches the `allowed_bots` branch; and the SDK workflow is path-filtered to `arthur-observability-sdk/**`, so it does not trigger here at all. The end-to-end proof is #2141 going green after this lands and it picks up the new workflow.

## Note for #2141

`pull_request` events read the workflow from the PR's merge commit, so #2141 will not go green from a plain re-run. It needs this merged to `dev` and then a rebase or a new push.

## Follow-up (not fixed here)

- SDK PRs get two Claude reviews — `claude-review` from `claude-code-review.yml` (all PRs) and `claude-code-review` from the SDK workflow (SDK paths). Pre-existing duplication, worth collapsing separately.
- The two `allowed_bots` lists are now identical but still maintained by hand; they have drifted twice already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)