### PR TITLE
ci: re-scan images when the VEX changes

### DIFF
--- a/.github/workflows/image-vuln-scan.yml
+++ b/.github/workflows/image-vuln-scan.yml
@@ -1,9 +1,10 @@
 name: Scheduled image vulnerability scan
 
 # Re-scans the published images daily so newly-disclosed CVEs surface (and the justification
-# reports regenerate) even when no new release was built. Advisory only — this workflow never
-# gates anything. Findings land in Security -> Code scanning; SBOM + per-image justification
-# reports are uploaded as workflow artifacts.
+# reports regenerate) even when no new release was built, and again whenever the VEX is edited so
+# a fresh triage decision takes effect immediately. Advisory only — this workflow never gates
+# anything. Findings land in Security -> Code scanning; SBOM + per-image justification reports are
+# uploaded as workflow artifacts.
 #
 # Tag selection: by default we scan the latest `-dev` image, derived from the `version` file via
 # the set-version action. The workflow runs on the `dev` default branch, so set-version appends
@@ -15,6 +16,15 @@ on:
   schedule:
     # Daily at 09:00 UTC
     - cron: "0 9 * * *"
+  # Editing the VEX changes how existing findings are triaged without changing any image, so
+  # nothing else would re-scan: the build-time scans only fire when an image is rebuilt, and an
+  # image whose contents are unchanged is retagged rather than rebuilt. Without this trigger a
+  # newly-added suppression sits unapplied — and its alert stays open in the Security tab — until
+  # the next nightly run.
+  push:
+    branches: [dev]
+    paths:
+      - "security/vex/openvex.json"
   workflow_dispatch:
     inputs:
       tag:

--- a/security/README.md
+++ b/security/README.md
@@ -68,6 +68,11 @@ curl -O https://arthur-cft.s3.us-east-2.amazonaws.com/arthur-engine/sbom/latest/
   images (which are rebuilt when their HuggingFace models **or** their build inputs —
   `deployment/model-upload/` Dockerfile, deps, or entrypoint scripts — change; otherwise a
   version bump re-tags the existing image).
+- **On every edit to `vex/openvex.json`** — the same workflow, via a `push` trigger on `dev`.
+  Editing the VEX re-triages existing findings without changing any image, so neither of the
+  triggers above fires: an unchanged image is re-tagged rather than rebuilt, and its open alerts
+  would otherwise stay open until the next nightly run. This is what makes a new statement take
+  effect (and close its alert) at merge time.
 
 Both call the shared composite action `.github/workflows/composite-actions/vuln-report`.
 


### PR DESCRIPTION
## Problem

Editing `security/vex/openvex.json` re-triages existing findings **without changing any image**, and no trigger picks that up:

| Kind of drift | Trigger | Covered? |
| --- | --- | --- |
| Image contents changed | build-time `vuln-report` scan | ✅ #2155 |
| Vulnerability DB changed | daily 09:00 UTC schedule | ✅ |
| **Triage changed (VEX edit)** | — | ❌ |

A Trivy alert stays open until a newer SARIF upload for the same category and ref omits it, so a merged suppression does nothing until something re-scans. For the models images that is especially slow: a version bump re-tags an unchanged image (`tag-genai-engine-models-*`, registry-to-registry via `imagetools`) rather than rebuilding it, and the re-tag path has no scan step.

Observed on CVE-2026-14456 (`libssl3`, OpenSSL QUIC listener DoS). #2147 added a statement covering all six images at 21:44 UTC:

```
249, 248  models-gcs   closed 05:24Z  ← build job has no has_updates gate, so it rebuilt
246, 245  gpu, cpu     closed 21:57Z  ← rebuilt for unrelated reasons
244       ml-engine    closed 21:52Z  ← same
250, 247  models-s3/fs still open     ← re-tag path; waiting on the nightly run
```

`code-scanning/analyses` confirms the two stragglers had no upload after `2026-08-18T09:41Z`, i.e. before the statement existed.

## Change

A `push` trigger on `dev` scoped to `security/vex/openvex.json`, so a triage decision takes effect at merge time for all six images. Plus the matching note in `security/README.md` § *Where the scanning runs*.

Tag resolution needs no change: `set-version` reads the `version` file and appends `-dev`, and that tag exists from the previous bump's re-tag. `github.event.inputs.tag` renders empty on `push` exactly as it already does on `schedule`.

## Alternatives considered

Both were rejected for paying a recurring cost on every one of dev's ~23 weekly version bumps to fix something that only breaks when a human edits the VEX (8 times since June):

- **Drop the `has_updates` gate on the s3/fs build jobs** (match `build-gcp-model-upload-docker-image`) — rebuilds a 7.28 GB model image from scratch ~3×/day per image just to produce a scan of contents that did not change. The gate is correct; gcs lacking one is the anomaly.
- **Add a scan step to the `tag-*` jobs** — cheaper, but still ~15 GB of pulls and 20–30 min of runner time per bump to re-scan a digest the nightly run already covered.

## Known gap

This does not scan s3/fs between a genuine content change and the next nightly run — #2155 already covers that case, since a real model update takes the build path.

## Testing

`push`/`paths` triggers cannot fire from a PR branch, so this is verified by inspection: YAML parses and yields `['schedule', 'push', 'workflow_dispatch']`, and pre-commit `check yaml` passes. First real exercise is the next VEX edit merged to `dev`; the workflow stays advisory and gates nothing, so a misfire cannot block a build. Alerts 250/247 will close on their own at the 09:00 UTC run regardless of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
