### PR TITLE
ci: scan the models images at build time, not only overnight

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -716,6 +716,13 @@ jobs:
 
   build-genai-engine-models-docker-image:
     uses: ./.github/workflows/build-ecs-model-upload.yml
+    # Passed through to the reusable workflow, which runs the vuln-report scan and
+    # publishes SARIF. A called workflow is capped by its caller's token, so
+    # security-events: write has to be granted here as well as there.
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     needs: [check-models-updates]
     if: |
       needs.check-models-updates.outputs.has_updates == 'true' &&
@@ -769,6 +776,13 @@ jobs:
 
   build-genai-engine-models-fs-docker-image:
     uses: ./.github/workflows/build-fs-model-upload.yml
+    # Passed through to the reusable workflow, which runs the vuln-report scan and
+    # publishes SARIF. A called workflow is capped by its caller's token, so
+    # security-events: write has to be granted here as well as there.
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     needs: [check-models-updates]
     if: |
       needs.check-models-updates.outputs.has_updates == 'true' &&
@@ -822,6 +836,13 @@ jobs:
 
   build-gcp-model-upload-docker-image:
     uses: ./.github/workflows/build-gcp-model-upload.yml
+    # Passed through to the reusable workflow, which runs the vuln-report scan and
+    # publishes SARIF. A called workflow is capped by its caller's token, so
+    # security-events: write has to be granted here as well as there.
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     needs: [check-models-updates]
     if: |
       github.repository == 'arthur-ai/arthur-engine' &&

--- a/.github/workflows/build-ecs-model-upload.yml
+++ b/.github/workflows/build-ecs-model-upload.yml
@@ -29,6 +29,19 @@ on:
 jobs:
   build-ecs-model-upload:
     environment: shared-protected-branch-secrets
+    # security-events: write is what lets the scan below publish SARIF to the
+    # Security tab. A reusable workflow cannot grant itself more than its caller
+    # holds, so the calling job in arthur-engine-workflow.yml declares the same set.
+    #
+    # contents: read is deliberate and does not affect the manifest commit further
+    # down: checkout, the git push and gh all run on the Arthur Automator App token,
+    # not GITHUB_TOKEN. The only thing here that touches github.token is the Trivy
+    # installer fetching a public release. Declaring any permissions block at all
+    # drops the unlisted scopes to none, hence spelling out all three.
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     runs-on: ubuntu-latest
     steps:
       - name: Generate Arthur GitHub Automator App Token
@@ -123,3 +136,25 @@ jobs:
           done
           echo "Failed to push manifest after retries." >&2
           exit 1
+      # Advisory vulnerability scan + justification docs, matching what the
+      # genai-engine and ml-engine builds already do. Without this the models
+      # images were only ever scanned by the nightly image-vuln-scan, so a fix
+      # merged just after a release sat visibly "open" in the Security tab for up
+      # to a day after it had actually shipped.
+      #
+      # The slug is the SARIF category, so it must stay identical to this image's
+      # entry in the image-vuln-scan.yml matrix (models-s3); a different category
+      # would open a second, parallel set of alerts instead of updating these.
+      #
+      # Runs last: the scan takes minutes, and the manifest commit above races
+      # other jobs pushing to the same branch, so this keeps that window tight.
+      # Only meaningful when the image was pushed -- the scan pulls it by tag.
+      - name: Scan image & generate justification docs
+        if: inputs.push
+        continue-on-error: true
+        uses: ./.github/workflows/composite-actions/vuln-report
+        with:
+          image: ${{ inputs.image }}:${{ env.VERSION }}
+          slug: models-s3
+          dockerhub-username: ${{ secrets.DOCKERHUB_ENTERPRISE_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_ENTERPRISE_TOKEN }}

--- a/.github/workflows/build-fs-model-upload.yml
+++ b/.github/workflows/build-fs-model-upload.yml
@@ -29,6 +29,19 @@ on:
 jobs:
   build-fs-model-upload:
     environment: shared-protected-branch-secrets
