### PR TITLE
feat(helm): make MAX_API_KEYS configurable via values.yaml

### DIFF
--- a/deployment/helm/arthur-engine/values.yaml.template
+++ b/deployment/helm/arthur-engine/values.yaml.template
@@ -233,6 +233,8 @@ arthur-genai-engine:
     labels: {}
   # Allow the admin key general API access (Must be enabled for the Arthur Platform. Can be disabled for the guardrails-only standalone deployment.)
   genaiEngineAllowAdminKeyGeneralAccess: "enabled"
+  # Maximum number of active API keys GenAI Engine will issue. Leave unset to use the application default (100).
+  genaiEngineMaxApiKeys: 100
   # Chunked transfer-encoding middleware. Referenced unconditionally by the deployment, so set it
   # explicitly here (empty renders as an invalid value and crashes worker boot).
   transferEncodingMiddlewareEnabled: "enabled"

--- a/deployment/helm/genai-engine/templates/arthur-genai-engine-daemonset.yaml
+++ b/deployment/helm/genai-engine/templates/arthur-genai-engine-daemonset.yaml
@@ -177,6 +177,10 @@ spec:
               value: {{ .Values.genaiEngineAllowAdminKeyGeneralAccess }}
             - name: TRANSFER_ENCODING_MIDDLEWARE_ENABLED
               value: {{ .Values.transferEncodingMiddlewareEnabled }}
+            {{- if .Values.genaiEngineMaxApiKeys }}
+            - name: MAX_API_KEYS
+              value: {{ .Values.genaiEngineMaxApiKeys | quote }}
+            {{- end }}
             {{- if .Values.modelRepositoryURL }}
             - name: MODEL_REPOSITORY_URL
               value: {{ .Values.modelRepositoryURL | quote }}

--- a/deployment/helm/genai-engine/templates/arthur-genai-engine-deployment.yaml
+++ b/deployment/helm/genai-engine/templates/arthur-genai-engine-deployment.yaml
@@ -177,6 +177,10 @@ spec:
               value: {{ .Values.genaiEngineAllowAdminKeyGeneralAccess }}
             - name: TRANSFER_ENCODING_MIDDLEWARE_ENABLED
               value: {{ .Values.transferEncodingMiddlewareEnabled }}
+            {{- if .Values.genaiEngineMaxApiKeys }}
+            - name: MAX_API_KEYS
+              value: {{ .Values.genaiEngineMaxApiKeys | quote }}
+            {{- end }}
             {{- if .Values.modelRepositoryURL }}
             - name: MODEL_REPOSITORY_URL
               value: {{ .Values.modelRepositoryURL | quote }}

--- a/deployment/helm/genai-engine/values.schema.json
+++ b/deployment/helm/genai-engine/values.schema.json
@@ -503,6 +503,11 @@
             ],
             "description": "Allow the admin key general API access (Must be enabled for the Arthur Platform. Can be disabled for the guardrails-only standalone deployment.)"
         },
+        "genaiEngineMaxApiKeys": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "(Optional) Maximum number of active API keys GenAI Engine will issue. Leave unset to use the application default (100)."
+        },
         "modelRepositoryURL": {
             "type": "string",
             "description": "(Optional) Custom URL for the model repository (e.g. a private Hugging Face mirror). If not specified, the default Hugging Face endpoint will be used."

--- a/deployment/helm/genai-engine/values.yaml.template
+++ b/deployment/helm/genai-engine/values.yaml.template
@@ -238,6 +238,8 @@ arthurGenaiEngineService:
   labels: {}
 # Allow the admin key general API access (Must be enabled for the Arthur Platform. Can be disabled for the guardrails-only standalone deployment.)
 genaiEngineAllowAdminKeyGeneralAccess: "enabled"
+# Maximum number of active API keys GenAI Engine will issue. Leave unset to use the application default (100).
+genaiEngineMaxApiKeys: 100
 # (Optional) Custom URL for the model repository (e.g. a private Hugging Face mirror). If not specified, the default Hugging Face endpoint will be used.
 # modelRepositoryURL: ""
 # (Optional) reCAPTCHA Enterprise — gates the public tenant signup endpoint. All three of project id, site key, and the API-key secret


### PR DESCRIPTION
## Summary

GenAI Engine reads `MAX_API_KEYS` to cap how many active API keys it will issue (`Config.max_api_key_limit()`, `genai-engine/src/config/config.py:22`), but the chart never set it — the only way to change the limit on a Helm deployment was to patch the rendered Deployment by hand.

This adds `genaiEngineMaxApiKeys` as a chart value and plumbs it through to the container env.

## Changes

- **`templates/arthur-genai-engine-deployment.yaml`**, **`templates/arthur-genai-engine-daemonset.yaml`** — set `MAX_API_KEYS` from the new value, guarded by `if`.
- **`genai-engine/values.yaml.template`**, **`arthur-engine/values.yaml.template`** (under `arthur-genai-engine:`) — ship `genaiEngineMaxApiKeys: 100` next to `genaiEngineAllowAdminKeyGeneralAccess`.
- **`genai-engine/values.schema.json`** — optional `integer`, `minimum: 1`. Deliberately *not* added to `required`, so values files predating this key still validate.

## Why the `if` guard

Rendering the env var unconditionally would emit `value: ""` for any values file that predates this key, and `int("")` in `Config.max_api_key_limit()` raises on worker boot. With the guard, an older values file renders no `MAX_API_KEYS` at all and the app keeps its built-in default of 100.

## Testing

`helm template` against the genai-engine chart:

| case | result |
|---|---|
| template defaults | `MAX_API_KEYS: "100"` |
| `--set genaiEngineMaxApiKeys=250` | `MAX_API_KEYS: "250"` |
| `genaiEngineDeploymentType=daemonset`, `--set genaiEngineMaxApiKeys=42` | `MAX_API_KEYS: "42"` in the DaemonSet |
| key removed from values file | no `MAX_API_KEYS` env var emitted |

🤖 Generated with [Claude Code](https://claude.com/claude-code)