### PR TITLE
ci: catch pyproject/uv.lock drift before it merges

### DIFF
--- a/.github/scripts/check-lockfile-drift.sh
+++ b/.github/scripts/check-lockfile-drift.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Fail if any uv.lock in the repo disagrees with the pyproject.toml beside it.
+#
+# `uv lock --check` re-resolves from the manifest and exits non-zero if the
+# lockfile is not what that resolution produces. It catches both shapes of the
+# drift Renovate can leave behind:
+#
+#   1. The manifest is unsatisfiable, so the lock could never have been
+#      regenerated (openai==3.0.0 against litellm's openai<3.0.0, PR #2134).
+#   2. The manifest resolves fine but the lock still pins the old version, so
+#      the "upgrade" is absent from everything that installs with --frozen
+#      (python-keycloak==7.1.1 with 5.12.0 locked, PR #2124).
+#
+# Projects are discovered rather than listed, so a new one is covered the day it
+# is added instead of the day someone remembers to extend this script.
+#
+# Runs in CI via .github/workflows/arthur-engine-workflow.yml; safe to run
+# locally from the repo root as well.
+
+# No `set -e`: every failure below is inspected and reported deliberately rather
+# than aborting the run, so a second broken project is still shown to whoever has
+# to fix them.
+set -uo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)" || {
+  echo "::error::Not inside a git repository; cannot locate the projects to check." >&2
+  exit 1
+}
+cd "$repo_root" || exit 1
+
+# Populated with a read loop rather than `mapfile`, which macOS's bash 3.2 does
+# not have — this script is meant to run locally as well as on the CI runner.
+LOCKS=()
+while IFS= read -r lock; do
+  LOCKS+=("$lock")
+done < <(
+  find . -name uv.lock \
+    -not -path '*/node_modules/*' \
+    -not -path '*/.venv/*' \
+    -not -path '*/.git/*' \
+    | sort
+)
+
+if [ "${#LOCKS[@]}" -eq 0 ]; then
+  echo "::error::No uv.lock files found. Either the repo layout moved or this script is looking in the wrong place."
+  exit 1
+fi
+
+echo "Checking ${#LOCKS[@]} uv project(s) against their manifests."
+echo
+
+stale=()
+unresolvable=()
+diagnostics=""
+
+for lock in "${LOCKS[@]}"; do
+  proj="$(dirname "$lock")"
+  proj="${proj#./}"
+
+  if [ ! -f "$proj/pyproject.toml" ]; then
+    echo "::error file=$lock::$lock has no pyproject.toml beside it."
+    unresolvable+=("$proj")
+    continue
+  fi
+
+  printf '%-42s ' "$proj"
+
+  if uv lock --check --directory "$proj" >/dev/null 2>&1; then
+    echo "ok"
+    continue
+  fi
+
+  # --check only reports THAT the lock is wrong. Re-running the real resolve is
+  # what separates the two causes, and they need opposite responses: a stale lock
+  # just has to be regenerated, while an unsatisfiable manifest means the bump
+  # itself cannot stand. `uv lock` leaves the file untouched when it fails, so the
+  # restore below only matters on the stale path.
+  if out=$(uv lock --directory "$proj" 2>&1); then
+    echo "STALE — lock not regenerated for the manifest change"
+    stale+=("$proj")
+    diagnostics="${diagnostics}
+--- ${proj}: regenerating the lock changes these pins ---
+${out}
+$(git --no-pager diff --stat -- "$proj/uv.lock" 2>/dev/null)
+"
+  else
+    echo "UNRESOLVABLE — pyproject.toml has no valid resolution"
+    unresolvable+=("$proj")
+    diagnostics="${diagnostics}
+--- ${proj}: the manifest cannot be resolved at all ---
+${out}
+"
+  fi
+  git checkout -- "$proj/uv.lock" 2>/dev/null || true
+done
+
+echo
+
+if [ "${#stale[@]}" -eq 0 ] && [ "${#unresolvable[@]}" -eq 0 ]; then
+  echo "All uv.lock files agree with their manifests."
+  exit 0
+fi
+
+echo "$diagnostics"
+
+# Written to the job summary as well as the log: this failure is nearly always a
+# Renovate PR, and the person triaging it needs the decision tree, not a stack
+# trace. Keep this in sync with the packageRules commentary in /renovate.json.
+{
+  echo
+  echo "## Lockfile drift detected"
+  echo
+  echo "\`pyproject.toml\` and \`uv.lock\` disagree, so what the manifest declares is"
+  echo "**not** what \`uv sync --frozen\` installs — not in CI, not in the Docker"
+  echo "images, not in a teammate's checkout. If this is a Renovate PR, its lockfile"
+  echo "step failed and it shipped the manifest edit on its own."
+  echo
+
+  if [ "${#stale[@]}" -gt 0 ]; then
+    echo "### Stale lock: ${stale[*]}"
+    echo
+    echo "The manifest resolves fine; the lock simply was not regenerated, so the"
+    echo "update is absent from everything that installs from it. Regenerate and"
+    echo "commit:"
+    echo
+    for proj in "${stale[@]}"; do
+      echo "    uv lock --directory $proj"
+    done
+    echo
+  fi
+
+  if [ "${#unresolvable[@]}" -gt 0 ]; then
+    echo "### Unresolvable manifest: ${unresolvable[*]}"
+    echo
+    echo "No lockfile could satisfy this pyproject.toml, so regenerating will not"
+    echo "help. The resolver output above names both sides of the conflict. Either:"
+    echo
+    echo "1. **Move the lagging constraint forward.** If the package blocking the"
+    echo "   update has a release that accepts the new version, bump it in the same"
+    echo "   PR. Never cap or downgrade the package the PR is updating — that turns"
+    echo "   the PR into a no-op while making it look fixed."
+    echo "2. **Cap it, if the blocker is upstream with no fix yet.** Close the PR and"
+    echo "   add an \`allowedVersions\` rule for the package in \`/renovate.json\`,"
+    echo "   naming the dependency that imposes the ceiling and the condition for"
+    echo "   lifting it, so Renovate stops re-proposing an update that cannot land."
+    echo "   The \`openai\`, \`transformers\` and \`importlib-metadata\` rules there are"
+    echo "   existing examples."
+    echo
+  fi
+
+  echo "Do not resolve this by hand-editing uv.lock."
+} | tee -a "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+exit 1

