### PR TITLE
fix(ci): finalize Renovate Claude traces from Agent SDK output

### DIFF
--- a/.github/workflows/claude-code-observability-workflow.yml
+++ b/.github/workflows/claude-code-observability-workflow.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install test dependencies
+        run: pip install pytest -r integrations/claude-code-observability/requirements.txt
 
       - name: Run tests
         run: python3 -m pytest integrations/claude-code-observability/test_tracer.py -v

--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -162,6 +162,7 @@ jobs:
             echo "::warning::Arthur tracer could not be copied; continuing without tracing."
 
       - name: Claude auto-fix (edits + self-verify only; no commit)
+        id: claude_autofix
         if: steps.guard.outputs.proceed == 'true'
         # The success marker lives OUTSIDE the repo (in RUNNER_TEMP) so it cannot be
         # committed to the PR branch to forge a "verified" signal.
@@ -181,8 +182,7 @@ jobs:
                 "UserPromptSubmit": [{"matcher": "", "hooks": [{"type": "command", "command": "T=\"${{ runner.temp }}/claude_code_tracer.py\"; [ -f \"$T\" ] && python3 \"$T\" user_prompt_submit; true"}]}],
                 "PreToolUse": [{"matcher": "", "hooks": [{"type": "command", "command": "T=\"${{ runner.temp }}/claude_code_tracer.py\"; [ -f \"$T\" ] && python3 \"$T\" pre_tool; true"}]}],
                 "PostToolUse": [{"matcher": "", "hooks": [{"type": "command", "command": "T=\"${{ runner.temp }}/claude_code_tracer.py\"; [ -f \"$T\" ] && python3 \"$T\" post_tool; true"}]}],
-                "PostToolUseFailure": [{"matcher": "", "hooks": [{"type": "command", "command": "T=\"${{ runner.temp }}/claude_code_tracer.py\"; [ -f \"$T\" ] && python3 \"$T\" post_tool_failure; true"}]}],
-                "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "T=\"${{ runner.temp }}/claude_code_tracer.py\"; [ -f \"$T\" ] && python3 \"$T\" stop; true"}]}]
+                "PostToolUseFailure": [{"matcher": "", "hooks": [{"type": "command", "command": "T=\"${{ runner.temp }}/claude_code_tracer.py\"; [ -f \"$T\" ] && python3 \"$T\" post_tool_failure; true"}]}]
               }
             }
           # Allow the action to run even though the PR was authored by a bot.
@@ -361,6 +361,25 @@ jobs:
             invariants hold, verified, self-reviewed, and review findings addressed". The change still goes
             through the full CI + merge queue (and an independent Claude review) before merging. Never leave
             broken, unreviewed, or unverified edits.
+
+      - name: Finalize Arthur Engine trace
+        if: always() && steps.guard.outputs.proceed == 'true'
+        env:
+          USER: renovate-autofix-pr-${{ steps.pr.outputs.number }}
+          GENAI_ENGINE_API_KEY: ${{ secrets.GENAI_ENGINE_API_KEY }}
+          GENAI_ENGINE_TASK_ID: ${{ vars.GENAI_ENGINE_TASK_ID }}
+          GENAI_ENGINE_TRACE_ENDPOINT: ${{ vars.GENAI_ENGINE_TRACE_ENDPOINT }}
+          CLAUDE_SESSION_ID: ${{ steps.claude_autofix.outputs.session_id }}
+          CLAUDE_EXECUTION_FILE: ${{ steps.claude_autofix.outputs.execution_file }}
+        run: |
+          T="$RUNNER_TEMP/claude_code_tracer.py"
+          if { [ -n "$CLAUDE_SESSION_ID" ] || [ -f "$CLAUDE_EXECUTION_FILE" ]; } && [ -f "$T" ]; then
+            jq -cn \
+              --arg session_id "$CLAUDE_SESSION_ID" \
+              --arg execution_file "$CLAUDE_EXECUTION_FILE" \
+              '{session_id: $session_id, execution_file: $execution_file}' | \
+              timeout 120s python3 "$T" stop || true
+          fi
 
       - name: Commit, push, then approve (minor/patch) or flag (major)
         if: steps.guard.outputs.proceed == 'true'

--- a/integrations/claude-code-observability/claude_code_tracer.py
+++ b/integrations/claude-code-observability/claude_code_tracer.py
@@ -271,6 +271,46 @@ def _session_lock(session_id: str):
 # ---------------------------------------------------------------------------
 
 
+def _read_transcript_entries(path: str) -> list[dict]:
+    """Read Claude Code JSONL or Claude Agent SDK JSON-array output."""
+    try:
+        text = Path(path).read_text()
+    except OSError:
+        return []
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+
+    if isinstance(parsed, list):
+        return [entry for entry in parsed if isinstance(entry, dict)]
+    if isinstance(parsed, dict):
+        return [parsed]
+
+    entries = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(entry, dict):
+            entries.append(entry)
+    return entries
+
+
+def _execution_session_id(path: str) -> str:
+    """Return the Agent SDK session ID from its system.init event."""
+    for entry in _read_transcript_entries(path):
+        if entry.get("type") == "system" and entry.get("subtype") == "init":
+            session_id = entry.get("session_id", "")
+            if isinstance(session_id, str):
+                return session_id
+    return ""
+
+
 def _is_real_transcript(path: str) -> bool:
     """Return True if the transcript has at least one human or assistant entry.
 
@@ -279,21 +319,10 @@ def _is_real_transcript(path: str) -> bool:
     one of these as the authoritative transcript would leave the tracer with
     nothing to extract LLM spans from.
     """
