### PR TITLE
security(vex): remove statements for remediated and MEDIUM-rated CVEs

### DIFF
--- a/security/vex/openvex.json
+++ b/security/vex/openvex.json
@@ -4,8 +4,8 @@
   "author": "Arthur Security <security@arthur.ai>",
   "role": "Document Creator",
   "timestamp": "2026-08-18T00:00:00.000000000-00:00",
-  "version": 10,
-  "_comment": "Scope: HIGH/CRITICAL findings that a container-image re-scan still reports for the genai-engine, ml-engine and genai-engine-models-* images AND that are not exploitable in our usage. Every statement here is 'not_affected' with a justification. Remediated CVEs are excluded by policy — fix, don't justify (security/README.md), so a CVE disappearing from this document means it was fixed, not dropped. Remediated and therefore absent: python3.11 is removed from every image (its dpkg metadata deleted); litellm/langsmith/msgpack/nltk/uv/pyasn1 are upgraded past their advisories; and as of 2026-07-30 the distroless OS-package findings (libc6, libssl3, libkrb5*, liblzma5) are fixed at the source — the build stages now mirror the base's /lib layout with their apt-upgraded libraries and rewrite /var/lib/dpkg/status.d to the versions actually installed, so the patched objects ship and scanners read true versions. Auditor note: the distroless base is not merged-/usr, so before that change `COPY /usr/lib` never reached the glibc and liblzma objects the base keeps in /lib. Images up to and including 2.1.754 shipped the base's unpatched glibc (2.36-9+deb12u13) and liblzma5 (5.4.1-1), and earlier revisions of this document incorrectly recorded those libc6 CVEs as fixed. The libssl3 and krb5 objects do live under /usr/lib and were genuinely patched throughout; only their dpkg metadata was stale. See genai-engine/dockerfile, ml-engine/Dockerfile, deployment/model-upload/Dockerfile and PR #2073. Audited 2026-08-18 against the per-image Trivy reports from the daily image-vuln-scan: (a) no remaining statement suppresses a finding that has an upstream fix \u2014 every one is unfixed at the installed version, so none is masking a bump we could take instead; (b) the python3.11 statements (CVE-2025-69534, CVE-2026-3644, CVE-2026-4224, CVE-2026-6100, CVE-2026-7210, CVE-2025-13836) were removed because the runtime-s3 and runtime-fs stages now delete the interpreter and its dpkg metadata outright, so the packages are absent and those statements matched nothing; (c) four statements are deliberately RETAINED even though they currently match nothing \u2014 CVE-2026-11822 and CVE-2026-11824 (libsqlite3-0) and CVE-2026-56131 and CVE-2026-56407 (libexpat1) have been re-rated from HIGH to MEDIUM in the vulnerability database, so they fall below the scan's --severity HIGH,CRITICAL filter. They are still present and still unfixed in bookworm (Debian marks the sqlite pair <postponed>), so the justifications remain true and would resume applying if the rating moves back up. Do not mistake them for stale.",
+  "version": 11,
+  "_comment": "Scope: HIGH/CRITICAL findings that a container-image re-scan still reports for the genai-engine, ml-engine and genai-engine-models-* images AND that are not exploitable in our usage. Every statement here is 'not_affected' with a justification. Remediated CVEs are excluded by policy — fix, don't justify (security/README.md), so a CVE disappearing from this document means it was fixed, not dropped. Remediated and therefore absent: python3.11 is removed from every image (its dpkg metadata deleted); litellm/langsmith/msgpack/nltk/uv/pyasn1 are upgraded past their advisories; and as of 2026-07-30 the distroless OS-package findings (libc6, libssl3, libkrb5*, liblzma5) are fixed at the source — the build stages now mirror the base's /lib layout with their apt-upgraded libraries and rewrite /var/lib/dpkg/status.d to the versions actually installed, so the patched objects ship and scanners read true versions. Auditor note: the distroless base is not merged-/usr, so before that change `COPY /usr/lib` never reached the glibc and liblzma objects the base keeps in /lib. Images up to and including 2.1.754 shipped the base's unpatched glibc (2.36-9+deb12u13) and liblzma5 (5.4.1-1), and earlier revisions of this document incorrectly recorded those libc6 CVEs as fixed. The libssl3 and krb5 objects do live under /usr/lib and were genuinely patched throughout; only their dpkg metadata was stale. See genai-engine/dockerfile, ml-engine/Dockerfile, deployment/model-upload/Dockerfile and PR #2073. Audited 2026-08-18 against the per-image Trivy reports from the daily image-vuln-scan: (a) no remaining statement suppresses a finding that has an upstream fix \u2014 every one is unfixed at the installed version, so none is masking a bump we could take instead; (b) the python3.11 statements (CVE-2025-69534, CVE-2026-3644, CVE-2026-4224, CVE-2026-6100, CVE-2026-7210, CVE-2025-13836) were removed because the runtime-s3 and runtime-fs stages now delete the interpreter and its dpkg metadata outright, so the packages are absent and those statements matched nothing; (c) the document is scoped to HIGH/CRITICAL, so four statements were removed for falling below that line: CVE-2026-11822 and CVE-2026-11824 (libsqlite3-0) and CVE-2026-56131 and CVE-2026-56407 (libexpat1) were re-rated from HIGH to MEDIUM in the vulnerability database. Note what this does and does not mean: those four are NOT remediated. The packages are still installed at the same versions and Debian still ships no fix (it marks the sqlite pair <postponed> for bookworm); they simply sit under the scan's --severity HIGH,CRITICAL filter, so nothing reports them today. If any of them is ever re-rated back to HIGH it will surface as an untriaged finding and will need its justification restored -- the reasoning was sound, only the severity changed.",
   "statements": [
     {
       "_comment": "libexpat1: the reported system library (pkg:deb libexpat1 2.5.0-1~deb12u2 from the distroless base) is not linked by the application runtime. CPython 3.12/3.13 (from /usr/local) statically bundle their own expat (2.7.4 / 2.8.1) and do not load the system libexpat.so.1. Its only consumer in the base image, Python 3.11, has been removed. No Debian bookworm fix is available yet (fixed upstream in expat 2.8.1). DoS-only (CWE-407, CVSS ~2.9). Residual risk: the bundled CPython expat (2.7.4 on 3.12) is also affected, but is reachable only by parsing attacker-controlled XML, which these images do not do (the engines expose JSON APIs; the model-upload jobs parse no XML).",
@@ -84,38 +84,6 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Persistence uses PostgreSQL (pgvector); libsqlite3 is a transitive dependency that is never given attacker-controlled SQL. Exploitation requires executing crafted SQL (KeyInfoFromExprList), which is not in the engine's data path.",
-      "timestamp": "2026-06-27T00:00:00Z"
-    },
-    {
-      "_comment": "libsqlite3-0: Persistence uses PostgreSQL; libsqlite3 is a transitive dependency. The vulnerability is in the FTS5 full-text-search extension, which Arthur never loads or queries with untrusted input. Owner: security@arthur.ai. Review by: 2026-12-27.",
-      "vulnerability": { "name": "CVE-2026-11822" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] },
-        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Persistence uses PostgreSQL; libsqlite3 is a transitive dependency. The vulnerability is in the FTS5 full-text-search extension, which Arthur never loads or queries with untrusted input.",
-      "timestamp": "2026-06-27T00:00:00Z"
-    },
-    {
-      "_comment": "libsqlite3-0: Persistence uses PostgreSQL; libsqlite3 is a transitive dependency. The vulnerability is in the FTS5 full-text-search extension, which Arthur never loads or queries with untrusted input. Owner: security@arthur.ai. Review by: 2026-12-27.",
-      "vulnerability": { "name": "CVE-2026-11824" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] },
-        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/libsqlite3-0" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Persistence uses PostgreSQL; libsqlite3 is a transitive dependency. The vulnerability is in the FTS5 full-text-search extension, which Arthur never loads or queries with untrusted input.",
       "timestamp": "2026-06-27T00:00:00Z"
     },
     {
@@ -208,38 +176,6 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "perl-base is a transitive base-OS package on the models-gcs image; no Arthur process invokes the Perl interpreter or the Storable module, so no attacker-controlled blob is ever passed to thaw/retrieve. The upload job runs a single Python entrypoint (upload_models.py).",
-      "timestamp": "2026-07-28T00:00:00Z"
-    },
-    {
-      "_comment": "libexpat1: CVE-2026-56131 is a use-after-free reachable only through an XML_ResumeParser suspend/resume flow on a policy violation; no Debian bookworm fix is available (bookworm/bookworm-security ship 2.5.0-1+deb12u2, still vulnerable; fixed upstream in expat 2.8.2, only in sid). The system libexpat1 is not loaded by the application: CPython 3.12/3.13 bundle their own expat statically and do not link /usr/lib/*/libexpat.so.1, and the only base-image consumer (Python 3.11) has been removed. The engines expose JSON/HTTP APIs and never parse attacker-controlled XML through the system libexpat. Owner: security@arthur.ai. Review by: 2027-01-28.",
-      "vulnerability": { "name": "CVE-2026-56131" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
-        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-56131 (use-after-free via XML_ResumeParser in libexpat < 2.8.2) is reachable only by parsing attacker-controlled XML through the system libexpat1. That library is not loaded by the application: CPython 3.12/3.13 bundle their own expat statically and do not link /usr/lib/*/libexpat.so.1, and the only base-image consumer (Python 3.11) has been removed. No Debian bookworm fix is available yet (fixed upstream in expat 2.8.2).",
-      "timestamp": "2026-07-28T00:00:00Z"
-    },
-    {
-      "_comment": "libexpat1: CVE-2026-56407 is an integer overflow (CWE-190) in doProlog/storeEntityValue; no Debian bookworm fix is available (fixed upstream in expat 2.8.2, only in sid). The system libexpat1 is not loaded by the application (CPython bundles expat statically; the only base-image consumer, Python 3.11, has been removed) and the engines never parse attacker-controlled XML through it. DoS-class. Owner: security@arthur.ai. Review by: 2027-01-28.",
-      "vulnerability": { "name": "CVE-2026-56407" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-cpu", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
-        { "@id": "pkg:oci/genai-engine-gpu", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
-        { "@id": "pkg:oci/ml-engine", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] },
-        { "@id": "pkg:oci/genai-engine-models-gcs", "subcomponents": [ { "@id": "pkg:deb/debian/libexpat1" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "CVE-2026-56407 (integer overflow in doProlog/storeEntityValue in libexpat < 2.8.2, DoS-class) is reachable only by parsing attacker-controlled XML through the system libexpat1, which the application does not load (CPython bundles expat statically; the base-image Python 3.11 consumer is removed). No Debian bookworm fix is available yet (fixed upstream in expat 2.8.2).",
       "timestamp": "2026-07-28T00:00:00Z"
     },
     {

--- a/security/vex/openvex.json
+++ b/security/vex/openvex.json
@@ -4,8 +4,8 @@
   "author": "Arthur Security <security@arthur.ai>",
   "role": "Document Creator",
   "timestamp": "2026-08-18T00:00:00.000000000-00:00",
-  "version": 9,
-  "_comment": "Scope: HIGH/CRITICAL findings that a container-image re-scan still reports for the genai-engine, ml-engine and genai-engine-models-* images AND that are not exploitable in our usage. Every statement here is 'not_affected' with a justification. Remediated CVEs are excluded by policy — fix, don't justify (security/README.md), so a CVE disappearing from this document means it was fixed, not dropped. Remediated and therefore absent: python3.11 is removed from every image (its dpkg metadata deleted); litellm/langsmith/msgpack/nltk/uv/pyasn1 are upgraded past their advisories; and as of 2026-07-30 the distroless OS-package findings (libc6, libssl3, libkrb5*, liblzma5) are fixed at the source — the build stages now mirror the base's /lib layout with their apt-upgraded libraries and rewrite /var/lib/dpkg/status.d to the versions actually installed, so the patched objects ship and scanners read true versions. Auditor note: the distroless base is not merged-/usr, so before that change `COPY /usr/lib` never reached the glibc and liblzma objects the base keeps in /lib. Images up to and including 2.1.754 shipped the base's unpatched glibc (2.36-9+deb12u13) and liblzma5 (5.4.1-1), and earlier revisions of this document incorrectly recorded those libc6 CVEs as fixed. The libssl3 and krb5 objects do live under /usr/lib and were genuinely patched throughout; only their dpkg metadata was stale. See genai-engine/dockerfile, ml-engine/Dockerfile, deployment/model-upload/Dockerfile and PR #2073.",
+  "version": 10,
+  "_comment": "Scope: HIGH/CRITICAL findings that a container-image re-scan still reports for the genai-engine, ml-engine and genai-engine-models-* images AND that are not exploitable in our usage. Every statement here is 'not_affected' with a justification. Remediated CVEs are excluded by policy — fix, don't justify (security/README.md), so a CVE disappearing from this document means it was fixed, not dropped. Remediated and therefore absent: python3.11 is removed from every image (its dpkg metadata deleted); litellm/langsmith/msgpack/nltk/uv/pyasn1 are upgraded past their advisories; and as of 2026-07-30 the distroless OS-package findings (libc6, libssl3, libkrb5*, liblzma5) are fixed at the source — the build stages now mirror the base's /lib layout with their apt-upgraded libraries and rewrite /var/lib/dpkg/status.d to the versions actually installed, so the patched objects ship and scanners read true versions. Auditor note: the distroless base is not merged-/usr, so before that change `COPY /usr/lib` never reached the glibc and liblzma objects the base keeps in /lib. Images up to and including 2.1.754 shipped the base's unpatched glibc (2.36-9+deb12u13) and liblzma5 (5.4.1-1), and earlier revisions of this document incorrectly recorded those libc6 CVEs as fixed. The libssl3 and krb5 objects do live under /usr/lib and were genuinely patched throughout; only their dpkg metadata was stale. See genai-engine/dockerfile, ml-engine/Dockerfile, deployment/model-upload/Dockerfile and PR #2073. Audited 2026-08-18 against the per-image Trivy reports from the daily image-vuln-scan: (a) no remaining statement suppresses a finding that has an upstream fix \u2014 every one is unfixed at the installed version, so none is masking a bump we could take instead; (b) the python3.11 statements (CVE-2025-69534, CVE-2026-3644, CVE-2026-4224, CVE-2026-6100, CVE-2026-7210, CVE-2025-13836) were removed because the runtime-s3 and runtime-fs stages now delete the interpreter and its dpkg metadata outright, so the packages are absent and those statements matched nothing; (c) four statements are deliberately RETAINED even though they currently match nothing \u2014 CVE-2026-11822 and CVE-2026-11824 (libsqlite3-0) and CVE-2026-56131 and CVE-2026-56407 (libexpat1) have been re-rated from HIGH to MEDIUM in the vulnerability database, so they fall below the scan's --severity HIGH,CRITICAL filter. They are still present and still unfixed in bookworm (Debian marks the sqlite pair <postponed>), so the justifications remain true and would resume applying if the rating moves back up. Do not mistake them for stale.",
   "statements": [
     {
       "_comment": "libexpat1: the reported system library (pkg:deb libexpat1 2.5.0-1~deb12u2 from the distroless base) is not linked by the application runtime. CPython 3.12/3.13 (from /usr/local) statically bundle their own expat (2.7.4 / 2.8.1) and do not load the system libexpat.so.1. Its only consumer in the base image, Python 3.11, has been removed. No Debian bookworm fix is available yet (fixed upstream in expat 2.8.1). DoS-only (CWE-407, CVSS ~2.9). Residual risk: the bundled CPython expat (2.7.4 on 3.12) is also affected, but is reachable only by parsing attacker-controlled XML, which these images do not do (the engines expose JSON APIs; the model-upload jobs parse no XML).",
@@ -20,7 +20,8 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The system libexpat1 is not loaded by the application: CPython 3.12/3.13 bundle their own expat statically and do not link /usr/lib/*/libexpat.so.1, and the only base-image consumer (Python 3.11) has been removed. The flaw is a denial-of-service (inefficient algorithmic complexity, CWE-407, CVSS ~2.9) reachable only by parsing attacker-controlled XML through this system library."
+      "impact_statement": "The system libexpat1 is not loaded by the application: CPython 3.12/3.13 bundle their own expat statically and do not link /usr/lib/*/libexpat.so.1, and the only base-image consumer (Python 3.11) has been removed. The flaw is a denial-of-service (inefficient algorithmic complexity, CWE-407, CVSS ~2.9) reachable only by parsing attacker-controlled XML through this system library.",
+      "timestamp": "2026-06-27T00:00:00Z"
     },
     {
       "_comment": "zlib1g: The overflow is in MiniZip (zlib contrib/minizip), which upstream states is not a supported part of zlib. Debian's zlib1g shared library does not build or export the MiniZip code (the vulnerable zipOpenNewFileInZip4_64 symbol is absent); Arthur links only the core inflate/deflate API. Owner: security@arthur.ai. Review by: 2026-12-27.",
@@ -51,18 +52,6 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Triggering requires parsing attacker-controlled XML through libexpat. Arthur's engines expose JSON/HTTP APIs and never parse untrusted XML via the system libexpat; it is a transitive base-OS dependency.",
-      "timestamp": "2026-06-27T00:00:00Z"
-    },
-    {
-      "_comment": "python3.11 (system, unused): Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local (deployment/model-upload/Dockerfile); the inherited system 3.11 is removed and never executed. Owner: security@arthur.ai. Review by: 2026-12-27.",
-      "vulnerability": { "name": "CVE-2025-69534" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local (deployment/model-upload/Dockerfile); the inherited system 3.11 is removed and never executed.",
       "timestamp": "2026-06-27T00:00:00Z"
     },
     {
@@ -145,30 +134,6 @@
       "timestamp": "2026-06-27T00:00:00Z"
     },
     {
-      "_comment": "python3.11 (system, unused): Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local; the inherited system 3.11 is removed and never executed. (http.cookies.Morsel is also not on the upload path.) Owner: security@arthur.ai. Review by: 2026-12-27.",
-      "vulnerability": { "name": "CVE-2026-3644" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local; the inherited system 3.11 is removed and never executed. (http.cookies.Morsel is also not on the upload path.)",
-      "timestamp": "2026-06-27T00:00:00Z"
-    },
-    {
-      "_comment": "python3.11 (system, unused): Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local; the inherited system 3.11 is removed and never executed. Owner: security@arthur.ai. Review by: 2026-12-27.",
-      "vulnerability": { "name": "CVE-2026-4224" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local; the inherited system 3.11 is removed and never executed.",
-      "timestamp": "2026-06-27T00:00:00Z"
-    },
-    {
       "_comment": "perl-base: perl-base is a transitive base-OS package on the models-gcs image; no Arthur process invokes the Perl interpreter or Archive::Tar. The upload job runs a single Python entrypoint (upload_models.py). Owner: security@arthur.ai. Review by: 2026-12-27.",
       "vulnerability": { "name": "CVE-2026-42496" },
       "products": [
@@ -199,30 +164,6 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "perl-base is a transitive base-OS package on the models-gcs image; no Arthur process invokes the Perl interpreter or IO::Compress/File::GlobMapper. The upload job runs a single Python entrypoint (upload_models.py).",
-      "timestamp": "2026-06-27T00:00:00Z"
-    },
-    {
-      "_comment": "python3.11 (system, unused): Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local; the inherited system 3.11 is removed and never executed. Owner: security@arthur.ai. Review by: 2026-12-27.",
-      "vulnerability": { "name": "CVE-2026-6100" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local; the inherited system 3.11 is removed and never executed.",
-      "timestamp": "2026-06-27T00:00:00Z"
-    },
-    {
-      "_comment": "python3.11 (system, unused): Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local; the inherited system 3.11 is removed and never executed. Owner: security@arthur.ai. Review by: 2026-12-27.",
-      "vulnerability": { "name": "CVE-2026-7210" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local; the inherited system 3.11 is removed and never executed.",
       "timestamp": "2026-06-27T00:00:00Z"
     },
     {
@@ -268,18 +209,6 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "perl-base is a transitive base-OS package on the models-gcs image; no Arthur process invokes the Perl interpreter or the Storable module, so no attacker-controlled blob is ever passed to thaw/retrieve. The upload job runs a single Python entrypoint (upload_models.py).",
       "timestamp": "2026-07-28T00:00:00Z"
-    },
-    {
-      "_comment": "python3.11 (system, unused): Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local (deployment/model-upload/Dockerfile); the inherited system 3.11 is removed and never executed. A Debian fix exists but is moot — the package is removed, not upgraded, in these images. Owner: security@arthur.ai. Review by: 2026-12-27.",
-      "vulnerability": { "name": "CVE-2025-13836" },
-      "products": [
-        { "@id": "pkg:oci/genai-engine-models-s3", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] },
-        { "@id": "pkg:oci/genai-engine-models-fs", "subcomponents": [ { "@id": "pkg:deb/debian/libpython3.11-minimal" }, { "@id": "pkg:deb/debian/libpython3.11-stdlib" }, { "@id": "pkg:deb/debian/python3.11-minimal" } ] }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Flagged against the system Python 3.11 deb packages. The model-upload job runs on Python 3.12 from /usr/local (deployment/model-upload/Dockerfile); the inherited system 3.11 is removed and never executed. A Debian fix exists but is moot — the package is removed, not upgraded, in these images.",
-      "timestamp": "2026-06-27T00:00:00Z"
     },
     {
       "_comment": "libexpat1: CVE-2026-56131 is a use-after-free reachable only through an XML_ResumeParser suspend/resume flow on a policy violation; no Debian bookworm fix is available (bookworm/bookworm-security ship 2.5.0-1+deb12u2, still vulnerable; fixed upstream in expat 2.8.2, only in sid). The system libexpat1 is not loaded by the application: CPython 3.12/3.13 bundle their own expat statically and do not link /usr/lib/*/libexpat.so.1, and the only base-image consumer (Python 3.11) has been removed. The engines expose JSON/HTTP APIs and never parse attacker-controlled XML through the system libexpat. Owner: security@arthur.ai. Review by: 2027-01-28.",


### PR DESCRIPTION
Audits every VEX statement against the per-image Trivy reports from the latest `image-vuln-scan` run, and removes the ones that no longer belong. **29 statements → 19.**

## No statement is masking an available fix

Every suppressed finding across all six images is **unfixed at the installed version** — there is no bump to take instead:

| CVE | Package | Installed | Fix available |
| --- | --- | --- | --- |
| CVE-2023-45853 | zlib1g | 1:1.2.13.dfsg-1 | none |
| CVE-2025-59375 / 25210 / 45186 / 56408 | libexpat1 | 2.5.0-1+deb12u2 | none |
| CVE-2025-69720 | libncursesw6, libtinfo6, ncurses-base, ncurses-bin | 6.4-4 | none |
| CVE-2025-7458 | libsqlite3-0 | 3.40.1-2+deb12u2 | none |
| CVE-2026-13221 / 42496 / 42497 / 48962 / 57432 / 57433 / 8376 / 9538 | perl-base | 5.36.0-7+deb12u3 | none |
| CVE-2026-41992 | gzip | 1.12-1 | none |
| CVE-2026-53615 | util-linux family, libuuid1 | 2.38.1-5+deb12u3 | none |
| CVE-2026-54369 | libacl1 | 2.3.1-3 | none |

Read straight from Trivy's `FixedVersion` on each suppressed finding, not inferred.

## Removed: six remediated (python3.11)

```
CVE-2025-69534   CVE-2026-3644   CVE-2026-4224
CVE-2026-6100    CVE-2026-7210   CVE-2025-13836
```

All six justified findings against `libpython3.11-minimal`, `libpython3.11-stdlib` and `python3.11-minimal` on models-s3 and models-fs. The `runtime-s3` and `runtime-fs` stages now delete the unused interpreter and its dpkg metadata outright, so **those packages are absent from the images**. Verified from each image's SBOM that all three are genuinely gone, not renamed or re-purled. `security/README.md` says remediated CVEs are excluded rather than justified.

## Removed: four now rated MEDIUM

The document declares itself scoped to HIGH/CRITICAL, so statements below that line do not belong in it. I checked the current severity of all remaining statements — against the per-image reports, falling back to an unfiltered scan of the shared distroless base for any the reports do not mention. Exactly four come back MEDIUM:

```
CVE-2026-11822   libsqlite3-0   3.40.1-2+deb12u2   MEDIUM   fix=-
CVE-2026-11824   libsqlite3-0   3.40.1-2+deb12u2   MEDIUM   fix=-
CVE-2026-56131   libexpat1      2.5.0-1+deb12u2    MEDIUM   fix=-
CVE-2026-56407   libexpat1      2.5.0-1+deb12u2    MEDIUM   fix=-
```

The other nineteen are HIGH or CRITICAL and stay.

> [!NOTE]
> These four are **not remediated**, unlike the python3.11 group. The packages are still installed at the same versions and Debian still ships no fix — it marks the sqlite pair `<postponed>` for bookworm. They were re-rated HIGH → MEDIUM, which puts them under the scan's `--severity HIGH,CRITICAL` filter, so nothing reports them today and the statements had stopped doing any work.
>
> The consequence is recorded in the scope comment: if any of the four is re-rated back to HIGH, it will reappear as an untriaged finding and will need its justification restored. The reasoning in those statements was sound — only the severity changed.

## Also

Fills in the one statement missing a `timestamp` (`CVE-2026-45186`), set to the date of the commit that introduced it (#1852). Pre-existing gap, surfaced by the audit; every statement now carries one.

`CVE-2026-14456` was added in #2147 after the audited scan ran, so it shows as non-matching there. It is HIGH and will suppress on the next scan — kept.

Document version 9 → 11, statements 29 → 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