--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -162,6 +162,64 @@ jobs:
             genai-engine/staging.openapi.json
             genai-engine/src/api_changelog.md
 
+  # Renovate's pep621 manager edits pyproject.toml and regenerates uv.lock as a
+  # separate "artifact" step. When that regeneration fails — typically because the
+  # new version violates a transitive constraint of another pinned dependency —
+  # Renovate still opens the PR with the manifest edit ALONE, and does not
+  # reliably flag it in the PR body. Renovate offers no option to fail closed
+  # here (see /renovate.json), so the repo has to detect it.
+  #
+  # Nothing else in CI can: every Python job installs with `uv sync --frozen`,
+  # which replays uv.lock verbatim and never compares it against pyproject.toml.
+  # A manifest-only PR is therefore fully green, merges, and leaves the two files
+  # disagreeing — at which point `uv lock` fails for everyone, and the upgrade the
+  # PR claimed to make was never actually applied to what ships. That is how
+  # openai==3.0.0 (#2134, unresolvable against litellm) and python-keycloak==7.1.1
+  # (#2124, which shipped 5.12.0 for weeks) both landed.
+  #
+  # This job is the gate. It must live in THIS workflow: renovate-autofix.yml
+  # listens for "Arthur Engine CI" failing, so a gate in a separate workflow would
+  # never hand the failure to the auto-fixer.
+  check-dependency-automation:
+    if: |
+      (
+        github.event_name == 'pull_request' ||
+        github.event_name == 'merge_group' ||
+        (github.event_name == 'push' && github.ref_type == 'branch')
+      ) &&
+      github.ref != 'refs/heads/main' &&
+      github.ref != 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      # Deliberately NOT the setup-uv composite: that one runs `uv sync --frozen`
+      # against a single project, which is both far more work than this needs and
+      # the very command that cannot see the drift.
+      - name: Install uv
+        run: |
+          curl -LsSf --retry 5 --retry-delay 2 --retry-all-errors \
+            https://astral.sh/uv/0.11.7/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+          uv --version
+      - name: Verify every uv.lock agrees with its pyproject.toml
+        shell: bash
+        run: .github/scripts/check-lockfile-drift.sh
+      # An invalid /renovate.json does not fail loudly — Renovate keeps running on
+      # its last good config, or stops opening PRs, and either way dependency
+      # updates quietly stall. The failure message above actively tells people to
+      # go add allowedVersions rules there, so the file needs a syntax gate. Only
+      # worth the validator's install cost when the file actually changed.
+      - uses: dorny/paths-filter@v2
+        id: renovate-config
+        if: github.event_name != 'merge_group'
+        with:
+          filters: |
+            changed:
+              - 'renovate.json'
+      - name: Validate renovate.json
+        if: github.event_name == 'merge_group' || steps.renovate-config.outputs.changed == 'true'
+        run: npx --yes --package renovate renovate-config-validator renovate.json
+
   check-genai-engine-changes:
     if: |
       (

--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -264,6 +264,23 @@ jobs:
                 `... autoflake --remove-all-unused-imports --in-place --recursive src`, `... black src`
               - UI: `cd genai-engine/ui && corepack enable && yarn install --immutable`, then
                 `yarn type-check && yarn lint && yarn format:check` (fixer: `yarn format`)
+              - Lockfile drift: `.github/scripts/check-lockfile-drift.sh` (every uv project at once)
+
+            ## IF THE FAILING CHECK IS `check-dependency-automation`
+
+            This one has a specific cause, so do not treat it as a generic red check. Renovate updates
+            pyproject.toml and regenerates uv.lock in a separate step; when that second step fails it
+            opens the PR with the manifest edit ALONE. The script prints which of two states it found,
+            and they need opposite responses:
+
+              - **STALE** — the manifest resolves, the lock just was not regenerated. This is the easy
+                case and it IS your job: run `uv lock --directory <project>` for each project it names,
+                confirm the diff contains the update the PR is for, and carry on. Nothing else to fix.
+              - **UNRESOLVABLE** — no lockfile can satisfy the manifest, so re-locking will not help.
+                The resolver output names both sides. If the package blocking the update has a release
+                that accepts the new version, bump that one too (invariant 1: move the LAGGING package
+                forward, never cap or downgrade the one the PR is updating). If no such release exists,
+                you cannot fix this — see below.
 
             ## WHEN YOU CANNOT REACH THE GOAL
 
@@ -275,6 +292,16 @@ jobs:
             This includes any case where the only path to green would break an invariant — for example a
             required version does not exist yet, two updates in the PR are mutually incompatible at every
             available version, or the fix would have to change CI config or /renovate.json.
+
+            **Transitive ceiling** — the case where an UNRESOLVABLE manifest has no fix at any available
+            version: something else we pin caps the package this PR is updating, and no release of that
+            blocker accepts the new version yet. The update simply cannot land, and Renovate will keep
+            re-proposing it every run until told otherwise. Telling it otherwise means an `allowedVersions`
+            rule in /renovate.json, which invariant 6 forbids you from touching — so hand it over cleanly.
+            Say in your comment: the package and version being proposed, the pinned dependency that caps
+            it and the exact range it requires, that you verified no newer release of that blocker lifts
+            the cap, and the `allowedVersions` value a human should add. This is what should have happened
+            for openai 3.0.0 against litellm's `openai<3.0.0` (PR #2134).
 
             **Release-age soak** — flag this one precisely. The blocker is that a NEWER release WOULD fix the
             build but is held back by the 3-day soak (invariant 5). Tell-tale signs: `uv lock` reports the

--- a/.github/workflows/version-workflow.yml
+++ b/.github/workflows/version-workflow.yml
@@ -47,6 +47,14 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - uses: ./.github/workflows/composite-actions/setup-git
+      # Needed to re-lock after the pyproject version bumps below. Installed
+      # directly rather than via the setup-uv composite, which syncs a whole
+      # project environment this job has no use for. Keep the pin in step with
+      # the one in .github/workflows/composite-actions/setup-uv/action.yml.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.11.7"
       - name: Sync main into dev
         run: |
           git fetch origin main
@@ -151,8 +159,26 @@ jobs:
           sed -i "s/^version = \".*\"/version = \"$NEW_ARTHUR_ENGINE_VERSION\"/" ml-engine/pyproject.toml
           sed -i "s/^version = \".*\"/version = \"$NEW_ARTHUR_ENGINE_VERSION\"/" arthur-observability-sdk/python/pyproject.toml
 
+          # Each uv.lock records its own project's version, so the three seds above
+          # leave every lockfile disagreeing with its manifest until something else
+          # happens to re-lock. That drift is harmless on its own, but it is
+          # indistinguishable from the drift check-dependency-automation exists to
+          # catch, and it would leave that gate permanently red. Re-lock here so the
+          # invariant "uv.lock always matches pyproject.toml" holds on every commit.
+          #
+          # `uv lock` without --upgrade keeps every existing pin as a preference, so
+          # no dependency moves here: the only edits are the project's own version
+          # entry and the `exclude-newer` line, which records where the 3-day soak
+          # window sat at lock time and is recomputed on every run. It is deliberately
+          # allowed to fail the job: if a manifest no longer resolves, dev is already
+          # broken and cutting a release from it would only ship the breakage.
+          for proj in genai-engine ml-engine arthur-observability-sdk/python; do
+            echo "Re-locking ${proj} at ${NEW_ARTHUR_ENGINE_VERSION}"
+            uv lock --directory "$proj"
+          done
+
           # Add and commit changes
-          git add version genai-engine/version genai-engine/src/version genai-engine/pyproject.toml ml-engine/pyproject.toml arthur-observability-sdk/python/pyproject.toml genai-engine/staging.openapi.json $GENAI_ENGINE_HELM_CHART_YAML_PATH $GENAI_ENGINE_HELM_VALUES_YAML_PATH $ARTHUR_ENGINE_HELM_CPU_START_SCRIPT_PATH $ARTHUR_ENGINE_HELM_GPU_START_SCRIPT_PATH $ARTHUR_ENGINE_CFT_GPU_HTML_PATH $ARTHUR_ENGINE_CFT_CPU_HTML_PATH $ARTHUR_ENGINE_CHART_YAML_PATH $ARTHUR_ENGINE_VALUES_YAML_PATH $ML_ENGINE_CHART_YAML_PATH $ML_ENGINE_VALUES_YAML_PATH
+          git add version genai-engine/version genai-engine/src/version genai-engine/pyproject.toml ml-engine/pyproject.toml arthur-observability-sdk/python/pyproject.toml genai-engine/uv.lock ml-engine/uv.lock arthur-observability-sdk/python/uv.lock genai-engine/staging.openapi.json $GENAI_ENGINE_HELM_CHART_YAML_PATH $GENAI_ENGINE_HELM_VALUES_YAML_PATH $ARTHUR_ENGINE_HELM_CPU_START_SCRIPT_PATH $ARTHUR_ENGINE_HELM_GPU_START_SCRIPT_PATH $ARTHUR_ENGINE_CFT_GPU_HTML_PATH $ARTHUR_ENGINE_CFT_CPU_HTML_PATH $ARTHUR_ENGINE_CHART_YAML_PATH $ARTHUR_ENGINE_VALUES_YAML_PATH $ML_ENGINE_CHART_YAML_PATH $ML_ENGINE_VALUES_YAML_PATH
           git status
           git diff --cached
           git commit --no-verify -m "Increment arthur-engine version to ${NEW_ARTHUR_ENGINE_VERSION}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,30 @@ Arthur Engine is an AI/ML monitoring and governance platform. Each component has
 - Repo skills cover environment setup and running the stack: `setup-genai-dev`, `start-genai-backend`, `start-genai-frontend`.
 - Full-stack local deployment: [deployment/docker-compose/genai-engine/](deployment/docker-compose/genai-engine/) (`cp .env.template .env`, then `docker compose up`).
 
+## Dependencies
+
+Every Python project here is `pyproject.toml` + `uv.lock`, and the two must never disagree. CI installs
+with `uv sync --frozen`, which replays the lockfile and never looks at the manifest — so a manifest-only
+change is invisible at runtime while still looking merged. Change a pin, then `uv lock --directory <project>`
+and commit both files together. Never hand-edit `uv.lock`.
+
+`check-dependency-automation` in [the CI workflow](.github/workflows/arthur-engine-workflow.yml) enforces
+this across all four uv projects via
+[`.github/scripts/check-lockfile-drift.sh`](.github/scripts/check-lockfile-drift.sh), which you can run
+locally from the repo root. It reports one of two states:
+
+- **STALE** — the manifest resolves but the lock was not regenerated. Run `uv lock` and commit.
+- **UNRESOLVABLE** — nothing can satisfy the manifest, usually because a *transitive* constraint of
+  another pinned dependency caps the package being bumped (`litellm` caps `openai<3.0.0`; `gliner` caps
+  `transformers`; `presidio-anonymizer` caps `cryptography`). Move the lagging dependency forward — never
+  cap or downgrade the one being updated. If nothing upstream lifts the ceiling yet, add an
+  `allowedVersions` rule in [renovate.json](renovate.json) so Renovate stops re-proposing it, naming the
+  blocker and the condition for removing the cap.
+
+Renovate opens PRs that edit the manifest without the lock whenever its lockfile step fails, and offers no
+way to fail closed — that gate is the only thing that catches it. See the `description` at the top of
+[renovate.json](renovate.json).
+
 ## Code style
 
 Write code that reads like the surrounding code: match its comment density, naming, and idiom.

--- a/arthur-observability-sdk/python/uv.lock
+++ b/arthur-observability-sdk/python/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-15T19:03:43.844345Z"
+exclude-newer = "2026-08-15T20:50:00.890207Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -173,7 +173,7 @@ wheels = [
 
 [[package]]
 name = "arthur-observability-sdk"
-version = "2.1.795"
+version = "2.1.796"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/genai-engine/uv.lock
+++ b/genai-engine/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-15T19:01:36.167213Z"
+exclude-newer = "2026-08-15T20:50:00.621232Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -185,7 +185,7 @@ wheels = [
 
 [[package]]
 name = "arthur-genai-engine"
-version = "2.1.795"
+version = "2.1.796"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/ml-engine/uv.lock
+++ b/ml-engine/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-15T18:59:29.11634Z"
+exclude-newer = "2026-08-15T20:50:00.836334Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1474,7 +1474,7 @@ wheels = [
 
 [[package]]
 name = "ml-engine"
-version = "2.1.795"
+version = "2.1.796"
 source = { editable = "." }
 dependencies = [
     { name = "adlfs" },

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "Renovate updates pyproject.toml and regenerates uv.lock as a separate artifact step. When that regeneration fails — almost always because the new version violates a transitive constraint of another pinned dependency — Renovate opens the PR with the manifest edit ALONE, and does not reliably say so in the PR body (#2134 carried no artifact warning at all).",
+    "There is no configuration option that makes Renovate fail closed instead: that is upstream behaviour, not something this file can switch off. The backstop is therefore CI — .github/workflows/arthur-engine-workflow.yml runs check-dependency-automation, which fails any PR whose uv.lock disagrees with its pyproject.toml.",
+    "What this file CAN do is stop Renovate re-proposing updates already known to be unsatisfiable. See the allowedVersions rules below; each names the dependency imposing the ceiling and the condition for lifting it."
+  ],
   "extends": ["config:recommended"],
   "minimumReleaseAge": "3 days",
   "rebaseWhen": "conflicted",
@@ -83,6 +88,7 @@
       "matchPackageNames": ["fsspec", "gcsfs", "s3fs", "adlfs"]
     },
     {
+      "description": "litellm pins openai to a narrow range (openai>=2.20.0,<3.0.0 as of litellm 1.96.2), so an openai bump that leaves litellm behind cannot resolve. Grouping them means the family moves together or not at all, instead of Renovate proposing a half-bump that no lockfile can satisfy. arthur-common is deliberately NOT in this group even though it pins litellm exactly: it is first-party and updates several times a week, so coupling it here would stall those. If a litellm bump ever conflicts with the pinned arthur-common, check-dependency-automation catches it.",
       "matchManagers": ["pep621"],
       "groupName": "langchain + openai",
       "matchPackageNames": [
@@ -92,8 +98,15 @@
         "langchain-openai",
         "langchain-text-splitters",
         "langsmith",
+        "litellm",
         "openai"
       ]
+    },
+    {
+      "description": "Cap openai < 3.0.0: litellm 1.96.2 (the pinned version, itself pinned by arthur-common) requires openai>=2.20.0,<3.0.0, so openai 3.x is unsatisfiable in genai-engine no matter what else moves. Renovate cannot see that transitive ceiling and re-proposed it as PR #2134, whose lockfile step then failed — which is how a manifest-only bump reached dev. Lift this cap once litellm accepts openai 3.x (openai 3.0.0's breaking change is the move to HTTPX2).",
+      "matchManagers": ["pep621"],
+      "matchPackageNames": ["openai"],
+      "allowedVersions": "<3.0.0"
     },
     {
       "description": "gliner 0.2.28 (latest release) requires transformers>=4.51.3,<5.14.0, so transformers 5.14.x makes genai-engine unresolvable. Raise or drop this cap once a gliner release widens its transformers ceiling.",


### PR DESCRIPTION
Prevents the class of failure that produced #2134 (`openai==3.0.0`), fixed in #2144.

> [!IMPORTANT]
> **Stacked on #2144** — the new gate cannot be green until genai-engine's lockfile resolves again. GitHub will retarget this to `dev` when #2144 merges.
>
> **After merging, add `check-dependency-automation` to the `dev-branch-ruleset` required checks.** Auto-merge is enabled for minor/patch, and GitHub's auto-merge only waits on *required* checks — until this one is required, a failing gate will not stop a Renovate PR from merging itself. Do it after merge, not before, or every open PR blocks on a check that does not exist yet.

## What actually went wrong

Renovate edits `pyproject.toml` and regenerates `uv.lock` in a **separate artifact step**. When that second step fails — typically because the new version violates a *transitive* constraint of another pinned dependency — Renovate still opens the PR with the manifest edit alone. It did not flag it: #2134's body carries no artifact warning at all.

Nothing in CI could see it. Every Python job installs via `uv sync --frozen`, which replays the lockfile and **never compares it to the manifest**. So the PR was fully green, merged, and left the two files disagreeing.

Two of the last 25 Renovate commits did this:

| PR | Manifest said | Lock said | Outcome |
| --- | --- | --- | --- |
| #2134 | `openai==3.0.0` | `openai 2.54.0` | `uv lock` impossible for everyone until #2144 |
| #2124 | `python-keycloak==7.1.1` | `python-keycloak 5.12.0` | shipped 5.12.0 for weeks, then silently repaired by an unrelated re-lock |

#2124 is the more dangerous shape: no one ever noticed. A `[SECURITY]` bump landing that way looks fixed while the vulnerable version keeps shipping.

## Can Renovate just fail closed?

No. Opening the PR anyway is upstream behaviour with no configuration option to change it ([discussion #17039](https://github.com/renovatebot/renovate/discussions/17039), [#32535](https://github.com/renovatebot/renovate/discussions/32535)). Renovate also cannot see the ceiling in the first place — its `pep621` manager reads direct deps in `pyproject.toml` and has no idea `litellm` constrains `openai`.

So detection has to be ours, and config can only stop Renovate re-proposing updates already known to be impossible. Both are here.

## Layers

**1. Detection — `check-dependency-automation`**

Runs [`.github/scripts/check-lockfile-drift.sh`](.github/scripts/check-lockfile-drift.sh) over every uv project, *discovered* rather than listed, so a new project is covered the day it is added (this already picks up `deployment/model-upload`, which no CI job touches today). It separates the two states, because they need opposite fixes:

- **STALE** — the manifest resolves, the lock just was not regenerated → `uv lock` and commit.
- **UNRESOLVABLE** — no lockfile can satisfy the manifest → re-locking will not help; move the lagging constraint forward, or cap the package in `renovate.json`.

The decision tree goes to the job summary, not just the log. It lives in `arthur-engine-workflow.yml` **deliberately**: `renovate-autofix.yml` listens for *"Arthur Engine CI"* failing, so a gate in a separate workflow would never reach the auto-fixer. Adding it here means the existing Claude auto-fix machinery now covers this failure class for free.

**2. Removing the false positive — `version-workflow.yml` re-locks**

Each `uv.lock` records its own project's version, so the release bumper's three `sed`s left every lockfile disagreeing with its manifest *on every release* — 3 of 4 projects were in that state on `dev`. Harmless in itself, but indistinguishable from the real thing, and it would have left this gate permanently red. Verified that `uv lock` without `--upgrade` moves no dependency: the only edits are the project's own version and the `exclude-newer` soak boundary.

**3. Renovate config**

- Cap `openai < 3.0.0`, naming litellm as the ceiling and the condition for lifting it — same idiom as the existing `transformers` (capped by gliner) and `importlib-metadata` (capped by opentelemetry) rules. Without this Renovate re-proposes openai v3 on every run, now burning a red CI + auto-fix cycle each time.
- `litellm` joins the **langchain + openai** group so the family moves together instead of half at a time. `arthur-common` is deliberately left out despite pinning litellm — it is first-party and updates several times a week; the gate covers that case instead.
- A top-level `description` records why CI has to be the backstop.

**4. Teaching the auto-fixer**

`renovate-autofix.yml` learns how to tell STALE from UNRESOLVABLE, and that a transitive ceiling with no upstream fix is a **hand-off**, not a fix — invariant 6 forbids it touching `renovate.json`, so it should name the `allowedVersions` cap a human needs to add.

## Verification

Both original regressions were reintroduced against the finished gate:

```
$ # openai==3.0.0 restored
genai-engine    UNRESOLVABLE — pyproject.toml has no valid resolution
  ╰─▶ Because litellm==1.96.2 depends on openai>=2.20.0,<3.0.0 ...

$ # a pin moved without re-locking
genai-engine    STALE — lock not regenerated for the manifest change
  Updated python-keycloak v7.1.1 -> v7.1.0
```

Both exit 1; the clean tree exits 0; the working tree is left untouched afterward. Also verified: the version-bump flow goes red before the re-lock and green after; `renovate.json` passes the real `renovate-config-validator` (and I confirmed the validator rejects a bad key, so the pass is meaningful); all three workflows parse; the script runs on macOS bash 3.2 as well as CI's bash 5.

Not covered here: the npm side already fails correctly, because the UI job runs `yarn install --immutable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
