### PR TITLE
Deprecate Nexus: stop publishing ml-engine images to docker.arthur.ai

### DIFF
--- a/.github/workflows/arthur-engine-workflow.yml
+++ b/.github/workflows/arthur-engine-workflow.yml
@@ -622,30 +622,6 @@ jobs:
           slug: ml-engine
           dockerhub-username: ${{ secrets.DOCKERHUB_ENTERPRISE_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_ENTERPRISE_TOKEN }}
-      # Do NOT `docker logout` here: `imagetools create` below reads the source image from
-      # Docker Hub (logged in above) and writes to Artifactory (logged in now). Both sessions
-      # coexist in the docker config.
-      - name: Login to Artifactory
-        run: |
-          echo "${{ secrets.NEXUS_REPOSITORY_PASSWORD }}" | docker login docker.arthur.ai -u "${{ secrets.NEXUS_REPOSITORY_USERNAME }}" --password-stdin
-      # imagetools copies the full image (incl. the SBOM attestation) registry-to-registry.
-      # Required because buildx `push: true` does not load the image into the local docker
-      # store, so the old `docker tag` on a local image would no longer find it.
-      - name: Retag and push image to Artifactory
-        run: |
-          docker buildx imagetools create \
-            --tag docker.arthur.ai/arthur/scope/ml-engine:${{ env.VERSION }} \
-            arthurplatform/ml-engine:${{ env.VERSION }}
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            docker buildx imagetools create \
-              --tag docker.arthur.ai/arthur/scope/ml-engine:latest \
-              arthurplatform/ml-engine:${{ env.VERSION }}
-          fi
-          if [ "${{ github.ref }}" = "refs/heads/dev" ]; then
-            docker buildx imagetools create \
-              --tag docker.arthur.ai/arthur/scope/ml-engine:latest-dev \
-              arthurplatform/ml-engine:${{ env.VERSION }}
-          fi
 
   check-models-updates:
     environment: shared-protected-branch-secrets

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@ All production publishing is triggered by the version bump commit landing on `ma
 
 **[Arthur Engine CI](https://github.com/arthur-ai/arthur-engine/actions/workflows/arthur-engine-workflow.yml)**
 - GenAI Engine Docker images (CPU + GPU) → Docker Hub
-- ML Engine Docker images → Docker Hub + Artifactory
+- ML Engine Docker images → Docker Hub
 - Models Docker images → Docker Hub
 - CloudFormation templates → S3
 - Helm charts → GHCR + Docker Hub


### PR DESCRIPTION
## What

Part of deprecating Arthur's self-hosted Nexus registry (`docker.arthur.ai`).

- Removes the "Login to Artifactory" and "Retag and push image to Artifactory" steps from `build-ml-engine-docker-images` in `.github/workflows/arthur-engine-workflow.yml`, which pushed `docker.arthur.ai/arthur/scope/ml-engine:{VERSION,latest,latest-dev}` on every version-bump commit to `main`/`dev`.
- The ml-engine image continues to publish to Docker Hub (`arthurplatform/ml-engine`) exactly as before — this only removes the Nexus/Artifactory leg.

## Side effects

Checked for anything that pulls ml-engine from `docker.arthur.ai` — found none. No deployment config in this repo or in `arthur-scope` references `docker.arthur.ai/arthur/scope/ml-engine`, so there's nothing else to update.

## Related

- Companion MR in `arthur-scope`: [!1904](https://gitlab.com/ArthurAI/arthur-scope/-/merge_requests/1904) — removes the Nexus publish job for scope images, and fixes a real pull-side dependency on Nexus in the `aws-dev-platform` environment (arthur-auth image).
- Companion MR in `arthur-auth`: [!154](https://gitlab.com/ArthurAI/arthur-auth/-/merge_requests/154) — removes the Nexus publish job there.
- `arthur-shield` also pushes **Helm charts** (not images) to Nexus — out of scope here, flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)