### PR TITLE
feat(integrations): add Codex observability hooks

### DIFF
--- a/integrations/codex-observability/.env.example
+++ b/integrations/codex-observability/.env.example
@@ -1,0 +1,3 @@
+GENAI_ENGINE_API_KEY=<your-api-key>
+GENAI_ENGINE_TASK_ID=<your-task-id>
+GENAI_ENGINE_TRACE_ENDPOINT=https://<your-arthur-engine-host>/api/v1/traces

--- a/integrations/codex-observability/.env.example
+++ b/integrations/codex-observability/.env.example
@@ -1,3 +1,5 @@
 GENAI_ENGINE_API_KEY=<your-api-key>
 GENAI_ENGINE_TASK_ID=<your-task-id>
-GENAI_ENGINE_TRACE_ENDPOINT=https://<your-arthur-engine-host>/api/v1/traces
+# For Local GenAI Engine: http://localhost:3030/api/v1/traces
+# For Hosted GenAI Engine: https://<your-engine-host>/api/v1/traces
+GENAI_ENGINE_TRACE_ENDPOINT=http://localhost:3030/api/v1/traces

--- a/integrations/codex-observability/README.md
+++ b/integrations/codex-observability/README.md
@@ -1,0 +1,165 @@
+# Codex → Arthur Engine Integration
+
+Exports local Codex turns as OpenInference traces in Arthur Engine. Each user
+prompt becomes one `codex.turn` trace containing the final assistant response,
+tool spans, model metadata, token usage, and Codex session and turn IDs.
+
+## How it works
+
+Codex starts command hooks at defined points in its lifecycle. The integration
+registers `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, and `Stop` in Codex's
+`hooks.json`. Each hook starts
+`arthur-engine/integrations/codex-observability/codex_hook_tracer.py`, which
+updates short-lived per-turn state or exports spans directly to Arthur Engine.
+There is no background daemon or local OTLP listener.
+
+Each handler has a five-second Codex timeout, while the outgoing OTLP request
+has a shorter four-second timeout. The generated command always exits
+successfully, including when the Python runtime, tracer, configuration, or
+Engine is unavailable. Observability therefore cannot block a Codex prompt or
+tool call.
+
+```text
+Codex lifecycle hook
+    → codex_hook_tracer.py
+    → OTLP/HTTP protobuf with arthur.task
+    → Arthur Engine /api/v1/traces
+```
+
+`UserPromptSubmit` supplies the exact prompt and start time. `PostToolUse`
+supplies tool input and output. `Stop` supplies the final assistant message and
+completes the root span. The tracer reads token counts from the current Codex
+session transcript; no historical sessions are scanned or backfilled.
+
+## Global installation
+
+Use a global install to trace Codex sessions in every trusted project:
+
+```bash
+cd arthur-engine/integrations/codex-observability
+cp .env.example .env
+# Fill .env with the target Arthur Engine values.
+./install.sh
+```
+
+The installer:
+
+1. Creates an Arthur-owned Python environment under
+   `~/.codex/hooks/.arthur-venv`, isolated from other hook integrations.
+2. Installs the dependencies from
+   `arthur-engine/integrations/codex-observability/requirements.txt`.
+3. Copies the tracer to `~/.codex/hooks/codex_hook_tracer.py`.
+4. Merges four Arthur handlers into `~/.codex/hooks.json` without replacing
+   other hook definitions. Reinstalling replaces older definitions of these
+   Arthur handlers instead of accumulating duplicates.
+5. Writes `~/.codex/arthur_config.json` with mode `0600` when a complete `.env`
+   or complete `GENAI_ENGINE_*` environment configuration is present.
+
+Open `/hooks` in Codex, review the exact command definitions, and trust them.
+Restart Codex after the first install. Codex skips new or changed non-managed
+hooks until their current definitions are trusted.
+
+## Project-scoped installation
+
+Use a project install when only one repository should export traces:
+
+```bash
+cd arthur-engine/integrations/codex-observability
+./install.sh --project-dir /absolute/path/to/project
+```
+
+This installs the runtime under `<project>/.codex/hooks/`, registers it in
+`<project>/.codex/hooks.json`, and keeps `<project>/.codex/arthur_config.json`
+out of version control. Codex loads project hooks only for trusted projects.
+
+## Configuration
+
+The tracer resolves configuration in this order:
+
+1. `GENAI_ENGINE_API_KEY`, `GENAI_ENGINE_TASK_ID`, and
+   `GENAI_ENGINE_TRACE_ENDPOINT` environment variables.
+2. `<hook-payload-cwd>/.codex/arthur_config.json`.
+3. `~/.codex/arthur_config.json`.
+
+The installer also accepts the three environment variables directly and writes
+their values to the mode-`0600` config without echoing them. This avoids a
+temporary `.env` when credentials already come from a secure local provider.
+
+The JSON format is:
+
+```json
+{
+  "api_key": "<your-api-key>",
+  "task_id": "<your-task-id>",
+  "endpoint": "https://<your-arthur-engine-host>/api/v1/traces"
+}
+```
+
+When no complete configuration exists, hook commands exit successfully without
+exporting. API keys are used only in the outgoing `Authorization` header and are
+never added to span attributes or logs.
+
+The tracer sends prompt text, assistant output, tool input and output, model
+metadata, token counts, timestamps, and Codex session and turn identifiers to
+the configured Engine. Treat the destination as sensitive telemetry storage and
+choose a task and retention policy appropriate for the repositories being
+traced.
+
+Exports are synchronous and have no durable retry queue. A turn or tool span
+emitted while the Engine is unavailable can be lost after the bounded request
+fails; Codex continues normally.
+
+## Trace shape
+
+```text
+codex.turn                         OpenInference LLM root
+├── Bash                           OpenInference TOOL
+├── apply_patch                    OpenInference TOOL
+└── mcp__server__tool              OpenInference TOOL
+```
+
+The root includes:
+
+- `input.value` and `output.value`
+- `session.id`, `codex.thread.id`, and `codex.turn.id`
+- `llm.model_name`
+- prompt, completion, cached-input, reasoning, and total token counts when the
+  current transcript provides them
+- start and end timestamps from the hook lifecycle
+
+Codex currently exposes tool completion through `PostToolUse`; it does not
+provide the separate `PostToolUseFailure` lifecycle event used by the Claude
+Code integration.
+
+## Testing
+
+The tests use temporary homes and mocked exporter boundaries; they do not need
+credentials or a running Engine.
+
+```bash
+cd arthur-engine
+uv run --with pytest python -m pytest \
+  integrations/codex-observability/test_tracer.py \
+  integrations/codex-observability/test_install.py -v
+```
+
+For a live test, configure a disposable Arthur task, submit a harmless marked
+prompt in a new Codex session, and verify the actual content through
+`GET /api/v1/traces?task_ids=<task-id>&include_spans=true`.
+
+## Uninstall
+
+```bash
+cd arthur-engine/integrations/codex-observability
+./uninstall.sh
+```
+
+For a project-scoped installation:
+
+```bash
+./uninstall.sh --project-dir /absolute/path/to/project
+```
+
+The uninstaller removes only handlers that invoke this integration's tracer. It
+preserves other Codex hooks and leaves `arthur_config.json` in place so removing
+the runtime does not silently delete credentials or task selection.

--- a/integrations/codex-observability/README.md
+++ b/integrations/codex-observability/README.md
@@ -26,14 +26,30 @@ Codex lifecycle hook
     → Arthur Engine /api/v1/traces
 ```
 
-`UserPromptSubmit` supplies the exact prompt and start time. `PostToolUse`
-supplies tool input and output. `Stop` supplies the final assistant message and
-completes the root span. The tracer reads token counts from the current Codex
-session transcript; no historical sessions are scanned or backfilled.
+`SessionStart` records a local activation marker without exporting conversation
+content. `UserPromptSubmit` supplies the exact prompt and start time.
+`PostToolUse` supplies tool input and output. `Stop` supplies the final assistant
+message and completes the root span. `SubagentStart` and `SubagentStop` connect
+thread-spawned child work to its parent as an OpenInference `AGENT` span:
+
+```text
+parent codex.turn
+    └── codex.agent
+        └── child codex.turn
+            └── child tool spans
+```
+
+Codex reports the parent session ID on subagent hooks. The tracer correlates
+the parent's `spawn_agent` result with the child lifecycle events using the
+shared `agent_id`.
+
+The tracer reads token counts from the current Codex session transcript; no
+historical sessions are scanned or backfilled.
 
 ## Global installation
 