+    # security-events: write is what lets the scan below publish SARIF to the
+    # Security tab. A reusable workflow cannot grant itself more than its caller
+    # holds, so the calling job in arthur-engine-workflow.yml declares the same set.
+    #
+    # contents: read is deliberate and does not affect the manifest commit further
+    # down: checkout, the git push and gh all run on the Arthur Automator App token,
+    # not GITHUB_TOKEN. The only thing here that touches github.token is the Trivy
+    # installer fetching a public release. Declaring any permissions block at all
+    # drops the unlisted scopes to none, hence spelling out all three.
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     runs-on: ubuntu-latest
     steps:
       - name: Generate Arthur GitHub Automator App Token
@@ -123,3 +136,25 @@ jobs:
           done
           echo "Failed to push manifest after retries." >&2
           exit 1
+      # Advisory vulnerability scan + justification docs, matching what the
+      # genai-engine and ml-engine builds already do. Without this the models
+      # images were only ever scanned by the nightly image-vuln-scan, so a fix
+      # merged just after a release sat visibly "open" in the Security tab for up
+      # to a day after it had actually shipped.
+      #
+      # The slug is the SARIF category, so it must stay identical to this image's
+      # entry in the image-vuln-scan.yml matrix (models-fs); a different category
+      # would open a second, parallel set of alerts instead of updating these.
+      #
+      # Runs last: the scan takes minutes, and the manifest commit above races
+      # other jobs pushing to the same branch, so this keeps that window tight.
+      # Only meaningful when the image was pushed -- the scan pulls it by tag.
+      - name: Scan image & generate justification docs
+        if: inputs.push
+        continue-on-error: true
+        uses: ./.github/workflows/composite-actions/vuln-report
+        with:
+          image: ${{ inputs.image }}:${{ env.VERSION }}
+          slug: models-fs
+          dockerhub-username: ${{ secrets.DOCKERHUB_ENTERPRISE_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_ENTERPRISE_TOKEN }}

--- a/.github/workflows/build-gcp-model-upload.yml
+++ b/.github/workflows/build-gcp-model-upload.yml
@@ -29,6 +29,19 @@ on:
 jobs:
   build-gcp-model-upload:
     environment: shared-protected-branch-secrets
+    # security-events: write is what lets the scan below publish SARIF to the
+    # Security tab. A reusable workflow cannot grant itself more than its caller
+    # holds, so the calling job in arthur-engine-workflow.yml declares the same set.
+    #
+    # contents: read is deliberate and does not affect the manifest commit further
+    # down: checkout, the git push and gh all run on the Arthur Automator App token,
+    # not GITHUB_TOKEN. The only thing here that touches github.token is the Trivy
+    # installer fetching a public release. Declaring any permissions block at all
+    # drops the unlisted scopes to none, hence spelling out all three.
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     runs-on: ubuntu-latest
     steps:
       - name: Generate Arthur GitHub Automator App Token
@@ -123,3 +136,25 @@ jobs:
           done
           echo "Failed to push manifest after retries." >&2
           exit 1
+      # Advisory vulnerability scan + justification docs, matching what the
+      # genai-engine and ml-engine builds already do. Without this the models
+      # images were only ever scanned by the nightly image-vuln-scan, so a fix
+      # merged just after a release sat visibly "open" in the Security tab for up
+      # to a day after it had actually shipped.
+      #
+      # The slug is the SARIF category, so it must stay identical to this image's
+      # entry in the image-vuln-scan.yml matrix (models-gcs); a different category
+      # would open a second, parallel set of alerts instead of updating these.
+      #
+      # Runs last: the scan takes minutes, and the manifest commit above races
+      # other jobs pushing to the same branch, so this keeps that window tight.
+      # Only meaningful when the image was pushed -- the scan pulls it by tag.
+      - name: Scan image & generate justification docs
+        if: inputs.push
+        continue-on-error: true
+        uses: ./.github/workflows/composite-actions/vuln-report
+        with:
+          image: ${{ inputs.image }}:${{ env.VERSION }}
+          slug: models-gcs
+          dockerhub-username: ${{ secrets.DOCKERHUB_ENTERPRISE_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_ENTERPRISE_TOKEN }}


