### PR TITLE
fix(tests): compare sorted prompt-variable lists instead of None-vs-None

### DIFF
--- a/genai-engine/tests/unit/routes/tasks/test_agentic_prompt_routes.py
+++ b/genai-engine/tests/unit/routes/tasks/test_agentic_prompt_routes.py
@@ -2235,8 +2235,8 @@ def test_get_unsaved_prompt_variables_list_route_success(
     )
     assert response.status_code == 200
 
-    response_variables = response.json()["variables"].sort()
-    expected_variables = expected_variables.sort()
+    response_variables = sorted(response.json()["variables"])
+    expected_variables = sorted(expected_variables)
 
     assert response_variables == expected_variables
 


### PR DESCRIPTION
### Problem

In `test_get_unsaved_prompt_variables_list_route_success`, the assertion never verifies anything:

```python
response_variables = response.json()["variables"].sort()
expected_variables = expected_variables.sort()

assert response_variables == expected_variables
```

`list.sort()` sorts **in place and returns `None`**. So both `response_variables` and `expected_variables` are bound to `None`, and the assertion is always `assert None == None` — it passes regardless of what the `/api/v1/prompt_variables` endpoint returns. The parametrized `expected_variables` cases (including the ones expecting specific variable names) are effectively unused, so this test provides no coverage.

### Fix

Use `sorted()`, which returns a new sorted list, so the assertion compares the actual returned variables against the expected ones (order-independent):

```python
response_variables = sorted(response.json()["variables"])
expected_variables = sorted(expected_variables)

assert response_variables == expected_variables
```

No production code changes; this only makes the existing test meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