-Use a global install to trace Codex sessions in every trusted project:
+Use a global install to trace supported Codex lifecycle events in trusted
+projects:
 
 ```bash
 cd arthur-engine/integrations/codex-observability
@@ -49,7 +65,7 @@ The installer:
 2. Installs the dependencies from
    `arthur-engine/integrations/codex-observability/requirements.txt`.
 3. Copies the tracer to `~/.codex/hooks/codex_hook_tracer.py`.
-4. Merges four Arthur handlers into `~/.codex/hooks.json` without replacing
+4. Merges seven Arthur handlers into `~/.codex/hooks.json` without replacing
    other hook definitions. Reinstalling replaces older definitions of these
    Arthur handlers instead of accumulating duplicates.
 5. Writes `~/.codex/arthur_config.json` with mode `0600` when a complete `.env`
@@ -58,6 +74,16 @@ The installer:
 Open `/hooks` in Codex, review the exact command definitions, and trust them.
 Restart Codex after the first install. Codex skips new or changed non-managed
 hooks until their current definitions are trusted.
+
+Codex binds hook runtimes to tasks. After installing, upgrading, or trusting a
+changed hook definition, start a new task and verify that
+`~/.codex/tracer/activation/` receives a fresh mode-`0600` marker. Existing
+Desktop tasks may keep stale hook state until Codex refreshes their runtime.
+Arthur cannot export an event that Codex did not dispatch.
+
+Codex exposes `SubagentStart` and `SubagentStop` only for thread-spawned
+subagents. Internal or synthetic Codex agents that do not expose user lifecycle
+hooks cannot be observed by this integration.
 
 ## Project-scoped installation
 

--- a/integrations/codex-observability/codex_hook_tracer.py
+++ b/integrations/codex-observability/codex_hook_tracer.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Export Codex lifecycle-hook events as OpenInference traces to Arthur Engine."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import hashlib
+import json
+import logging
+import os
+import secrets
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Iterator, Mapping, Optional
+
+logging.basicConfig(
+    level=logging.WARNING,
+    format="[codex_hook_tracer] %(levelname)s: %(message)s",
+    stream=sys.stderr,
+)
+log = logging.getLogger("codex_hook_tracer")
+
+STATE_DIR = Path.home() / ".codex" / "tracer"
+STATE_MAX_AGE_SECONDS = 48 * 60 * 60
+TOKEN_FIELDS = (
+    "input_tokens",
+    "cached_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+)
+
+ExportFunction = Callable[[dict, str, list[dict]], None]
+
+
+def _load_config_file(path: Path) -> dict:
+    try:
+        if path.is_file():
+            value = json.loads(path.read_text())
+            return value if isinstance(value, dict) else {}
+    except (OSError, json.JSONDecodeError) as exc:
+        log.debug("Could not read config %s: %s", path, exc)
+    return {}
+
+
+def discover_config(
+    env: Optional[Mapping[str, str]] = None,
+    cwd: Optional[Path] = None,
+    home: Optional[Path] = None,
+) -> Optional[dict]:
+    """Resolve Engine configuration without ever logging credential values."""
+    env = os.environ if env is None else env
+    cwd = Path.cwd() if cwd is None else Path(cwd)
+    home = Path.home() if home is None else Path(home)
+
+    config = {
+        "api_key": env.get("GENAI_ENGINE_API_KEY", ""),
+        "task_id": env.get("GENAI_ENGINE_TASK_ID", ""),
+        "endpoint": env.get("GENAI_ENGINE_TRACE_ENDPOINT", ""),
+    }
+    for candidate in (
+        cwd / ".codex" / "arthur_config.json",
+        home / ".codex" / "arthur_config.json",
+    ):
+        values = _load_config_file(candidate)
+        for key in config:
+            config[key] = config[key] or values.get(key, "")
+        if all(config.values()):
+            return config
+    return config if all(config.values()) else None
+
+
+def _state_key(session_id: str, turn_id: str) -> str:
+    return hashlib.sha256(f"{session_id}\0{turn_id}".encode()).hexdigest()
+
+
+def _state_path(session_id: str, turn_id: str) -> Path:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    return STATE_DIR / f"{_state_key(session_id, turn_id)}.json"
+
+
+def _lock_path(session_id: str, turn_id: str) -> Path:
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    return STATE_DIR / f"{_state_key(session_id, turn_id)}.lock"
+
+
+@contextlib.contextmanager
+def _turn_lock(session_id: str, turn_id: str) -> Iterator[None]:
+    with _lock_path(session_id, turn_id).open("a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _load_state(session_id: str, turn_id: str) -> dict:
+    path = _state_path(session_id, turn_id)
+    try:
+        return json.loads(path.read_text()) if path.is_file() else {}
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("Could not read hook state for session %s: %s", session_id, exc)
+        return {}
+
+
+def _save_state(state: dict) -> None:
+    path = _state_path(state["session_id"], state["turn_id"])
+    path.write_text(json.dumps(state, sort_keys=True))
+    path.chmod(0o600)
+
+
+def _delete_state(session_id: str, turn_id: str) -> None:
+    _state_path(session_id, turn_id).unlink(missing_ok=True)
+
+
+def _cleanup_stale_state() -> None:
+    try:
+        cutoff = time.time() - STATE_MAX_AGE_SECONDS
+        for path in STATE_DIR.glob("*.json"):
+            if path.stat().st_mtime < cutoff:
+                path.unlink(missing_ok=True)
+    except OSError as exc:
+        log.debug("Could not clean stale hook state: %s", exc)
+
+
+def _new_trace_id() -> str:
+    return secrets.token_hex(16)
+
+
+def _new_span_id() -> str:
+    return secrets.token_hex(8)
+
+
+def _encoded_attribute(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def read_token_usage(transcript_path: Path, turn_id: str) -> dict[str, int]:
+    """Sum each model call recorded between this turn's start and completion."""
+    totals = {field: 0 for field in TOKEN_FIELDS}
+    inside_turn = False
+    try:
+        lines = transcript_path.read_text().splitlines()
+    except OSError:
+        return totals
+
+    for line in lines:
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if record.get("type") != "event_msg":
+            continue
+        payload = record.get("payload") or {}
+        event_type = payload.get("type")
+        if event_type == "task_started":
+            inside_turn = payload.get("turn_id") == turn_id
+            continue
+        if event_type == "task_complete":
+            if payload.get("turn_id") == turn_id:
+                break
+            inside_turn = False
+            continue
+        if inside_turn and event_type == "token_count":
+            usage = (payload.get("info") or {}).get("last_token_usage") or {}
+            for field in TOKEN_FIELDS:
+                totals[field] += int(usage.get(field) or 0)
+    return totals
+
+
+def _common_ids(data: dict) -> tuple[str, str]:
+    return str(data.get("session_id") or ""), str(data.get("turn_id") or "")
+
+
+def handle_user_prompt_submit(
+    data: dict,
+    config: dict,
+    export: ExportFunction = None,
+) -> None:
+    del config, export
+    session_id, turn_id = _common_ids(data)
+    if not session_id or not turn_id:
+        return
+    now_ns = time.time_ns()
+    with _turn_lock(session_id, turn_id):
+        _save_state(
+            {
+                "session_id": session_id,
+                "turn_id": turn_id,
+                "model": data.get("model") or "unknown",
+                "prompt": data.get("prompt") or "",
+                "trace_id_hex": _new_trace_id(),
+                "root_span_id_hex": _new_span_id(),
+                "start_ns": now_ns,
+                "pending_tools": {},
+            }
+        )
+
+
+def handle_pre_tool(data: dict, config: dict) -> None:
+    del config
+    session_id, turn_id = _common_ids(data)
+    tool_use_id = str(data.get("tool_use_id") or "")
+    if not session_id or not turn_id or not tool_use_id:
+        return
+    with _turn_lock(session_id, turn_id):
+        state = _load_state(session_id, turn_id)
+        if not state:
+            return
+        state.setdefault("pending_tools", {})[tool_use_id] = {
+            "start_ns": time.time_ns(),
+            "tool_name": data.get("tool_name") or "unknown",
+            "tool_input": data.get("tool_input"),
+        }
+        _save_state(state)
+
+
+def _tool_span_record(state: dict, data: dict, start_ns: int, end_ns: int) -> dict:
+    tool_name = data.get("tool_name") or "unknown"
+    tool_use_id = str(data.get("tool_use_id") or "")
+    return {
+        "name": tool_name,
+        "trace_id_hex": state["trace_id_hex"],
+        "span_id_hex": _new_span_id(),
+        "parent_span_id_hex": state["root_span_id_hex"],
+        "kind": "CLIENT",
+        "status_code": "OK",
+        "start_ns": start_ns,
+        "end_ns": end_ns,
+        "attributes": {
+            "openinference.span.kind": "TOOL",
+            "tool.name": tool_name,
+            "tool.call.id": tool_use_id,
+            "input.value": _encoded_attribute(data.get("tool_input")),
+            "input.mime_type": "application/json",
+            "output.value": _encoded_attribute(data.get("tool_response")),
+            "output.mime_type": "application/json",
+            "session.id": state["session_id"],
+            "codex.thread.id": state["session_id"],
+            "codex.turn.id": state["turn_id"],
+        },
+    }
+
+
+def handle_post_tool(
+    data: dict,
+    config: dict,
+    export: Optional[ExportFunction] = None,
+) -> None:
+    export = _build_and_export_spans if export is None else export
+    session_id, turn_id = _common_ids(data)
+    tool_use_id = str(data.get("tool_use_id") or "")
+    if not session_id or not turn_id:
+        return
+    end_ns = time.time_ns()
+    with _turn_lock(session_id, turn_id):
+        state = _load_state(session_id, turn_id)
+        if not state:
+            return
+        pending = state.setdefault("pending_tools", {}).pop(tool_use_id, {})
+        start_ns = int(pending.get("start_ns") or end_ns - 1_000_000)
+        record = _tool_span_record(state, data, start_ns, end_ns)
+        _save_state(state)
+    export(config, session_id, [record])
+
+
+def _root_span_record(state: dict, data: dict, end_ns: int) -> dict:
+    attributes = {
+        "openinference.span.kind": "LLM",
+        "input.value": state.get("prompt") or "",
+        "input.mime_type": "text/plain",
+        "output.value": data.get("last_assistant_message") or "",
+        "output.mime_type": "text/plain",
+        "session.id": state["session_id"],
+        "codex.thread.id": state["session_id"],
+        "codex.turn.id": state["turn_id"],
+        "codex.turn.status": "completed",
+        "codex.emission.transport": "hooks",
+        "codex.observer.name": "arthur-codex-hook-tracer",
+        "graph.node.id": f"turn:{state['turn_id']}",
+        "graph.node.name": "codex.turn",
+        "llm.model_name": state.get("model") or "unknown",
+    }
+    transcript_path = data.get("transcript_path")
+    if transcript_path:
+        usage = read_token_usage(Path(str(transcript_path)), state["turn_id"])
+        if any(usage.values()):
+            attributes.update(
+                {
+                    "llm.token_count.prompt": usage["input_tokens"],
+                    "llm.token_count.completion": usage["output_tokens"],
+                    "llm.token_count.total": usage["total_tokens"],
+                    "llm.token_count.prompt_details.cache_read": usage[
+                        "cached_input_tokens"
+                    ],
+                    "llm.token_count.completion_details.reasoning": usage[
+                        "reasoning_output_tokens"
+                    ],
+                }
+            )
+    return {
+        "name": "codex.turn",
+        "trace_id_hex": state["trace_id_hex"],
+        "span_id_hex": state["root_span_id_hex"],
+        "parent_span_id_hex": None,
+        "kind": "INTERNAL",
+        "status_code": "OK",
+        "start_ns": state["start_ns"],
+        "end_ns": end_ns,
+        "attributes": attributes,
+    }
+
+
+def handle_stop(
+    data: dict,
+    config: dict,
+    export: Optional[ExportFunction] = None,
+) -> None:
+    export = _build_and_export_spans if export is None else export
+    session_id, turn_id = _common_ids(data)
+    if not session_id or not turn_id:
+        return
+    end_ns = time.time_ns()
+    with _turn_lock(session_id, turn_id):
+        state = _load_state(session_id, turn_id)
+        if not state:
+            return
+        record = _root_span_record(state, data, end_ns)
+        _delete_state(session_id, turn_id)
+    export(config, session_id, [record])
+    _cleanup_stale_state()
+
+
+def _otel_imports():
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import SpanContext, TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.id_generator import IdGenerator
+    from opentelemetry.trace import (
+        NonRecordingSpan,
+        SpanKind,
+        Status,
+        StatusCode,
+        TraceFlags,
+    )
+
+    return (
+        trace,
+        Resource,
+        TracerProvider,
+        SpanContext,
+        SimpleSpanProcessor,
+        OTLPSpanExporter,
+        IdGenerator,
+        NonRecordingSpan,
+        SpanKind,
+        Status,
+        StatusCode,
+        TraceFlags,
+    )
+
+
+def _build_and_export_spans(config: dict, session_id: str, records: list[dict]) -> None:
+    (
+        trace,
+        Resource,
+        TracerProvider,
+        SpanContext,
+        SimpleSpanProcessor,
+        OTLPSpanExporter,
+        IdGenerator,
+        NonRecordingSpan,
+        SpanKind,
+        Status,
+        StatusCode,
+        TraceFlags,
+    ) = _otel_imports()
+
+    resource = Resource.create(
+        {
+            "service.name": "codex",
+            "arthur.task": config["task_id"],
+            "arthur.session": session_id,
+            "arthur.user": os.environ.get(
+                "USER", os.environ.get("USERNAME", "unknown")
+            ),
+        }
+    )
+
+    for record in records:
+        trace_id = int(record["trace_id_hex"], 16)
+        span_id = int(record["span_id_hex"], 16)
+
+        class FixedIdGenerator(IdGenerator):
+            def generate_trace_id(self) -> int:
+                return trace_id
+
+            def generate_span_id(self) -> int:
+                return span_id
+
+        exporter = OTLPSpanExporter(
+            endpoint=config["endpoint"],
+            headers={"Authorization": f"Bearer {config['api_key']}"},
+            timeout=4,
+        )
+        provider = TracerProvider(resource=resource, id_generator=FixedIdGenerator())
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer("arthur-codex-hook-tracer")
+
+        context = None
+        parent_span_id = record.get("parent_span_id_hex")
+        if parent_span_id:
+            parent_context = SpanContext(
+                trace_id=trace_id,
+                span_id=int(parent_span_id, 16),
+                is_remote=True,
+                trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            )
+            context = trace.set_span_in_context(NonRecordingSpan(parent_context))
+
+        kind = {
+            "CLIENT": SpanKind.CLIENT,
+            "INTERNAL": SpanKind.INTERNAL,
+        }.get(record.get("kind"), SpanKind.INTERNAL)
+        span = tracer.start_span(
+            record["name"],
+            context=context,
+            kind=kind,
+            start_time=record["start_ns"],
+        )
+        for key, value in record["attributes"].items():
+            if value is not None:
+                span.set_attribute(key, value)
+        if record.get("status_code") == "OK":
+            span.set_status(Status(StatusCode.OK))
+        span.end(end_time=record["end_ns"])
+        provider.shutdown()
+
+
+HANDLERS = {
+    "user_prompt_submit": handle_user_prompt_submit,
+    "pre_tool": handle_pre_tool,
+    "post_tool": handle_post_tool,
+    "stop": handle_stop,
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or sys.argv[1] not in HANDLERS:
+        print(
+            "Usage: codex_hook_tracer.py <user_prompt_submit|pre_tool|post_tool|stop>",
+            file=sys.stderr,
+        )
+        return 0
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        log.warning("Could not parse Codex hook input: %s", exc)
+        return 0
+
+    config = discover_config(cwd=Path(str(data.get("cwd") or Path.cwd())))
+    if config is None:
+        return 0
+    try:
+        HANDLERS[sys.argv[1]](data, config)
+    except Exception as exc:
+        log.warning("Tracer error for %s: %s", sys.argv[1], exc, exc_info=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/codex-observability/codex_hook_tracer.py
+++ b/integrations/codex-observability/codex_hook_tracer.py
@@ -76,6 +76,10 @@ def _state_key(session_id: str, turn_id: str) -> str:
     return hashlib.sha256(f"{session_id}\0{turn_id}".encode()).hexdigest()
 
 
+def _agent_key(agent_id: str) -> str:
+    return hashlib.sha256(agent_id.encode()).hexdigest()
+
+
 def _state_path(session_id: str, turn_id: str) -> Path:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     return STATE_DIR / f"{_state_key(session_id, turn_id)}.json"
@@ -84,6 +88,18 @@ def _state_path(session_id: str, turn_id: str) -> Path:
 def _lock_path(session_id: str, turn_id: str) -> Path:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     return STATE_DIR / f"{_state_key(session_id, turn_id)}.lock"
+
+
+def _agent_context_path(agent_id: str) -> Path:
+    directory = STATE_DIR / "agents"
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory / f"{_agent_key(agent_id)}.json"
+
+
+def _activation_path(session_id: str) -> Path:
+    directory = STATE_DIR / "activation"
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory / f"{hashlib.sha256(session_id.encode()).hexdigest()}.json"
 
 
 @contextlib.contextmanager
@@ -115,10 +131,29 @@ def _delete_state(session_id: str, turn_id: str) -> None:
     _state_path(session_id, turn_id).unlink(missing_ok=True)
 
 
+def _load_agent_context(agent_id: str) -> dict:
+    path = _agent_context_path(agent_id)
+    try:
+        return json.loads(path.read_text()) if path.is_file() else {}
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("Could not read hook state for agent %s: %s", agent_id, exc)
+        return {}
+
+
+def _save_agent_context(context: dict) -> None:
+    path = _agent_context_path(context["agent_id"])
+    path.write_text(json.dumps(context, sort_keys=True))
+    path.chmod(0o600)
+
+
+def _delete_agent_context(agent_id: str) -> None:
+    _agent_context_path(agent_id).unlink(missing_ok=True)
+
+
 def _cleanup_stale_state() -> None:
     try:
         cutoff = time.time() - STATE_MAX_AGE_SECONDS
-        for path in STATE_DIR.glob("*.json"):
+        for path in STATE_DIR.rglob("*.json"):
             if path.stat().st_mtime < cutoff:
                 path.unlink(missing_ok=True)
     except OSError as exc:
@@ -176,6 +211,66 @@ def _common_ids(data: dict) -> tuple[str, str]:
     return str(data.get("session_id") or ""), str(data.get("turn_id") or "")
 
 
+def _agent_fields(data: dict) -> tuple[str, str]:
+    return str(data.get("agent_id") or ""), str(data.get("agent_type") or "")
+
+
+def _find_agent_id(value: Any) -> str:
+    if isinstance(value, str):
+        try:
+            return _find_agent_id(json.loads(value))
+        except json.JSONDecodeError:
+            return ""
+    if isinstance(value, dict):
+        agent_id = value.get("agent_id")
+        if isinstance(agent_id, str) and agent_id:
+            return agent_id
+        for nested in value.values():
+            found = _find_agent_id(nested)
+            if found:
+                return found
+    if isinstance(value, list):
+        for nested in value:
+            found = _find_agent_id(nested)
+            if found:
+                return found
+    return ""
+
+
+def _agent_prompt(tool_input: Any) -> str:
+    if not isinstance(tool_input, dict):
+        return ""
+    for key in ("message", "prompt", "description"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def handle_session_start(
+    data: dict,
+    config: dict,
+    export: Optional[ExportFunction] = None,
+) -> None:
+    del config, export
+    session_id = str(data.get("session_id") or "")
+    if not session_id:
+        return
+    path = _activation_path(session_id)
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": session_id,
+                "source": data.get("source") or "unknown",
+                "model": data.get("model") or "unknown",
+                "observed_at_ns": time.time_ns(),
+            },
+            sort_keys=True,
+        )
+    )
+    path.chmod(0o600)
+
+
 def handle_user_prompt_submit(
     data: dict,
     config: dict,
@@ -185,6 +280,8 @@ def handle_user_prompt_submit(
     session_id, turn_id = _common_ids(data)
     if not session_id or not turn_id:
         return
+    agent_id, agent_type = _agent_fields(data)
+    agent_context = _load_agent_context(agent_id) if agent_id else {}
     now_ns = time.time_ns()
     with _turn_lock(session_id, turn_id):
         _save_state(
@@ -193,12 +290,20 @@ def handle_user_prompt_submit(
                 "turn_id": turn_id,
                 "model": data.get("model") or "unknown",
                 "prompt": data.get("prompt") or "",
-                "trace_id_hex": _new_trace_id(),
+                "trace_id_hex": agent_context.get("trace_id_hex") or _new_trace_id(),
                 "root_span_id_hex": _new_span_id(),
+                "parent_span_id_hex": agent_context.get("agent_span_id_hex"),
+                "trace_session_id": agent_context.get("parent_session_id")
+                or session_id,
+                "agent_id": agent_id,
+                "agent_type": agent_type or agent_context.get("agent_type") or "",
                 "start_ns": now_ns,
                 "pending_tools": {},
             }
         )
+    if agent_context:
+        agent_context["turn_id"] = turn_id
+        _save_agent_context(agent_context)
 
 
 def handle_pre_tool(data: dict, config: dict) -> None:
@@ -222,6 +327,27 @@ def handle_pre_tool(data: dict, config: dict) -> None:
 def _tool_span_record(state: dict, data: dict, start_ns: int, end_ns: int) -> dict:
     tool_name = data.get("tool_name") or "unknown"
     tool_use_id = str(data.get("tool_use_id") or "")
+    attributes = {
+        "openinference.span.kind": "TOOL",
+        "tool.name": tool_name,
+        "tool.call.id": tool_use_id,
+        "input.value": _encoded_attribute(data.get("tool_input")),
+        "input.mime_type": "application/json",
+        "output.value": _encoded_attribute(data.get("tool_response")),
+        "output.mime_type": "application/json",
+        "session.id": state.get("trace_session_id") or state["session_id"],
+        "codex.thread.id": state.get("agent_id") or state["session_id"],
+        "codex.turn.id": state["turn_id"],
+    }
+    if state.get("agent_id"):
+        attributes.update(
+            {
+                "codex.parent.thread.id": state.get("trace_session_id")
+                or state["session_id"],
+                "codex.agent.id": state["agent_id"],
+                "codex.agent.type": state.get("agent_type") or "unknown",
+            }
+        )
     return {
         "name": tool_name,
         "trace_id_hex": state["trace_id_hex"],
@@ -231,19 +357,33 @@ def _tool_span_record(state: dict, data: dict, start_ns: int, end_ns: int) -> di
         "status_code": "OK",
         "start_ns": start_ns,
         "end_ns": end_ns,
-        "attributes": {
-            "openinference.span.kind": "TOOL",
-            "tool.name": tool_name,
-            "tool.call.id": tool_use_id,
-            "input.value": _encoded_attribute(data.get("tool_input")),
-            "input.mime_type": "application/json",
-            "output.value": _encoded_attribute(data.get("tool_response")),
-            "output.mime_type": "application/json",
-            "session.id": state["session_id"],
-            "codex.thread.id": state["session_id"],
-            "codex.turn.id": state["turn_id"],
-        },
+        "attributes": attributes,
     }
+
+
+def _record_spawned_agent(state: dict, pending: dict, data: dict) -> None:
+    tool_name = str(data.get("tool_name") or "").lower()
+    if tool_name not in {"agent", "spawn_agent", "task"}:
+        return
+    agent_id = _find_agent_id(data.get("tool_response"))
+    if not agent_id:
+        return
+    existing = _load_agent_context(agent_id)
+    tool_input = pending.get("tool_input", data.get("tool_input"))
+    _save_agent_context(
+        {
+            **existing,
+            "parent_session_id": state.get("trace_session_id") or state["session_id"],
+            "parent_turn_id": state["turn_id"],
+            "agent_id": agent_id,
+            "agent_type": existing.get("agent_type") or "unknown",
+            "prompt": _agent_prompt(tool_input),
+            "trace_id_hex": state["trace_id_hex"],
+            "agent_span_id_hex": existing.get("agent_span_id_hex") or _new_span_id(),
+            "parent_span_id_hex": state["root_span_id_hex"],
+            "start_ns": int(pending.get("start_ns") or time.time_ns()),
+        }
+    )
 
 
 def handle_post_tool(
@@ -264,8 +404,9 @@ def handle_post_tool(
         pending = state.setdefault("pending_tools", {}).pop(tool_use_id, {})
         start_ns = int(pending.get("start_ns") or end_ns - 1_000_000)
         record = _tool_span_record(state, data, start_ns, end_ns)
+        _record_spawned_agent(state, pending, data)
         _save_state(state)
-    export(config, session_id, [record])
+    export(config, state.get("trace_session_id") or session_id, [record])
 
 
 def _root_span_record(state: dict, data: dict, end_ns: int) -> dict:
@@ -275,8 +416,8 @@ def _root_span_record(state: dict, data: dict, end_ns: int) -> dict:
         "input.mime_type": "text/plain",
         "output.value": data.get("last_assistant_message") or "",
         "output.mime_type": "text/plain",
-        "session.id": state["session_id"],
-        "codex.thread.id": state["session_id"],
+        "session.id": state.get("trace_session_id") or state["session_id"],
+        "codex.thread.id": state.get("agent_id") or state["session_id"],
         "codex.turn.id": state["turn_id"],
         "codex.turn.status": "completed",
         "codex.emission.transport": "hooks",
@@ -285,6 +426,15 @@ def _root_span_record(state: dict, data: dict, end_ns: int) -> dict:
         "graph.node.name": "codex.turn",
         "llm.model_name": state.get("model") or "unknown",
     }
+    if state.get("agent_id"):
+        attributes.update(
+            {
+                "codex.parent.thread.id": state.get("trace_session_id")
+                or state["session_id"],
+                "codex.agent.id": state["agent_id"],
+                "codex.agent.type": state.get("agent_type") or "unknown",
+            }
+        )
     transcript_path = data.get("transcript_path")
     if transcript_path:
         usage = read_token_usage(Path(str(transcript_path)), state["turn_id"])
@@ -306,13 +456,100 @@ def _root_span_record(state: dict, data: dict, end_ns: int) -> dict:
         "name": "codex.turn",
         "trace_id_hex": state["trace_id_hex"],
         "span_id_hex": state["root_span_id_hex"],
-        "parent_span_id_hex": None,
+        "parent_span_id_hex": state.get("parent_span_id_hex"),
         "kind": "INTERNAL",
         "status_code": "OK",
         "start_ns": state["start_ns"],
         "end_ns": end_ns,
         "attributes": attributes,
     }
+
+
+def handle_subagent_start(
+    data: dict,
+    config: dict,
+    export: Optional[ExportFunction] = None,
+) -> None:
+    del config, export
+    session_id, turn_id = _common_ids(data)
+    agent_id, agent_type = _agent_fields(data)
+    if not session_id or not turn_id or not agent_id:
+        return
+    context = _load_agent_context(agent_id)
+    context.update(
+        {
+            "parent_session_id": context.get("parent_session_id") or session_id,
+            "turn_id": turn_id,
+            "agent_id": agent_id,
+            "agent_type": agent_type or context.get("agent_type") or "unknown",
+            "prompt": context.get("prompt") or "",
+            "trace_id_hex": context.get("trace_id_hex") or _new_trace_id(),
+            "agent_span_id_hex": context.get("agent_span_id_hex") or _new_span_id(),
+            "parent_span_id_hex": context.get("parent_span_id_hex"),
+            "start_ns": int(context.get("start_ns") or time.time_ns()),
+        }
+    )
+    _save_agent_context(context)
+
+
+def _agent_span_record(context: dict, data: dict, end_ns: int) -> dict:
+    agent_id = context["agent_id"]
+    agent_type = context.get("agent_type") or "unknown"
+    parent_session_id = context.get("parent_session_id") or data.get("session_id", "")
+    return {
+        "name": "codex.agent",
+        "trace_id_hex": context["trace_id_hex"],
+        "span_id_hex": context["agent_span_id_hex"],
+        "parent_span_id_hex": context.get("parent_span_id_hex"),
+        "kind": "INTERNAL",
+        "status_code": "OK",
+        "start_ns": context["start_ns"],
+        "end_ns": end_ns,
+        "attributes": {
+            "openinference.span.kind": "AGENT",
+            "input.value": context.get("prompt") or "",
+            "input.mime_type": "text/plain",
+            "output.value": data.get("last_assistant_message") or "",
+            "output.mime_type": "text/plain",
+            "session.id": parent_session_id,
+            "codex.thread.id": agent_id,
+            "codex.parent.thread.id": parent_session_id,
+            "codex.turn.id": context.get("turn_id") or "",
+            "codex.agent.id": agent_id,
+            "codex.agent.type": agent_type,
+            "graph.node.id": f"agent:{agent_id}",
+            "graph.node.name": "codex.agent",
+        },
+    }
+
+
+def handle_subagent_stop(
+    data: dict,
+    config: dict,
+    export: Optional[ExportFunction] = None,
+) -> None:
+    export = _build_and_export_spans if export is None else export
+    session_id, turn_id = _common_ids(data)
+    agent_id, _ = _agent_fields(data)
+    if not session_id or not turn_id or not agent_id:
+        return
+    end_ns = time.time_ns()
+    records = []
+    with _turn_lock(session_id, turn_id):
+        state = _load_state(session_id, turn_id)
+        if state:
+            root_data = dict(data)
+            if data.get("agent_transcript_path"):
+                root_data["transcript_path"] = data["agent_transcript_path"]
+            records.append(_root_span_record(state, root_data, end_ns))
+            _delete_state(session_id, turn_id)
+    context = _load_agent_context(agent_id)
+    if context:
+        records.append(_agent_span_record(context, data, end_ns))
+        _delete_agent_context(agent_id)
+    if records:
+        export(config, context.get("parent_session_id") or session_id, records)
+    _cleanup_stale_state()
 
 
 def handle_stop(
@@ -444,9 +681,12 @@ def _build_and_export_spans(config: dict, session_id: str, records: list[dict]) 
 
 
 HANDLERS = {
+    "session_start": handle_session_start,
     "user_prompt_submit": handle_user_prompt_submit,
     "pre_tool": handle_pre_tool,
     "post_tool": handle_post_tool,
+    "subagent_start": handle_subagent_start,
+    "subagent_stop": handle_subagent_stop,
     "stop": handle_stop,
 }
 
@@ -454,7 +694,8 @@ HANDLERS = {
 def main() -> int:
     if len(sys.argv) != 2 or sys.argv[1] not in HANDLERS:
         print(
-            "Usage: codex_hook_tracer.py <user_prompt_submit|pre_tool|post_tool|stop>",
+            "Usage: codex_hook_tracer.py "
+            "<session_start|user_prompt_submit|pre_tool|post_tool|subagent_start|subagent_stop|stop>",
             file=sys.stderr,
         )
         return 0

--- a/integrations/codex-observability/install.sh
+++ b/integrations/codex-observability/install.sh
@@ -65,9 +65,12 @@ except (json.JSONDecodeError, OSError):
 
 hooks = settings.setdefault("hooks", {})
 for event, argument, matcher in (
+    ("SessionStart", "session_start", None),
     ("UserPromptSubmit", "user_prompt_submit", None),
     ("PreToolUse", "pre_tool", ""),
     ("PostToolUse", "post_tool", ""),
+    ("SubagentStart", "subagent_start", None),
+    ("SubagentStop", "subagent_stop", None),
     ("Stop", "stop", None),
 ):
     command = " ".join(

--- a/integrations/codex-observability/install.sh
+++ b/integrations/codex-observability/install.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Install the Arthur Codex hook tracer globally or into one trusted project.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --project-dir)
+            PROJECT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -n "$PROJECT_DIR" ]]; then
+    CODEX_ROOT="$PROJECT_DIR/.codex"
+else
+    CODEX_ROOT="$HOME/.codex"
+fi
+
+HOOK_DIR="$CODEX_ROOT/hooks"
+VENV_DIR="$HOOK_DIR/.arthur-venv"
+TRACER_SOURCE="$SCRIPT_DIR/codex_hook_tracer.py"
+TRACER_DEST="$HOOK_DIR/codex_hook_tracer.py"
+HOOKS_FILE="$CODEX_ROOT/hooks.json"
+PYTHON_COMMAND="${PYTHON_COMMAND:-python3}"
+
+if [[ ! -f "$TRACER_SOURCE" ]]; then
+    echo "Tracer not found: $TRACER_SOURCE" >&2
+    exit 1
+fi
+
+mkdir -p "$HOOK_DIR"
+if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+    "$PYTHON_COMMAND" -m venv "$VENV_DIR"
+fi
+
+if [[ "${CODEX_OBSERVABILITY_SKIP_DEPENDENCIES:-0}" != "1" ]]; then
+    "$VENV_DIR/bin/python" -m pip install --quiet -r "$SCRIPT_DIR/requirements.txt"
+fi
+
+cp "$TRACER_SOURCE" "$TRACER_DEST"
+chmod 755 "$TRACER_DEST"
+
+"$VENV_DIR/bin/python" - "$HOOKS_FILE" "$VENV_DIR/bin/python" "$TRACER_DEST" <<'PY'
+import json
+import shlex
+import sys
+from pathlib import Path
+
+hooks_path = Path(sys.argv[1])
+python_path = sys.argv[2]
+tracer_path = sys.argv[3]
+try:
+    settings = json.loads(hooks_path.read_text()) if hooks_path.exists() else {}
+except (json.JSONDecodeError, OSError):
+    settings = {}
+
+hooks = settings.setdefault("hooks", {})
+for event, argument, matcher in (
+    ("UserPromptSubmit", "user_prompt_submit", None),
+    ("PreToolUse", "pre_tool", ""),
+    ("PostToolUse", "post_tool", ""),
+    ("Stop", "stop", None),
+):
+    command = " ".join(
+        (
+            "[",
+            "-x",
+            shlex.quote(python_path),
+            "]",
+            "&&",
+            "[",
+            "-f",
+            shlex.quote(tracer_path),
+            "]",
+            "&&",
+            shlex.quote(python_path),
+            shlex.quote(tracer_path),
+            argument + ";",
+            "true",
+        )
+    )
+    groups = hooks.setdefault(event, [])
+    retained_groups = []
+    for group in groups:
+        if not isinstance(group, dict):
+            retained_groups.append(group)
+            continue
+        retained_handlers = [
+            handler
+            for handler in group.get("hooks", [])
+            if not (
+                isinstance(handler, dict)
+                and tracer_path in handler.get("command", "")
+            )
+        ]
+        if retained_handlers:
+            retained_group = dict(group)
+            retained_group["hooks"] = retained_handlers
+            retained_groups.append(retained_group)
+    group = {
+        "hooks": [
+            {"type": "command", "command": command, "timeout": 5}
+        ]
+    }
+    if matcher is not None:
+        group["matcher"] = matcher
+    retained_groups.append(group)
+    hooks[event] = retained_groups
+
+hooks_path.parent.mkdir(parents=True, exist_ok=True)
+hooks_path.write_text(json.dumps(settings, indent=2) + "\n")
+PY
+
+ENV_FILE="$SCRIPT_DIR/.env"
+if [[ -n "$PROJECT_DIR" && -f "$PROJECT_DIR/.env" ]]; then
+    ENV_FILE="$PROJECT_DIR/.env"
+fi
+if [[ -n "${GENAI_ENGINE_API_KEY:-}" && -n "${GENAI_ENGINE_TASK_ID:-}" && -n "${GENAI_ENGINE_TRACE_ENDPOINT:-}" ]]; then
+    "$VENV_DIR/bin/python" - "$CODEX_ROOT/arthur_config.json" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+output_path = Path(sys.argv[1])
+config = {
+    "api_key": os.environ["GENAI_ENGINE_API_KEY"],
+    "task_id": os.environ["GENAI_ENGINE_TASK_ID"],
+    "endpoint": os.environ["GENAI_ENGINE_TRACE_ENDPOINT"],
+}
+output_path.write_text(json.dumps(config, indent=2) + "\n")
+output_path.chmod(0o600)
+PY
+elif [[ -f "$ENV_FILE" ]]; then
+    "$VENV_DIR/bin/python" - "$CODEX_ROOT/arthur_config.json" "$ENV_FILE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+output_path = Path(sys.argv[1])
+env_path = Path(sys.argv[2])
+values = {}
+for raw_line in env_path.read_text().splitlines():
+    line = raw_line.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        continue
+    key, value = line.split("=", 1)
+    values[key.strip()] = value.strip().strip("'\"")
+
+config = {
+    "api_key": values.get("GENAI_ENGINE_API_KEY", ""),
+    "task_id": values.get("GENAI_ENGINE_TASK_ID", ""),
+    "endpoint": values.get("GENAI_ENGINE_TRACE_ENDPOINT", ""),
+}
+if all(config.values()):
+    output_path.write_text(json.dumps(config, indent=2) + "\n")
+    output_path.chmod(0o600)
+else:
+    print("Arthur .env is incomplete; config was not written", file=sys.stderr)
+PY
+fi
+
+if [[ -n "$PROJECT_DIR" ]]; then
+    GITIGNORE="$PROJECT_DIR/.gitignore"
+    if [[ ! -f "$GITIGNORE" ]] || ! grep -qF '.codex/arthur_config.json' "$GITIGNORE"; then
+        printf '\n.codex/arthur_config.json\n' >> "$GITIGNORE"
+    fi
+fi
+
+echo "Installed Codex tracer: $TRACER_DEST"
+echo "Registered lifecycle hooks: $HOOKS_FILE"
+echo "Review and trust the new hook definition with /hooks, then restart Codex."

--- a/integrations/codex-observability/requirements.txt
+++ b/integrations/codex-observability/requirements.txt
@@ -1,0 +1,2 @@
+opentelemetry-sdk>=1.20.0
+opentelemetry-exporter-otlp-proto-http>=1.20.0

--- a/integrations/codex-observability/test_install.py
+++ b/integrations/codex-observability/test_install.py
@@ -51,7 +51,15 @@ def test_global_install_is_idempotent_and_preserves_existing_hooks(tmp_path):
     assert (codex_dir / "hooks" / ".arthur-venv" / "bin" / "python").is_file()
     hooks = json.loads(hooks_path.read_text())["hooks"]
     assert hooks["SessionStart"][0]["hooks"][0]["command"] == "/usr/bin/true"
-    for event in ("UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop"):
+    for event in (
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "SubagentStart",
+        "SubagentStop",
+        "Stop",
+    ):
         arthur_handlers = [
             hook
             for group in hooks[event]
@@ -174,18 +182,18 @@ def test_install_writes_mode_0600_config_from_environment_without_echoing_key(tm
         "install.sh",
         tmp_path,
         {
-            "GENAI_ENGINE_API_KEY": "local-development-key",
+            "GENAI_ENGINE_API_KEY": "example-test-key",
             "GENAI_ENGINE_TASK_ID": "00000000-0000-0000-0000-000000000123",
             "GENAI_ENGINE_TRACE_ENDPOINT": EXAMPLE_ENDPOINT,
         },
     )
 
     assert result.returncode == 0, result.stderr
-    assert "local-development-key" not in result.stdout + result.stderr
+    assert "example-test-key" not in result.stdout + result.stderr
     config_path = tmp_path / ".codex" / "arthur_config.json"
     assert config_path.stat().st_mode & 0o777 == 0o600
     assert json.loads(config_path.read_text()) == {
-        "api_key": "local-development-key",
+        "api_key": "example-test-key",
         "task_id": "00000000-0000-0000-0000-000000000123",
         "endpoint": EXAMPLE_ENDPOINT,
     }

--- a/integrations/codex-observability/test_install.py
+++ b/integrations/codex-observability/test_install.py
@@ -1,0 +1,191 @@
+"""Black-box tests for the Codex observability installer and uninstaller."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+INTEGRATION_DIR = Path(__file__).parent
+EXAMPLE_ENDPOINT = "https://engine.example.com/api/v1/traces"
+
+
+def _run(script: str, home: Path, extra_env=None):
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "CODEX_OBSERVABILITY_SKIP_DEPENDENCIES": "1",
+        **(extra_env or {}),
+    }
+    return subprocess.run(
+        ["bash", str(INTEGRATION_DIR / script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_global_install_is_idempotent_and_preserves_existing_hooks(tmp_path):
+    """Break caught: install duplicates or replaces another global Codex hook."""
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    hooks_path = codex_dir / "hooks.json"
+    hooks_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {"hooks": [{"type": "command", "command": "/usr/bin/true"}]}
+                    ]
+                }
+            }
+        )
+    )
+
+    first = _run("install.sh", tmp_path)
+    second = _run("install.sh", tmp_path)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert (codex_dir / "hooks" / "codex_hook_tracer.py").is_file()
+    assert (codex_dir / "hooks" / ".arthur-venv" / "bin" / "python").is_file()
+    hooks = json.loads(hooks_path.read_text())["hooks"]
+    assert hooks["SessionStart"][0]["hooks"][0]["command"] == "/usr/bin/true"
+    for event in ("UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop"):
+        arthur_handlers = [
+            hook
+            for group in hooks[event]
+            for hook in group.get("hooks", [])
+            if "codex_hook_tracer.py" in hook.get("command", "")
+        ]
+        assert len(arthur_handlers) == 1
+        assert arthur_handlers[0]["timeout"] == 5
+        assert arthur_handlers[0]["command"].endswith("; true")
+
+
+def test_reinstall_replaces_previous_arthur_handler_definition(tmp_path):
+    """Break caught: an upgraded command is appended beside its stale definition."""
+    codex_dir = tmp_path / ".codex"
+    tracer_path = codex_dir / "hooks" / "codex_hook_tracer.py"
+    codex_dir.mkdir()
+    hooks_path = codex_dir / "hooks.json"
+    hooks_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": f"python3 {tracer_path} old-stop",
+                                    "timeout": 600,
+                                },
+                                {"type": "command", "command": "/usr/bin/true"},
+                            ]
+                        }
+                    ]
+                }
+            }
+        )
+    )
+
+    result = _run("install.sh", tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    stop_groups = json.loads(hooks_path.read_text())["hooks"]["Stop"]
+    handlers = [hook for group in stop_groups for hook in group["hooks"]]
+    arthur_handlers = [
+        hook for hook in handlers if str(tracer_path) in hook.get("command", "")
+    ]
+    assert len(arthur_handlers) == 1
+    assert arthur_handlers[0]["timeout"] == 5
+    assert arthur_handlers[0]["command"].endswith(" stop; true")
+    assert {hook["command"] for hook in handlers if hook not in arthur_handlers} == {
+        "/usr/bin/true"
+    }
+
+
+def test_generated_commands_fail_open_for_crashing_or_missing_runtime(tmp_path):
+    """Break caught: an auxiliary tracer failure prevents a Codex lifecycle event."""
+    result = _run("install.sh", tmp_path)
+    assert result.returncode == 0, result.stderr
+    codex_dir = tmp_path / ".codex"
+    hooks = json.loads((codex_dir / "hooks.json").read_text())["hooks"]
+    command = next(
+        hook["command"]
+        for group in hooks["Stop"]
+        for hook in group["hooks"]
+        if "codex_hook_tracer.py" in hook.get("command", "")
+    )
+    tracer_path = codex_dir / "hooks" / "codex_hook_tracer.py"
+    tracer_path.write_text("raise SystemExit(9)\n")
+
+    crashed = subprocess.run(
+        command,
+        shell=True,
+        executable="/bin/sh",
+        input="{}",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert crashed.returncode == 0
+
+    (codex_dir / "hooks" / ".arthur-venv" / "bin" / "python").unlink()
+    missing = subprocess.run(
+        command,
+        shell=True,
+        executable="/bin/sh",
+        input="{}",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert missing.returncode == 0
+
+
+def test_uninstall_removes_only_arthur_hook_commands(tmp_path):
+    """Break caught: uninstall deletes another tool's Codex lifecycle hook."""
+    installed = _run("install.sh", tmp_path)
+    assert installed.returncode == 0, installed.stderr
+    hooks_path = tmp_path / ".codex" / "hooks.json"
+    hooks = json.loads(hooks_path.read_text())
+    hooks["hooks"]["Stop"][0]["hooks"].append(
+        {"type": "command", "command": "/usr/bin/true"}
+    )
+    hooks_path.write_text(json.dumps(hooks))
+
+    removed = _run("uninstall.sh", tmp_path)
+
+    assert removed.returncode == 0, removed.stderr
+    hooks = json.loads(hooks_path.read_text())["hooks"]
+    assert hooks["Stop"][0]["hooks"] == [
+        {"type": "command", "command": "/usr/bin/true"}
+    ]
+    serialized = json.dumps(hooks)
+    assert "codex_hook_tracer.py" not in serialized
+    assert not (tmp_path / ".codex" / "hooks" / "codex_hook_tracer.py").exists()
+
+
+def test_install_writes_mode_0600_config_from_environment_without_echoing_key(tmp_path):
+    """Break caught: safe non-file credentials are ignored or exposed in installer output."""
+    result = _run(
+        "install.sh",
+        tmp_path,
+        {
+            "GENAI_ENGINE_API_KEY": "local-development-key",
+            "GENAI_ENGINE_TASK_ID": "00000000-0000-0000-0000-000000000123",
+            "GENAI_ENGINE_TRACE_ENDPOINT": EXAMPLE_ENDPOINT,
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "local-development-key" not in result.stdout + result.stderr
+    config_path = tmp_path / ".codex" / "arthur_config.json"
+    assert config_path.stat().st_mode & 0o777 == 0o600
+    assert json.loads(config_path.read_text()) == {
+        "api_key": "local-development-key",
+        "task_id": "00000000-0000-0000-0000-000000000123",
+        "endpoint": EXAMPLE_ENDPOINT,
+    }

--- a/integrations/codex-observability/test_tracer.py
+++ b/integrations/codex-observability/test_tracer.py
@@ -170,6 +170,218 @@ def test_hook_lifecycle_exports_tool_then_complete_turn(isolated_state):
     assert not list(isolated_state.glob("*.json"))
 
 
+def test_session_start_records_hook_activation_without_exporting_content(
+    isolated_state,
+):
+    """Break caught: a live task silently uses no Arthur hook runtime."""
+    exported = []
+
+    tracer.handle_session_start(
+        {
+            "session_id": "session-123",
+            "hook_event_name": "SessionStart",
+            "source": "resume",
+            "model": "gpt-5.6-sol",
+        },
+        config(),
+        lambda *args: exported.append(args),
+    )
+
+    activation_files = list((isolated_state / "activation").glob("*.json"))
+    assert len(activation_files) == 1
+    activation = json.loads(activation_files[0].read_text())
+    assert activation["session_id"] == "session-123"
+    assert activation["source"] == "resume"
+    assert activation["model"] == "gpt-5.6-sol"
+    assert isinstance(activation["observed_at_ns"], int)
+    assert activation_files[0].stat().st_mode & 0o777 == 0o600
+    assert exported == []
+
+
+def test_subagent_lifecycle_exports_agent_turn_and_nested_tools(isolated_state):
+    """Break caught: Codex subagent work is flattened or never completed."""
+    exported = []
+    exported_session_ids = []
+
+    def export(cfg, session_id, records):
+        exported_session_ids.append(session_id)
+        exported.extend(records)
+
+    tracer.handle_user_prompt_submit(
+        {**common(), "prompt": "PARENT_PROMPT"}, config(), export
+    )
+    tracer.handle_pre_tool(
+        {
+            **common(),
+            "tool_name": "spawn_agent",
+            "tool_use_id": "spawn-1",
+            "tool_input": {
+                "task_name": "researcher",
+                "message": "SUBAGENT_PROMPT",
+            },
+        },
+        config(),
+    )
+    tracer.handle_post_tool(
+        {
+            **common(),
+            "tool_name": "spawn_agent",
+            "tool_use_id": "spawn-1",
+            "tool_input": {
+                "task_name": "researcher",
+                "message": "SUBAGENT_PROMPT",
+            },
+            "tool_response": {
+                "agent_id": "agent-789",
+                "status": "running",
+            },
+        },
+        config(),
+        export,
+    )
+    tracer.handle_subagent_start(
+        {
+            "session_id": "session-123",
+            "turn_id": "subagent-turn-1",
+            "agent_id": "agent-789",
+            "agent_type": "researcher",
+            "model": "gpt-5.6-sol",
+            "hook_event_name": "SubagentStart",
+        },
+        config(),
+        export,
+    )
+    tracer.handle_user_prompt_submit(
+        {
+            "session_id": "session-123",
+            "turn_id": "subagent-turn-1",
+            "agent_id": "agent-789",
+            "agent_type": "researcher",
+            "model": "gpt-5.6-sol",
+            "prompt": "SUBAGENT_PROMPT",
+            "hook_event_name": "UserPromptSubmit",
+        },
+        config(),
+        export,
+    )
+    tracer.handle_pre_tool(
+        {
+            "session_id": "session-123",
+            "turn_id": "subagent-turn-1",
+            "agent_id": "agent-789",
+            "agent_type": "researcher",
+            "tool_name": "Bash",
+            "tool_use_id": "child-tool-1",
+            "tool_input": {"command": "printf CHILD_TOOL"},
+        },
+        config(),
+    )
+    tracer.handle_post_tool(
+        {
+            "session_id": "session-123",
+            "turn_id": "subagent-turn-1",
+            "agent_id": "agent-789",
+            "agent_type": "researcher",
+            "tool_name": "Bash",
+            "tool_use_id": "child-tool-1",
+            "tool_input": {"command": "printf CHILD_TOOL"},
+            "tool_response": "CHILD_TOOL",
+        },
+        config(),
+        export,
+    )
+    tracer.handle_subagent_stop(
+        {
+            "session_id": "session-123",
+            "turn_id": "subagent-turn-1",
+            "agent_id": "agent-789",
+            "agent_type": "researcher",
+            "agent_transcript_path": None,
+            "last_assistant_message": "SUBAGENT_RESPONSE",
+            "hook_event_name": "SubagentStop",
+        },
+        config(),
+        export,
+    )
+    tracer.handle_stop(
+        {**common(), "last_assistant_message": "PARENT_RESPONSE"},
+        config(),
+        export,
+    )
+
+    records_by_name = {}
+    for record in exported:
+        records_by_name.setdefault(record["name"], []).append(record)
+
+    parent_turn = next(
+        record
+        for record in records_by_name["codex.turn"]
+        if record["attributes"]["codex.turn.id"] == "turn-456"
+    )
+    child_turn = next(
+        record
+        for record in records_by_name["codex.turn"]
+        if record["attributes"]["codex.turn.id"] == "subagent-turn-1"
+    )
+    agent = records_by_name["codex.agent"][0]
+    child_tool = next(
+        record
+        for record in records_by_name["Bash"]
+        if record["attributes"]["tool.call.id"] == "child-tool-1"
+    )
+
+    assert agent["trace_id_hex"] == parent_turn["trace_id_hex"]
+    assert child_turn["trace_id_hex"] == parent_turn["trace_id_hex"]
+    assert child_tool["trace_id_hex"] == parent_turn["trace_id_hex"]
+    assert agent["parent_span_id_hex"] == parent_turn["span_id_hex"]
+    assert child_turn["parent_span_id_hex"] == agent["span_id_hex"]
+    assert child_tool["parent_span_id_hex"] == child_turn["span_id_hex"]
+    assert agent["attributes"]["openinference.span.kind"] == "AGENT"
+    assert agent["attributes"]["input.value"] == "SUBAGENT_PROMPT"
+    assert agent["attributes"]["output.value"] == "SUBAGENT_RESPONSE"
+    assert agent["attributes"]["codex.agent.id"] == "agent-789"
+    assert agent["attributes"]["codex.agent.type"] == "researcher"
+    assert agent["attributes"]["session.id"] == "session-123"
+    assert child_turn["attributes"]["codex.agent.id"] == "agent-789"
+    assert child_turn["attributes"]["session.id"] == "session-123"
+    assert child_turn["attributes"]["codex.parent.thread.id"] == "session-123"
+    assert child_tool["attributes"]["codex.agent.id"] == "agent-789"
+    assert set(exported_session_ids) == {"session-123"}
+    assert not list(isolated_state.glob("*.json"))
+    assert not list((isolated_state / "agents").glob("*.json"))
+
+
+def test_stale_cleanup_removes_abandoned_agent_and_activation_state(
+    isolated_state, monkeypatch
+):
+    """Break caught: missing Stop events retain agent/session identifiers forever."""
+    tracer._save_agent_context(
+        {
+            "parent_session_id": "session-123",
+            "agent_id": "agent-789",
+            "trace_id_hex": "1" * 32,
+            "agent_span_id_hex": "2" * 16,
+            "start_ns": 1,
+        }
+    )
+    tracer.handle_session_start(
+        {"session_id": "session-123", "source": "startup"}, config()
+    )
+    paths = [
+        *list((isolated_state / "agents").glob("*.json")),
+        *list((isolated_state / "activation").glob("*.json")),
+    ]
+    old_time = 1_000
+    for path in paths:
+        os.utime(path, (old_time, old_time))
+    monkeypatch.setattr(tracer.time, "time", lambda: old_time + 49 * 60 * 60)
+
+    tracer._cleanup_stale_state()
+
+    assert not list((isolated_state / "agents").glob("*.json"))
+    assert not list((isolated_state / "activation").glob("*.json"))
+
+
 def test_token_usage_sums_all_model_calls_in_only_the_matching_turn(tmp_path):
     """Break caught: reporting session totals or only the final model call."""
     transcript = tmp_path / "rollout.jsonl"

--- a/integrations/codex-observability/test_tracer.py
+++ b/integrations/codex-observability/test_tracer.py
@@ -1,0 +1,478 @@
+"""Contract tests for the Codex lifecycle-hook Arthur tracer."""
+
+import importlib.util
+import json
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).with_name("codex_hook_tracer.py")
+SPEC = importlib.util.spec_from_file_location("codex_hook_tracer", MODULE_PATH)
+tracer = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(tracer)
+
+
+@pytest.fixture
+def isolated_state(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    monkeypatch.setattr(tracer, "STATE_DIR", state_dir)
+    return state_dir
+
+
+def config():
+    return {
+        "api_key": "example-test-key",
+        "task_id": "00000000-0000-0000-0000-000000000123",
+        "endpoint": "https://engine.example.com/api/v1/traces",
+    }
+
+
+def common():
+    return {
+        "session_id": "session-123",
+        "turn_id": "turn-456",
+        "model": "gpt-5.6-sol",
+    }
+
+
+def test_config_prefers_environment_then_project_then_global(tmp_path):
+    """Break caught: global credentials unexpectedly override a narrower source."""
+    project = tmp_path / "project"
+    home = tmp_path / "home"
+    (project / ".codex").mkdir(parents=True)
+    (home / ".codex").mkdir(parents=True)
+    (project / ".codex" / "arthur_config.json").write_text(
+        json.dumps(
+            {
+                "api_key": "project-key",
+                "task_id": "project-task",
+                "endpoint": "http://project/api/v1/traces",
+            }
+        )
+    )
+    (home / ".codex" / "arthur_config.json").write_text(
+        json.dumps(
+            {
+                "api_key": "global-key",
+                "task_id": "global-task",
+                "endpoint": "http://global/api/v1/traces",
+            }
+        )
+    )
+
+    assert tracer.discover_config(env={}, cwd=project, home=home) == {
+        "api_key": "project-key",
+        "task_id": "project-task",
+        "endpoint": "http://project/api/v1/traces",
+    }
+    assert tracer.discover_config(
+        env={
+            "GENAI_ENGINE_API_KEY": "env-key",
+            "GENAI_ENGINE_TASK_ID": "env-task",
+            "GENAI_ENGINE_TRACE_ENDPOINT": "http://env/api/v1/traces",
+        },
+        cwd=project,
+        home=home,
+    ) == {
+        "api_key": "env-key",
+        "task_id": "env-task",
+        "endpoint": "http://env/api/v1/traces",
+    }
+
+
+def test_incomplete_config_is_a_silent_noop(tmp_path):
+    """Break caught: a partial installation crashes every Codex turn."""
+    assert tracer.discover_config(env={}, cwd=tmp_path, home=tmp_path) is None
+
+
+def test_hook_lifecycle_exports_tool_then_complete_turn(isolated_state):
+    """Break caught: prompt, tool, or final response is lost between hook processes."""
+    exported = []
+    export = lambda cfg, session_id, records: exported.append(
+        (cfg, session_id, records)
+    )
+
+    tracer.handle_user_prompt_submit(
+        {**common(), "hook_event_name": "UserPromptSubmit", "prompt": "PROMPT_MARKER"},
+        config(),
+        export,
+    )
+    tracer.handle_pre_tool(
+        {
+            **common(),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": "tool-789",
+            "tool_input": {"command": "printf TOOL_MARKER"},
+        },
+        config(),
+    )
+    tracer.handle_post_tool(
+        {
+            **common(),
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": "tool-789",
+            "tool_input": {"command": "printf TOOL_MARKER"},
+            "tool_response": "TOOL_MARKER",
+        },
+        config(),
+        export,
+    )
+
+    assert len(exported) == 1
+    tool = exported[0][2][0]
+    assert tool["name"] == "Bash"
+    assert tool["attributes"]["openinference.span.kind"] == "TOOL"
+    assert tool["attributes"]["tool.call.id"] == "tool-789"
+    assert json.loads(tool["attributes"]["input.value"]) == {
+        "command": "printf TOOL_MARKER"
+    }
+    assert tool["attributes"]["output.value"] == "TOOL_MARKER"
+    assert tool["status_code"] == "OK"
+
+    tracer.handle_stop(
+        {
+            **common(),
+            "hook_event_name": "Stop",
+            "last_assistant_message": "RESPONSE_MARKER",
+        },
+        config(),
+        export,
+    )
+
+    assert len(exported) == 2
+    root = exported[1][2][0]
+    assert root["name"] == "codex.turn"
+    assert root["trace_id_hex"] == tool["trace_id_hex"]
+    assert tool["parent_span_id_hex"] == root["span_id_hex"]
+    assert root["attributes"] == {
+        "openinference.span.kind": "LLM",
+        "input.value": "PROMPT_MARKER",
+        "input.mime_type": "text/plain",
+        "output.value": "RESPONSE_MARKER",
+        "output.mime_type": "text/plain",
+        "session.id": "session-123",
+        "codex.thread.id": "session-123",
+        "codex.turn.id": "turn-456",
+        "codex.turn.status": "completed",
+        "codex.emission.transport": "hooks",
+        "codex.observer.name": "arthur-codex-hook-tracer",
+        "graph.node.id": "turn:turn-456",
+        "graph.node.name": "codex.turn",
+        "llm.model_name": "gpt-5.6-sol",
+    }
+    assert root["end_ns"] > root["start_ns"]
+    assert root["status_code"] == "OK"
+    assert not list(isolated_state.glob("*.json"))
+
+
+def test_token_usage_sums_all_model_calls_in_only_the_matching_turn(tmp_path):
+    """Break caught: reporting session totals or only the final model call."""
+    transcript = tmp_path / "rollout.jsonl"
+    records = [
+        {"type": "event_msg", "payload": {"type": "task_started", "turn_id": "older"}},
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 90,
+                        "output_tokens": 9,
+                        "total_tokens": 99,
+                    }
+                },
+            },
+        },
+        {"type": "event_msg", "payload": {"type": "task_complete", "turn_id": "older"}},
+        {
+            "type": "event_msg",
+            "payload": {"type": "task_started", "turn_id": "turn-456"},
+        },
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 10,
+                        "cached_input_tokens": 4,
+                        "output_tokens": 2,
+                        "reasoning_output_tokens": 1,
+                        "total_tokens": 12,
+                    }
+                },
+            },
+        },
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {
+                        "input_tokens": 20,
+                        "cached_input_tokens": 5,
+                        "output_tokens": 3,
+                        "reasoning_output_tokens": 0,
+                        "total_tokens": 23,
+                    }
+                },
+            },
+        },
+        {
+            "type": "event_msg",
+            "payload": {"type": "task_complete", "turn_id": "turn-456"},
+        },
+    ]
+    transcript.write_text("\n".join(json.dumps(record) for record in records))
+
+    assert tracer.read_token_usage(transcript, "turn-456") == {
+        "input_tokens": 30,
+        "cached_input_tokens": 9,
+        "output_tokens": 5,
+        "reasoning_output_tokens": 1,
+        "total_tokens": 35,
+    }
+
+
+def test_stop_adds_token_attributes_from_the_codex_transcript(tmp_path, isolated_state):
+    """Break caught: hook traces reach Arthur without model-usage metadata."""
+    transcript = tmp_path / "rollout.jsonl"
+    transcript.write_text(
+        "\n".join(
+            json.dumps(record)
+            for record in [
+                {
+                    "type": "event_msg",
+                    "payload": {"type": "task_started", "turn_id": "turn-456"},
+                },
+                {
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 30,
+                                "cached_input_tokens": 9,
+                                "output_tokens": 5,
+                                "reasoning_output_tokens": 1,
+                                "total_tokens": 35,
+                            }
+                        },
+                    },
+                },
+                {
+                    "type": "event_msg",
+                    "payload": {"type": "task_complete", "turn_id": "turn-456"},
+                },
+            ]
+        )
+    )
+    exported = []
+    tracer.handle_user_prompt_submit(
+        {**common(), "prompt": "PROMPT_MARKER", "transcript_path": str(transcript)},
+        config(),
+        lambda *_: None,
+    )
+    tracer.handle_stop(
+        {
+            **common(),
+            "last_assistant_message": "RESPONSE_MARKER",
+            "transcript_path": str(transcript),
+        },
+        config(),
+        lambda cfg, session_id, records: exported.extend(records),
+    )
+
+    attrs = exported[0]["attributes"]
+    assert attrs["llm.token_count.prompt"] == 30
+    assert attrs["llm.token_count.completion"] == 5
+    assert attrs["llm.token_count.total"] == 35
+    assert attrs["llm.token_count.prompt_details.cache_read"] == 9
+    assert attrs["llm.token_count.completion_details.reasoning"] == 1
+
+
+def test_parallel_post_tool_hooks_do_not_overwrite_state(isolated_state):
+    """Break caught: concurrent tools overwrite one another's state updates."""
+    tracer.handle_user_prompt_submit(
+        {**common(), "prompt": "parallel"}, config(), lambda *_: None
+    )
+    barrier = threading.Barrier(20)
+    exported = []
+    export_lock = threading.Lock()
+
+    def export(cfg, session_id, records):
+        with export_lock:
+            exported.extend(records)
+
+    def post(index):
+        barrier.wait()
+        tracer.handle_post_tool(
+            {
+                **common(),
+                "tool_name": "Bash",
+                "tool_use_id": f"tool-{index}",
+                "tool_input": {"command": f"printf {index}"},
+                "tool_response": str(index),
+            },
+            config(),
+            export,
+        )
+
+    threads = [threading.Thread(target=post, args=(index,)) for index in range(20)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(exported) == 20
+    assert len({record["attributes"]["tool.call.id"] for record in exported}) == 20
+
+
+def test_otlp_export_timeout_finishes_inside_hook_timeout(monkeypatch):
+    """Break caught: a slow Engine request outlives Codex's five-second hook limit."""
+    exporter_kwargs = []
+
+    class FakeResource:
+        @staticmethod
+        def create(attributes):
+            return attributes
+
+    class FakeExporter:
+        def __init__(self, **kwargs):
+            exporter_kwargs.append(kwargs)
+
+    class FakeProcessor:
+        def __init__(self, exporter):
+            self.exporter = exporter
+
+    class FakeSpan:
+        def set_attribute(self, key, value):
+            pass
+
+        def set_status(self, status):
+            pass
+
+        def end(self, end_time):
+            pass
+
+    class FakeTracer:
+        def start_span(self, *args, **kwargs):
+            return FakeSpan()
+
+    class FakeProvider:
+        def __init__(self, **kwargs):
+            pass
+
+        def add_span_processor(self, processor):
+            pass
+
+        def get_tracer(self, name):
+            return FakeTracer()
+
+        def shutdown(self):
+            pass
+
+    class FakeSpanKind:
+        CLIENT = "client"
+        INTERNAL = "internal"
+
+    class FakeStatusCode:
+        OK = "ok"
+
+    class FakeStatus:
+        def __init__(self, code):
+            self.code = code
+
+    monkeypatch.setattr(
+        tracer,
+        "_otel_imports",
+        lambda: (
+            object(),
+            FakeResource,
+            FakeProvider,
+            object,
+            FakeProcessor,
+            FakeExporter,
+            object,
+            object,
+            FakeSpanKind,
+            FakeStatus,
+            FakeStatusCode,
+            object,
+        ),
+    )
+    record = {
+        "name": "codex.turn",
+        "trace_id_hex": "1" * 32,
+        "span_id_hex": "2" * 16,
+        "parent_span_id_hex": None,
+        "kind": "INTERNAL",
+        "status_code": "OK",
+        "start_ns": 1,
+        "end_ns": 2,
+        "attributes": {},
+    }
+
+    tracer._build_and_export_spans(config(), "session-123", [record])
+
+    assert exporter_kwargs == [
+        {
+            "endpoint": "https://engine.example.com/api/v1/traces",
+            "headers": {"Authorization": "Bearer example-test-key"},
+            "timeout": 4,
+        }
+    ]
+
+
+def test_main_reads_one_hook_payload_and_silently_skips_without_config(monkeypatch):
+    """Break caught: the hook command writes invalid output or fails an unconfigured turn."""
+    monkeypatch.setattr(tracer.sys, "argv", ["codex_hook_tracer.py", "stop"])
+    monkeypatch.setattr(
+        tracer.sys, "stdin", __import__("io").StringIO(json.dumps(common()))
+    )
+    monkeypatch.setattr(tracer, "discover_config", lambda **kwargs: None)
+    assert tracer.main() == 0
+
+
+def test_main_resolves_project_config_from_hook_payload_cwd(tmp_path, monkeypatch):
+    """Break caught: project config is missed when the hook process starts elsewhere."""
+    project = tmp_path / "project"
+    launcher_cwd = tmp_path / "launcher"
+    home = tmp_path / "home"
+    (project / ".codex").mkdir(parents=True)
+    launcher_cwd.mkdir()
+    home.mkdir()
+    expected = {
+        "api_key": "project-key",
+        "task_id": "project-task",
+        "endpoint": "https://engine.example.com/api/v1/traces",
+    }
+    (project / ".codex" / "arthur_config.json").write_text(json.dumps(expected))
+    for key in (
+        "GENAI_ENGINE_API_KEY",
+        "GENAI_ENGINE_TASK_ID",
+        "GENAI_ENGINE_TRACE_ENDPOINT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(launcher_cwd)
+    monkeypatch.setattr(tracer.sys, "argv", ["codex_hook_tracer.py", "stop"])
+    monkeypatch.setattr(
+        tracer.sys,
+        "stdin",
+        __import__("io").StringIO(json.dumps({**common(), "cwd": str(project)})),
+    )
+    received = []
+    monkeypatch.setitem(
+        tracer.HANDLERS,
+        "stop",
+        lambda data, resolved_config: received.append(resolved_config),
+    )
+
+    assert tracer.main() == 0
+    assert received == [expected]

--- a/integrations/codex-observability/uninstall.sh
+++ b/integrations/codex-observability/uninstall.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Remove only the Arthur Codex hook tracer and its hook registrations.
+
+set -euo pipefail
+
+PROJECT_DIR=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --project-dir)
+            PROJECT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -n "$PROJECT_DIR" ]]; then
+    CODEX_ROOT="$PROJECT_DIR/.codex"
+else
+    CODEX_ROOT="$HOME/.codex"
+fi
+
+HOOK_DIR="$CODEX_ROOT/hooks"
+TRACER_PATH="$HOOK_DIR/codex_hook_tracer.py"
+HOOKS_FILE="$CODEX_ROOT/hooks.json"
+
+if [[ -f "$HOOKS_FILE" ]]; then
+    python3 - "$HOOKS_FILE" "$TRACER_PATH" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+hooks_path = Path(sys.argv[1])
+tracer_path = sys.argv[2]
+try:
+    settings = json.loads(hooks_path.read_text())
+except (json.JSONDecodeError, OSError):
+    raise SystemExit(0)
+
+events = settings.get("hooks", {})
+for event in list(events):
+    retained_groups = []
+    for group in events[event]:
+        if not isinstance(group, dict):
+            retained_groups.append(group)
+            continue
+        handlers = [
+            handler
+            for handler in group.get("hooks", [])
+            if not (
+                isinstance(handler, dict)
+                and tracer_path in handler.get("command", "")
+            )
+        ]
+        if handlers:
+            retained = dict(group)
+            retained["hooks"] = handlers
+            retained_groups.append(retained)
+    if retained_groups:
+        events[event] = retained_groups
+    else:
+        del events[event]
+
+hooks_path.write_text(json.dumps(settings, indent=2) + "\n")
+PY
+fi
+
+rm -f "$TRACER_PATH"
+rm -rf "$HOOK_DIR/.arthur-venv"
+echo "Removed Arthur Codex tracer registrations from $HOOKS_FILE"


### PR DESCRIPTION
## Why

Codex supports lifecycle hooks, but Arthur Engine does not currently include a repository-supported integration that converts each Codex turn into an OpenInference trace containing its prompt, response, tool activity, model metadata, token usage, and session identity.

## What

- Add an Arthur Codex hook tracer for session, prompt, tool, subagent, and stop lifecycle events.
- Represent thread-spawned subagents as `codex.agent` spans with nested child turns and tools.
- Record content-free `SessionStart` activation markers so users can distinguish hook dispatch from export failures.
- Register global or project-scoped hooks through an idempotent installer.
- Export OpenInference spans directly to a user-configured Arthur Engine task.
- Keep tracing fail-open so missing configuration, runtime failures, or export timeouts cannot interrupt Codex.
- Preserve unrelated Codex hooks and remove only Arthur-owned registrations during uninstall.
- Document configuration, hook trust, privacy implications, and verification.

## Validation

- 17 Codex observability tests pass.
- Formatting, shell syntax, whitespace, and sanitization checks pass.
- A harmless marked parent/subagent turn was verified through an isolated local Arthur Engine API.
- The resulting trace contained a root `codex.turn`, sibling `spawn_agent` tool, nested `codex.agent`, child `codex.turn`, and child tool span.
- Prompt, response, tool, model, timing, hierarchy, and successful status data were present.
- Missing and failing tracer paths do not block Codex.

## Known upstream Codex limitation

Codex hook delivery is not currently reliable after live hook configuration changes or quota/provider termination. In local validation, an existing Desktop task continued completing turns after a `hooks.json` change but stopped dispatching lifecycle hooks. A fresh CLI task dispatched `SessionStart` and `UserPromptSubmit`, but did not dispatch `Stop` when terminated by a ChatGPT usage limit.

The tracer cannot export an event that Codex does not dispatch. After installing, changing, or trusting hooks, users should restart Codex and validate a fresh task. Turns missing a terminal lifecycle event may remain incomplete.

Tracked upstream in [openai/codex#21160](https://github.com/openai/codex/issues/21160) and [openai/codex#22774](https://github.com/openai/codex/issues/22774).

The tracing destination, task identifier, and credentials are supplied outside the repository. No Arthur development endpoint, task identifier, session identifier, trace identifier, or credential is included in this PR.
