### PR TITLE
Update dependency typescript to v6

### DIFF
--- a/genai-engine/ui/package.json
+++ b/genai-engine/ui/package.json
@@ -95,7 +95,7 @@
     "jsdom": "^30.0.0",
     "prettier": "3.9.6",
     "swagger-typescript-api": "^13.12.6",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.67.0",
     "vite": "8.2.2",
     "vite-plugin-node-polyfills": "^0.28.0",

--- a/genai-engine/ui/src/test/setup.ts
+++ b/genai-engine/ui/src/test/setup.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 class TestIntersectionObserver implements IntersectionObserver {
   readonly root: Element | Document | null = null;
   readonly rootMargin = "";
+  readonly scrollMargin = "";
   readonly thresholds: ReadonlyArray<number> = [];
 
   disconnect(): void {}

--- a/genai-engine/ui/tsconfig.app.json
+++ b/genai-engine/ui/tsconfig.app.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
 
     /* Path mapping */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "material-react-table": ["./node_modules/material-react-table"],

--- a/genai-engine/ui/yarn.lock
+++ b/genai-engine/ui/yarn.lock
@@ -9326,17 +9326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
-  languageName: node
-  linkType: hard
-
-"typescript@npm:^6.0.3":
+"typescript@npm:6.0.3, typescript@npm:^6.0.3":
   version: 6.0.3
   resolution: "typescript@npm:6.0.3"
   bin:
@@ -9346,17 +9336,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
   version: 6.0.3
   resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
@@ -9436,7 +9416,7 @@ __metadata:
     swagger-typescript-api: "npm:^13.12.6"
     tailwind-merge: "npm:3.6.0"
     tailwindcss: "npm:4.3.3"
-    typescript: "npm:5.9.3"
+    typescript: "npm:6.0.3"
     typescript-eslint: "npm:8.67.0"
     usehooks-ts: "npm:3.1.1"
     uuid: "npm:14.0.2"


### PR DESCRIPTION
Bumps `typescript` in `genai-engine/ui` from **5.9.3 → 6.0.3**, replacing the unsatisfiable v7 bump in #2125.

## Why 6.0.3 and not 7.0.2

`typescript-eslint` (a direct devDependency here) declares peer `typescript: ">=4.8.4 <6.1.0"` and **hard-throws at ESLint config load** on any TS >= 7:

```
Error: typescript-eslint does not support TS 7.0.
    at node_modules/typescript-eslint/dist/index.js:52:11
```

`typescript@7.x` is the native port and no longer exports the JS compiler API `@typescript-eslint/typescript-estree` is built on (`exports["."]` is just `./lib/version.cjs`), so this is not a peer range a patch release widens — no published `typescript-eslint`, stable or canary, admits TS 7.x, and [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) targets TS >= 7.1, skipping 7.0 entirely.

`6.0.3` is the highest major that fits under that ceiling, so it captures a real major now and does all the TS 7 prep work — **both adaptations below are required by TS 7 as well.**

## The two required adaptations

**`tsconfig.app.json` — drop `"baseUrl": "."`.** TS 6 makes it a hard error (`TS5101`; removed outright in TS 7 as `TS5102`). All five `paths` entries are already tsconfig-relative (`./src/*`, `./node_modules/...`), which is exactly how TS resolves them when `baseUrl` is absent — so this is behaviour-neutral and `@/*` plus the dedupe aliases keep resolving unchanged. Chosen over silencing it with `ignoreDeprecations: "6.0"`, since removal is the direction TS 7 forces anyway.

**`src/test/setup.ts` — add `readonly scrollMargin = "";`.** The DOM lib shipped with TS 6 added `scrollMargin` to `IntersectionObserver`, so the test double stopped satisfying the interface (`TS2420`).

## Lockfile

`yarn.lock` **shrinks**: `swagger-typescript-api` already required `typescript@^6.0.3`, so the tree now dedupes to a single `typescript` copy instead of carrying both 5.9.3 and 6.0.3.

## Verification

Run locally against the real dependency tree (including the private `@arthur/*` packages, which the CI autofix sandbox could not install):

| check | result |
|---|---|
| `yarn install` | no `YN0060` typescript peer warning |
| `yarn type-check` | exit 0 |
| `yarn lint` | exit 0 |
| `yarn build` | built |
| `yarn test:run` | 50 files, 234 tests passed |

## Related

- Closes out #2125 (typescript v7 — cannot land).
- Pairs with `chore/cap-typescript-below-6.1`, which adds the Renovate `allowedVersions: "<6.1.0"` cap so v7 stops being re-proposed. That cap still permits this 6.0.x bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)