### PR TITLE
security(ml-engine): drop build-time Python tooling from the runtime image

### DIFF
--- a/ml-engine/Dockerfile
+++ b/ml-engine/Dockerfile
@@ -88,6 +88,37 @@ RUN mkdir -p /genai_client
 COPY src/genai_client /genai_client
 RUN uv pip install --system /genai_client
 
+# Drop the build-time Python tooling. This is the last step that needs pip/uv;
+# everything below is plain shell, and the runtime entrypoint is a bare
+# `python src/ml_engine/job_agent.py`. It matters because the final stage copies
+# /usr/local/lib and /usr/local/bin wholesale, so anything left in this stage's
+# site-packages ships — including the package manager and whatever it vendors.
+#
+# That is where the scanner findings against this image came from. Neither
+# offender is an ml-engine dependency and neither appears in uv.lock:
+#   - setuptools 70.3.0  (CVE-2025-47273) — build tooling from the base image
+#   - msgpack 1.1.2      (GHSA-6v7p-g79w-8964) — vendored inside pip, along with
+#     CacheControl, resolvelib, tomli, tomli-w, truststore and pyproject-hooks
+# Removing them is the fix rather than pinning: the vendored set is pip's to
+# choose, not ours, so a pin would only hold until the next pip bump.
+#
+# Safe to remove: nothing on an executed path imports setuptools or
+# pkg_resources. litellm reaches for pkg_resources only if importlib.resources
+# is unavailable (it is not, on 3.13); the remaining references across the
+# dependency set are in test fixtures and build helpers.
+RUN set -eu; \
+    SP="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; \
+    rm -rf "$SP"/pip "$SP"/pip-*.dist-info \
+           "$SP"/setuptools "$SP"/setuptools-*.dist-info \
+           "$SP"/pkg_resources "$SP"/_distutils_hack "$SP"/distutils-precedence.pth \
+           "$SP"/uv "$SP"/uv-*.dist-info; \
+    rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.* \
+          /usr/local/bin/uv /usr/local/bin/uvx; \
+    python -c "import sys, importlib.util as u; \
+      left = [n for n in ('pip','setuptools','pkg_resources','uv') if u.find_spec(n)]; \
+      sys.exit('build tooling survived the cleanup: %s' % left) if left else \
+      print('build tooling removed; interpreter ok:', sys.version.split()[0])"
+
 # Patch the libraries the distroless base keeps in /lib. Unlike bookworm, the base
 # is NOT merged-/usr: /lib is a real directory holding glibc (libc.so.6, libm,
 # libpthread, libnss_*, and the ELF interpreter that /lib64 symlinks to) plus


### PR DESCRIPTION
Clears the last two open Trivy findings against ml-engine, taking the backlog to **0**.

| CVE | Package | Installed | Fixed in |
| --- | --- | --- | --- |
| CVE-2025-47273 | setuptools | 70.3.0 | 78.1.1 |
| GHSA-6v7p-g79w-8964 | msgpack | 1.1.2 | 1.2.1 |

## Why these resisted the obvious fix

Neither is an ml-engine dependency, and neither appears anywhere in `ml-engine/uv.lock`. Trivy reports both with location `Python` and no file path, so nothing in the Security tab said where they came from — and the fix depends entirely on that.

The CI build was already publishing the answer. The `vuln-docs-ml-engine` artifact contains a CycloneDX SBOM with per-component layer IDs. Both packages sit in the layer holding site-packages, and diffing that layer against `uv.lock` leaves exactly eleven packages that are not declared dependencies:

```
genai-client, uv, pip, setuptools,
CacheControl, msgpack, pyproject-hooks, resolvelib, tomli, tomli-w, truststore
```

That last group is **pip 26.2.1's vendored bundle**. So:

- **`msgpack 1.1.2` is pip's vendored msgpack.**
- **`setuptools 70.3.0` is build tooling** inherited from the base image.

They ship because the final stage copies `/usr/local/lib` and `/usr/local/bin` wholesale out of the build stage — package manager included.

## Why removal rather than pinning

The vendored set is pip's to choose, not ours, so a pin would hold only until the next pip bump. The runtime needs none of it: the entrypoint is `python src/ml_engine/job_agent.py`, and no ml-engine code invokes pip or uv. This also drops a chunk of the image.

Supporting evidence that this is the right shape: the genai-engine images ship the *same* packages but at clean versions (setuptools 82.0.1, msgpack 1.2.1 — the latter only because genai-engine happens to declare `msgpack==1.2.1`, which overwrites pip's vendored copy). ml-engine being flagged is luck, not design.

## Why it is safe

Nothing on an executed path imports `setuptools` or `pkg_resources`. I checked every reference across the installed dependency set:

- `litellm` reaches for `pkg_resources` only if `importlib.resources` is unavailable — it is not, on 3.13.
- `numpy`, `pyarrow`, `cffi`, `google` — test fixtures and build helpers.
- `pytz`, `wrapt`, `werkzeug` — guarded fallbacks, none on a startup path.

The local uv venv already has no setuptools, and the ml-engine suite passes there.

## Verification

I built the **exact `RUN` block** from this diff against the same `python:3.13-slim-bookworm` base with a representative dependency set (`litellm`, `pytz`, `wrapt`, `cffi`, `numpy`):

```
removed: pip / setuptools / pkg_resources / uv          (as modules)
removed binary: pip / pip3 / uv / uvx                   (off PATH)
  litellm 1.97.0
  numpy 2.5.2
  TIKTOKEN_CACHE_DIR = .../litellm/litellm_core_utils/tokenizers
ALL CHECKS PASSED
```

That last line matters: it is litellm's tokenizer path, the one that reaches for `pkg_resources`, resolving correctly with setuptools gone.

The block ends in an **assertion**, not a bare command — if a future base image relocates any of this, the build fails instead of silently shipping it again.

> [!NOTE]
> I could not build the full ml-engine image locally (Oracle Instant Client and MS ODBC downloads). Image builds also don't run on PRs — only on the version-bump push to `dev` — so the first full-image validation happens post-merge. The isolated test above covers the logic; what it can't cover is interaction with the later `/lib` patching stages, which are plain shell and touch none of these paths.

## Follow-up, deliberately not attempted here

`genai-engine/dockerfile` has the same wholesale copy and the same latent exposure. But its entrypoint runs `uv run alembic upgrade head` and `uv run gunicorn`, so **uv must stay** there — only pip and setuptools could go. That is a more delicate change to the flagship image, and given image builds don't run on PRs it deserves its own change rather than riding along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