-    try:
-        with open(path) as fh:
-            for line in fh:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if entry.get("type") in ("user", "assistant"):
-                    return True
-        return False
-    except OSError:
-        return False
+    return any(
+        entry.get("type") in ("user", "assistant")
+        for entry in _read_transcript_entries(path)
+    )
 
 
 def _find_transcript_path(data: dict, session_id: str) -> Optional[str]:
@@ -377,19 +406,11 @@ def _is_human_message(entry: dict) -> bool:
 
 def _count_human_messages(transcript_path: str) -> int:
     """Count human (non-tool-result) user messages to detect turn boundaries."""
-    try:
-        count = 0
-        for line in Path(transcript_path).read_text().splitlines():
-            if not line.strip():
-                continue
-            try:
-                if _is_human_message(json.loads(line)):
-                    count += 1
-            except json.JSONDecodeError:
-                pass
-        return count
-    except Exception:
-        return 0
+    return sum(
+        1
+        for entry in _read_transcript_entries(transcript_path)
+        if _is_human_message(entry)
+    )
 
 
 def _iso_to_ns(ts: str) -> int:
@@ -423,6 +444,7 @@ def _extract_llm_spans_for_turn(
     human_count_at_start: int,
     trace_id_hex: str,
     root_span_id_hex: str,
+    fallback_human_prompt: str = "",
 ) -> list[dict]:
     """
     Extract LLM spans from transcript entries that belong to this turn.
@@ -465,7 +487,15 @@ def _extract_llm_spans_for_turn(
     """
     spans = []
     try:
-        lines = Path(transcript_path).read_text().splitlines()
+        entries = _read_transcript_entries(transcript_path)
+        if fallback_human_prompt and not any(_is_human_message(e) for e in entries):
+            entries.insert(
+                0,
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": fallback_human_prompt},
+                },
+            )
         human_count = 0
         in_turn = False
 
