### PR TITLE
ci: rebuild the models-gcs image only when its inputs change

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -672,9 +672,9 @@ jobs:
         run: |
           cd deployment/model-upload
           python check_model_updates.py --output github >> $GITHUB_OUTPUT
-          # If either model image doesn't exist yet (bootstrap case), force a build
+          # If any model image doesn't exist yet (bootstrap case), force a build
           TAG=${{ github.ref == 'refs/heads/main' && 'latest' || 'latest-dev' }}
-          for IMAGE in "arthurplatform/genai-engine-models-s3" "arthurplatform/genai-engine-models-fs"; do
+          for IMAGE in "arthurplatform/genai-engine-models-s3" "arthurplatform/genai-engine-models-fs" "arthurplatform/genai-engine-models-gcs"; do
             NAMESPACE="${IMAGE%%/*}"
             REPO="${IMAGE##*/}"
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://hub.docker.com/v2/repositories/${NAMESPACE}/${REPO}/tags/${TAG}/")
@@ -845,6 +845,7 @@ jobs:
       actions: read
     needs: [check-models-updates]
     if: |
+      needs.check-models-updates.outputs.has_updates == 'true' &&
       github.repository == 'arthur-ai/arthur-engine' &&
       contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
       (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
@@ -852,6 +853,46 @@ jobs:
       push: true
       image: arthurplatform/genai-engine-models-gcs
     secrets: inherit
+
+  tag-gcp-model-upload-docker-image:
+    needs: [check-models-updates]
+    environment: shared-protected-branch-secrets
+    if: |
+      needs.check-models-updates.outputs.has_updates == 'false' &&
+      github.repository == 'arthur-ai/arthur-engine' &&
+      contains(github.event.head_commit.message, 'Increment arthur-engine version') &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/workflows/composite-actions/setup-git
+        with:
+          safe-directory: ${{ runner.workspace }}
+      - uses: ./.github/workflows/composite-actions/set-version
+        with:
+          version-prefix: "genai-engine-"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.1.0
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_OSS_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_OSS_TOKEN }}
+      # imagetools copies the full image (incl. the SBOM attestation) registry-to-registry.
+      # The previous `docker pull`/`tag`/`push` fetched only the platform manifest and would
+      # drop the SBOM attestation from the newly-tagged version.
+      - name: Retag previous models gcs image with new version
+        run: |
+          SOURCE_TAG=${{ github.ref == 'refs/heads/main' && 'latest' || 'latest-dev' }}
+          echo "No model updates detected - retagging ${SOURCE_TAG} as ${{ env.VERSION }}"
+          docker buildx imagetools create \
+            --tag arthurplatform/genai-engine-models-gcs:${{ env.VERSION }} \
+            arthurplatform/genai-engine-models-gcs:${SOURCE_TAG}
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            docker buildx imagetools create \
+              --tag arthurplatform/genai-engine-models-gcs:latest \
+              arthurplatform/genai-engine-models-gcs:${SOURCE_TAG}
+          fi
 
   push-all-cfts:
     needs: [build-genai-engine-docker-images, build-ml-engine-docker-images]
@@ -945,6 +986,7 @@ jobs:
       - build-genai-engine-models-fs-docker-image
       - tag-genai-engine-models-fs-docker-image
       - build-gcp-model-upload-docker-image
+      - tag-gcp-model-upload-docker-image
     environment: shared-protected-branch-secrets
     # `needs` on a skipped model build/tag job still enforces ordering (a skipped job counts as
     # complete), so whichever of each build/tag pair ran will have published the <VERSION> tag.


### PR DESCRIPTION
## Problem

`build-gcp-model-upload-docker-image` was the only one of the three model image builds without the `has_updates` gate:

| Job | `has_updates == 'true'` gate | Re-tag counterpart |
| --- | --- | --- |
| `build-genai-engine-models-docker-image` (s3) | ✅ | ✅ |
| `build-genai-engine-models-fs-docker-image` (fs) | ✅ | ✅ |
| `build-gcp-model-upload-docker-image` (gcs) | ❌ | ❌ |

So gcs rebuilt a **7.25 GB** image on every version bump while its two siblings re-tagged. Visible on Docker Hub — `2.1.802-dev` at 05:20Z and `2.1.803-dev` at 08:09Z today, both 7.25 GB, from identical inputs.

Over the last six months: **450 version bumps on `dev`, ~19 warranted rebuilds.** The shared build inputs (`deployment/model-upload/{Dockerfile,pyproject.toml,uv.lock,download_models.py,upload_models.py}`) changed 15 times and `models-manifest.json` 4 times.

## Why the gate is the right signal for gcs

- All three images build from the same context (`{{defaultContext}}:deployment/model-upload`) and the same `Dockerfile`, differing only in `target` (`runtime-gcs` vs `runtime-s3`/`runtime-fs`).
- `check_model_updates.py` compares HuggingFace commits against `models-manifest.json` — no backend-specific logic.
- The build-inputs diff in `check-models-updates` already covers exactly the files gcs builds from.

## Change

Gating the build alone would have stopped publishing the `<VERSION>` tag on bumps where nothing changed, so this adds the three pieces that made the gate safe for s3/fs in the first place:

1. **`tag-gcp-model-upload-docker-image`** — mirrors the other two re-tag jobs, `imagetools` registry-to-registry so the SBOM attestation survives.
2. **`genai-engine-models-gcs` added to the bootstrap existence check** — otherwise a missing gcs image plus `has_updates=false` would re-tag a tag that doesn't exist. The loop previously covered only s3 and fs.
3. **The new tag job added to `push-all-sboms.needs`** — that job pulls `arthurplatform/genai-engine-models-gcs:${VERSION}` and relies on whichever half of each build/tag pair ran having published it. Its `!cancelled()` condition already tolerates the skipped half.

## Consequences, already true for -s3/-fs

On the re-tag path the gcs image keeps the AIBOM `engine-version` baked in at its last real build (`AIBOM_VERSION` build-arg), and the build-time Trivy scan from #2155 does not run. Scan coverage is unaffected: the nightly `image-vuln-scan` still covers gcs, as does the VEX-edit trigger in #2157. Worth merging #2157 first — it's what keeps gcs alerts closing promptly once gcs stops rebuilding incidentally.

`push-aibom` is unaffected; it depends only on the two engine builds and regenerates the AIBOM itself.

## Testing

Verified by inspection — the gated paths only execute on a `dev`/`main` version-bump commit, which a PR branch cannot produce:

- YAML parses; job graph has no dangling `needs`; the three build/tag pairs are now symmetric.
- `build-gcp-model-upload-docker-image` gates on `has_updates == 'true'`, `tag-gcp-model-upload-docker-image` on `'false'` — mutually exclusive, so exactly one runs per bump.
- The new job is a literal transposition of `tag-genai-engine-models-fs-docker-image` with the image name changed; diffing the two shows only that substitution.
- First real exercise is the next version bump merged to `dev`: expect `build-gcp-...` skipped, `tag-gcp-...` success, and a 7.25 GB `<VERSION>` tag on Docker Hub pointing at the same digest as `latest-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
