### PR TITLE
Cap typescript < 6.1.0 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -121,6 +121,12 @@
       "allowedVersions": "<8.8.0"
     },
     {
+      "description": "Cap typescript < 6.1.0: typescript-eslint (a direct devDependency of genai-engine/ui) declares peer typescript '>=4.8.4 <6.1.0' and hard-throws at ESLint config load on any TS >= 7 ('typescript-eslint does not support TS 7.0'), so yarn lint cannot run at all. typescript 7.x is the native port and no longer exports the JS compiler API that @typescript-eslint/typescript-estree is built on, so this is not a version range a patch release widens: no published typescript-eslint (latest 8.68.0 or canary) admits TS 7.x, and upstream typescript-eslint#10940 targets TS >= 7.1, skipping 7.0 entirely. <6.1.0 mirrors the upstream peer ceiling exactly and still allows the typescript 6.0.x major, which typescript-eslint does support. Lift this cap once a typescript-eslint release widens its typescript peer range past 7.0.",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<6.1.0"
+    },
+    {
       "matchManagers": ["dockerfile", "docker-compose"],
       "matchPackageNames": ["python"],
       "enabled": false


### PR DESCRIPTION
Adds a Renovate `allowedVersions` cap so `typescript` 7.x stops being re-proposed as an unsatisfiable major bump.

## Why

`typescript-eslint`, a direct devDependency of `genai-engine/ui`, declares peer `typescript: ">=4.8.4 <6.1.0"` and **hard-throws at ESLint config load** on any TS >= 7:

```js
const [versionMajor] = ts.versionMajorMinor.split('.').map(Number);
if (versionMajor >= 7) { throw new Error('typescript-eslint does not support TS 7.0.'); }
```

`eslint.config.js` imports `typescript-eslint` at the top level and extends `tseslint.configs.recommended`, so `yarn lint` cannot run at all — it dies before a single rule executes.

This is not a stale version range that a patch release widens. `typescript@7.x` is the native port: its npm package no longer exports the JS compiler API `@typescript-eslint/typescript-estree` is built on (`exports["."]` is just `./lib/version.cjs`, everything else behind `unstable/*` subpaths). No published `typescript-eslint` admits TS 7.x — verified against latest stable `8.68.0` and canary `8.68.1-alpha.5`, both still `>=4.8.4 <6.1.0`. Upstream [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) targets TS **>= 7.1**, skipping 7.0 entirely, and 7.1 exists only as `typescript@next` nightlies.

So this is a genuine transitive ceiling, **not** a release-age soak hold — no amount of waiting on current releases clears it. Without the cap, Renovate keeps reopening and rebasing a PR that can never go green (#2125, which accumulated six autofix attempts all reaching the same conclusion).

## Why `<6.1.0` and not `<7.0.0`

`<6.1.0` mirrors the range `typescript-eslint` actually declares. `<7.0.0` would be wrong — TS 6.1+ is equally unsupported by that peer range. The cap still allows the `typescript` 6.0.x major, which typescript-eslint does support; that bump is #2173.

Follows the existing convention for the `openai`, `transformers` and `importlib-metadata` caps in this file: the `description` names the dependency imposing the ceiling and the condition for lifting it (a `typescript-eslint` release widening its `typescript` peer range).

## Verification

`renovate-config-validator` on renovate 44, matching the version this repo runs: *"Config validated successfully against 1 file(s)."*

Note that a default `npx renovate-config-validator` resolves renovate **37** and reports three `managerFilePatterns` errors — those are spurious and already present on `dev`, an artifact of the old validator predating the `fileMatch` rename. They are unrelated to this change.

## Related

- #2125 — `typescript` v7, cannot land; this cap is what stops it recurring.
- #2173 — `typescript` 5.9.3 → 6.0.3, the bump this cap still permits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)