### PR DESCRIPTION
Closes the gap that left the models images' Security-tab alerts up to a day stale.

## The gap

`arthur-engine-workflow.yml` runs the `vuln-report` action and publishes SARIF right after building **genai-cpu**, **genai-gpu** and **ml-engine**. The three model-upload images are built by reusable workflows instead — and none of `build-ecs/fs/gcp-model-upload.yml` scans or uploads SARIF. Grepping for who publishes SARIF at all:

```
.github/workflows/arthur-engine-workflow.yml
.github/workflows/image-vuln-scan.yml
.github/workflows/composite-actions/vuln-report/action.yml
```

So models-* alerts were only ever refreshed by the nightly `image-vuln-scan` at 09:00 UTC.

## It is visible right now

Yesterday's fixes landed hours ago: #2144 bumped cryptography in `deployment/model-upload/uv.lock`, the 2.1.796 bump correctly **rebuilt** all three models images with it, and #2147 added the CVE-2026-14456 justification.

| Image | Rebuilt with fixes | Alerts refreshed |
| --- | --- | --- |
| genai-cpu / genai-gpu / ml-engine | ✅ | ✅ closed within minutes |
| models-s3 / models-fs / models-gcs | ✅ | ❌ waiting on the nightly |

The five still-open alerts are against images that **no longer contain the problem**. The Security tab is misreporting what actually ships, for up to a day at a time.

## The change

The same scan step, appended to all three build workflows. Details that matter:

- **The slug is the SARIF category**, so it must match this image's entry in the `image-vuln-scan.yml` matrix exactly (`models-s3` / `models-fs` / `models-gcs`). A different category would open a *second, parallel* set of alerts rather than updating the existing ones — validated automatically, see below.
- **Runs last** in the job. The scan takes minutes, and the manifest commit above it races other jobs pushing to the same branch; keeping the scan after it leaves that window tight.
- **`if: inputs.push`** — the scan pulls the image by tag, so a build without a push has nothing to pull.
- **`continue-on-error: true`**, matching the genai-engine and ml-engine builds. Advisory only; must never fail a release.

## Permissions

A called workflow is capped by its caller's token, so `security-events: write` is granted **both** on the job inside each reusable workflow **and** on the three calling jobs in `arthur-engine-workflow.yml`.

Those calling jobs previously declared no `permissions` block at all, and declaring one drops every unlisted scope to `none` — hence spelling out all three.

> `contents: read` is safe despite the manifest commit further down each workflow. I checked rather than assumed: `checkout`, the `git push` and `gh` all run on the **Arthur Automator App token**, not `GITHUB_TOKEN` — the only consumer of `github.token` anywhere in these workflows is the Trivy installer fetching a public release.

## Verification

A validator script checked, against the parsed YAML:

```
all workflows parse
  build-ecs-model-upload.yml     slug=models-s3    daily=models-s3    ok
  build-fs-model-upload.yml      slug=models-fs    daily=models-fs    ok
  build-gcp-model-upload.yml     slug=models-gcs   daily=models-gcs   ok
  caller build-genai-engine-models-docker-image      security-events=write ok
  caller build-genai-engine-models-fs-docker-image   security-events=write ok
  caller build-gcp-model-upload-docker-image         security-events=write ok
VALIDATION PASSED
```

It also confirms each hardcoded slug matches that workflow's own default `image` input, so the slug cannot silently drift from the image it labels.

> [!NOTE]
> Image builds do not run on PRs — only on the version-bump push to `dev` — so the first live exercise of this is post-merge. The failure mode is contained: the step is `continue-on-error`, so a problem shows up as a skipped scan rather than a broken release. The thing to watch on the next release is that the models-* alerts refresh at build time instead of at 09:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
