### PR TITLE
chore(renovate): one full-stack reviewer pool, one owner per PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -146,12 +146,8 @@
       "description": "Reviewer routing. Everyone in this pool is treated as full-stack and can take any Renovate PR, so there is one list covering every manager and update type rather than the old frontend/backend/infra split — no PR waits on one specific person being around. reviewersSampleSize 1 makes exactly one of them the owner of each PR, including majors: a single name on a PR is a person who knows it is theirs, whereas two names is a PR nobody owns.",
       "matchManagers": ["npm", "pep621", "dockerfile", "docker-compose", "custom.regex"],
       "reviewers": [
-        "TheLukaszNs-Blazity",
         "xV3rt",
-        "martin-arthur-ai",
         "notthattal",
-        "videetparekh",
-        "mcgrawia",
         "jan-lewandoski-blazity",
         "ntatsumi",
         "jdbarthur",

--- a/renovate.json
+++ b/renovate.json
@@ -143,36 +143,22 @@
       "allowedVersions": "<17"
     },
     {
-      "description": "Non-major npm updates get one randomly-sampled reviewer for visibility (they are auto-merged). Major npm bumps are routed to the frontend experts by the rule below.",
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "reviewers": ["TheLukaszNs-Blazity", "xV3rt", "martin-arthur-ai"],
+      "description": "Reviewer routing. Everyone in this pool is treated as full-stack and can take any Renovate PR, so there is one list covering every manager and update type rather than the old frontend/backend/infra split — no PR waits on one specific person being around. reviewersSampleSize 1 makes exactly one of them the owner of each PR, including majors: a single name on a PR is a person who knows it is theirs, whereas two names is a PR nobody owns.",
+      "matchManagers": ["npm", "pep621", "dockerfile", "docker-compose", "custom.regex"],
+      "reviewers": [
+        "TheLukaszNs-Blazity",
+        "xV3rt",
+        "martin-arthur-ai",
+        "notthattal",
+        "videetparekh",
+        "mcgrawia",
+        "jan-lewandoski-blazity",
+        "ntatsumi",
+        "jdbarthur",
+        "kc961163",
+        "TomLisankie"
+      ],
       "reviewersSampleSize": 1
-    },
-    {
-      "description": "Non-major Python updates get one randomly-sampled reviewer for visibility (they are auto-merged). Major backend bumps are routed to the backend experts by the rule below.",
-      "matchManagers": ["pep621"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "reviewers": ["notthattal", "videetparekh", "mcgrawia"],
-      "reviewersSampleSize": 1
-    },
-    {
-      "description": "Route major frontend (npm) bumps to the frontend experts. Major updates are not auto-approved, so request both experts for human review. No reviewersSampleSize, so both are always requested.",
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["major"],
-      "reviewers": ["jan-lewandoski-blazity", "xV3rt"]
-    },
-    {
-      "description": "Route major backend (Python/pep621) bumps to the backend experts for human review.",
-      "matchManagers": ["pep621"],
-      "matchUpdateTypes": ["major"],
-      "reviewers": ["ntatsumi", "notthattal"]
-    },
-    {
-      "description": "Route major infra bumps (Docker base images, docker-compose services, and the uv pin tracked by the custom regex manager) to the infra experts for human review.",
-      "matchManagers": ["dockerfile", "docker-compose", "custom.regex"],
-      "matchUpdateTypes": ["major"],
-      "reviewers": ["ntatsumi", "jdbarthur"]
     }
   ]
 }


### PR DESCRIPTION
## What

Collapses the five specialist reviewer rules in `renovate.json` into a single pool.

Before, reviewer routing was split by manager and update type:

| Rule | Reviewers |
| --- | --- |
| npm minor/patch | TheLukaszNs-Blazity, xV3rt, martin-arthur-ai (sample 1) |
| pep621 minor/patch | notthattal, videetparekh, mcgrawia (sample 1) |
| npm major | jan-lewandoski-blazity, xV3rt (both) |
| pep621 major | ntatsumi, notthattal (both) |
| infra major | ntatsumi, jdbarthur (both) |

Now there is one rule matching all five enabled managers and all update types, with a seven-person pool: xV3rt, notthattal, jan-lewandoski-blazity, ntatsumi, jdbarthur, kc961163, TomLisankie.

## Why

- **Everyone is full-stack.** Any engineer in the pool can take any Renovate PR — a frontend major no longer waits on one of two specific people being around.
- **Two new owners.** `kc961163` and `TomLisankie` join the pool; `martin-arthur-ai`, `videetparekh`, `mcgrawia` and `TheLukaszNs-Blazity` come off it.
- **Exactly one owner per PR.** `reviewersSampleSize: 1` now applies to majors too. The old major rules requested two reviewers each, which in practice means the PR is owned by nobody in particular.

## Note

Major bumps are still not auto-approved (`renovate-autofix.yml` flags them for human review rather than self-approving), so they wait on a human — that human is now one randomly sampled person from the whole pool rather than a named pair of domain experts. Easy to add a majors-get-two rule back if that trade isn't wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)