### PR TITLE
Make ML Engine health port configurable

### DIFF
--- a/ml-engine/src/ml_engine/config/config.py
+++ b/ml-engine/src/ml_engine/config/config.py
@@ -54,3 +54,10 @@ class Config:
             settings.GENAI_ENGINE_MAX_PAGE_SIZE,
             "GENAI_ENGINE_MAX_PAGE_SIZE",
         )
+
+    @staticmethod
+    def ml_engine_health_port() -> int:
+        return arthur_common_config.convert_to_int(
+            settings.ML_ENGINE_PORT,
+            "ML_ENGINE_PORT",
+        )

--- a/ml-engine/src/ml_engine/config/settings.yaml
+++ b/ml-engine/src/ml_engine/config/settings.yaml
@@ -6,6 +6,7 @@ ARTHUR_API_HOST: https://platform.arthur.ai
 ###############################################
 # General settings
 FETCH_RAW_DATA_ENABLED: true
+ML_ENGINE_PORT: 7492
 ###############################################
 # Engine Internal Shield Connection
 GENAI_ENGINE_INTERNAL_API_KEY: ""

--- a/ml-engine/src/ml_engine/job_agent.py
+++ b/ml-engine/src/ml_engine/job_agent.py
@@ -77,7 +77,9 @@ class JobAgent:
         self.running_jobs: Dict[str, RunningJob] = {}
         self.shutting_down = False
         self.shutdown_grace_period_seconds = shutdown_grace_period_seconds
-        self.health_check: HealthCheck = HealthCheck()
+        self.health_check: HealthCheck = HealthCheck(
+            port=Config.ml_engine_health_port(),
+        )
 
     def allocated_memory_mb(self) -> int:
         used_memory = sum(job.memory_requirements for job in self.running_jobs.values())

--- a/ml-engine/tests/unit/configuration/test_config.py
+++ b/ml-engine/tests/unit/configuration/test_config.py
@@ -74,3 +74,13 @@ def test_genai_engine_max_page_size():
     with patch("config.config.settings") as mock_settings:
         mock_settings.GENAI_ENGINE_MAX_PAGE_SIZE = "750"
         assert Config.genai_engine_max_page_size() == 750
+
+
+def test_ml_engine_health_port():
+    with patch("config.config.settings") as mock_settings:
+        mock_settings.ML_ENGINE_PORT = 7492
+        assert Config.ml_engine_health_port() == 7492
+
+    with patch("config.config.settings") as mock_settings:
+        mock_settings.ML_ENGINE_PORT = "7495"
+        assert Config.ml_engine_health_port() == 7495


### PR DESCRIPTION
## Summary

- add an `ML_ENGINE_PORT` setting with the existing `7492` default
- pass the configured port to the ML Engine health server
- cover integer and environment-style string values

## Why

ML Engine currently exposes its health server on a fixed port. Making that listener configurable allows multiple local ML Engine processes and deployment environments to choose an available health port while preserving the existing default behavior.

## Verification

- 9 focused configuration/job-agent tests passed, 1 skipped
- strict mypy: 49 source files, no issues
- black and isort checks passed
- `git diff --check` passed

The existing job-agent suite emits one pre-existing thread warning in `test_handle_process_failure`; it does not fail the suite.