@@ -593,14 +623,7 @@ def _extract_llm_spans_for_turn(
             group_stop_reason = ""
             group_input_snapshot = {}
 
-        for line in lines:
-            if not line.strip():
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
+        for entry in entries:
             entry_type = entry.get("type", "")
 
             # ── Human message: marks the start of this turn ──────────────────
@@ -1074,6 +1097,7 @@ def _emit_pending_llm_spans(
         current_trace.get("human_count_at_start", 0),
         current_trace["trace_id"],
         current_trace["root_span_id"],
+        current_trace.get("prompt_preview", ""),
     )
 
     emitted = current_trace.get("emitted_llm_span_count", 0)
@@ -1086,6 +1110,10 @@ def _emit_pending_llm_spans(
         current_trace["last_llm_output"] = all_llm_spans[-1]["attributes"].get(
             "output.value",
             "",
+        )
+        current_trace["last_llm_end_ns"] = max(
+            current_trace.get("last_llm_end_ns", 0),
+            max(span["end_ns"] for span in all_llm_spans),
         )
 
     if not new_spans:
@@ -1126,6 +1154,7 @@ def _complete_turn(
     trace_id = current_trace["trace_id"]
     root_span_id = current_trace["root_span_id"]
     turn_start_ns = current_trace["turn_start_ns"]
+    end_ns = max(end_ns, current_trace.get("last_llm_end_ns", 0))
     turn_number = current_trace.get("turn_number", 1)
     prompt_preview = current_trace.get("prompt_preview", "")
     final_output = current_trace.get("last_llm_output", "")
@@ -1487,22 +1516,13 @@ def handle_pre_tool(data: dict, config: dict) -> None:
 
 def _get_latest_human_message(transcript_path: str) -> str:
     """Return the text of the most recent human message in the transcript."""
-    try:
-        last = ""
-        for line in Path(transcript_path).read_text().splitlines():
-            if not line.strip():
-                continue
-            try:
-                entry = json.loads(line)
-                if _is_human_message(entry):
-                    content = entry.get("message", {}).get("content", "")
-                    if isinstance(content, str):
-                        last = content
-            except json.JSONDecodeError:
-                pass
-        return last
-    except Exception:
-        return ""
+    last = ""
+    for entry in _read_transcript_entries(transcript_path):
+        if _is_human_message(entry):
+            content = entry.get("message", {}).get("content", "")
+            if isinstance(content, str):
+                last = content
+    return last
 
 
 def _find_pending_tool_entry(
@@ -1700,7 +1720,11 @@ def handle_post_tool_failure(data: dict, config: dict) -> None:
 
 
 def handle_stop(data: dict, config: dict) -> None:
-    session_id = data.get("session_id", "unknown")
+    execution_file = data.get("execution_file", "")
+    session_id = data.get("session_id") or (
+        _execution_session_id(execution_file) if execution_file else ""
+    )
+    session_id = session_id or "unknown"
     end_ns = time.time_ns()
 
     with _session_lock(session_id):
@@ -1709,7 +1733,13 @@ def handle_stop(data: dict, config: dict) -> None:
             log.debug("No active trace for session %s at stop", session_id)
             return
 
-        transcript_path = _get_cached_transcript_path(data, state, session_id)
+        transcript_path = (
+            execution_file
+            if execution_file
+            and Path(execution_file).exists()
+            and _is_real_transcript(execution_file)
+            else _get_cached_transcript_path(data, state, session_id)
+        )
 
         # Detect context continuation: same check as handle_pre_tool.
         # When no tool calls happen during a continuation turn, handle_pre_tool

--- a/integrations/claude-code-observability/test_tracer.py
+++ b/integrations/claude-code-observability/test_tracer.py
@@ -1256,6 +1256,77 @@ class TestHandleStop:
         assert len(llm_spans) == 1
         assert llm_spans[0]["attributes"]["output.value"] == "Result"
 
+    def test_stop_reads_agent_sdk_execution_file_without_user_event(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(tracer, "STATE_DIR", tmp_path / "tracer")
+        (tmp_path / "tracer").mkdir()
+        captured = []
+        monkeypatch.setattr(
+            tracer,
+            "_build_and_export_spans",
+            lambda **kw: captured.extend(kw["span_records"]),
+        )
+
+        execution_file = tmp_path / "claude-execution-output.json"
+        assistant = llm_entry("Autofix complete")
+        assistant["message"]["id"] = "msg_sdk_1"
+        assistant.pop("timestamp")
+        execution_file.write_text(
+            json.dumps(
+                [
+                    {"type": "system", "subtype": "init", "session_id": "sdk1"},
+                    assistant,
+                    {"type": "result", "subtype": "success", "result": "done"},
+                ],
+            ),
+        )
+        stale_hook_transcript = tmp_path / "hook-transcript.jsonl"
+        _make_transcript(
+            [human_entry("Fix the failed Renovate PR")],
+            stale_hook_transcript,
+        )
+        state = {
+            "session_id": "sdk1",
+            "username": "renovate-autofix-pr-2170",
+            "transcript_path": str(stale_hook_transcript),
+            "current_trace": {
+                "trace_id": "1" * 32,
+                "root_span_id": "2" * 16,
+                "turn_start_ns": 1_000_000_000,
+                "turn_number": 1,
+                "human_count_at_start": 0,
+                "prompt_preview": "Fix the failed Renovate PR",
+                "emitted_llm_span_count": 0,
+            },
+        }
+        tracer._save_state("sdk1", state)
+
+        tracer.handle_stop(
+            {"execution_file": str(execution_file)},
+            self.CONFIG,
+        )
+
+        llm_spans = [
+            s
+            for s in captured
+            if s.get("attributes", {}).get("openinference.span.kind") == "LLM"
+        ]
+        chain_spans = [
+            s
+            for s in captured
+            if s.get("attributes", {}).get("openinference.span.kind") == "CHAIN"
+        ]
+        assert len(llm_spans) == 1
+        assert llm_spans[0]["attributes"]["output.value"] == "Autofix complete"
+        assert llm_spans[0]["attributes"]["llm.input_messages.0.message.content"] == (
+            "Fix the failed Renovate PR"
+        )
+        assert chain_spans[0]["attributes"]["output.value"] == "Autofix complete"
+        assert chain_spans[0]["end_ns"] >= max(span["end_ns"] for span in llm_spans)
+
 
 # ---------------------------------------------------------------------------
 # handle_user_prompt_submit — new trace creation and turn completion


### PR DESCRIPTION
## Why

Real Renovate autofix runs emit prompt and tool spans, but their LLM spans and final response can be absent because the workflow finalizes from Claude Code's hook transcript instead of the GitHub Action's complete Agent SDK execution output.

## What

- Capture the Claude Action's `session_id` and `execution_file` outputs.
- Finalize after the Action completes, deriving the session ID from `system.init` when the Action fails before exposing it.
- Parse both Claude Code JSONL and Agent SDK JSON-array output.
- Preserve the captured prompt when SDK output has no initial user event.
- Ensure the CHAIN span encloses generated LLM spans.
- Bound finalization and keep every tracing path non-blocking.

## Validation

- `236 passed` for the Claude Code observability tracer suite.
- Workflow YAML and embedded settings JSON parse successfully.
- Regression coverage reproduces Agent SDK JSON-array finalization with no explicit session ID and a stale cached hook transcript.
- Local Arthur Engine proof produced one CHAIN containing TOOL and LLM spans, with prompt, final output, token counts, attribution, and valid timing.
- `git diff --check` passes.

## Post-merge validation

Observe the next eligible failed Renovate run and confirm its trace contains LLM and TOOL children beneath one `claude-code-turn`.

This is a follow-up to #2140.
